### PR TITLE
Add release workflow and readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Create a release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Create a release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Create a release
 on:
   push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   build:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+- [Overview](#overview)
+- [Versioning](#versioning)
+- [Releasing](#releasing)
+
+## Overview
+
+This document explains the release strategy for artifacts in this organization.
+
+## Versioning
+
+This respository, as other in this organization follows semantic versioning.
+
+- **major**: Breaking changes
+- **minor**: New features
+- **patch**: Bug fixes
+
+## Releasing
+
+The release process includes a [MAINTAINER](MAINTAINERS.md) pushing a tag to this repository.


### PR DESCRIPTION
### Description
Add releasing.md file along with release create workflow. This will help to auto-create a release when a tag is pushed.

### Issues Resolved
#5 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
