### PR TITLE
Add library to publish artifacts to PyPi 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '1.2.0'
+String version = '1.3.0'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishToPyPi.groovy
+++ b/tests/jenkins/TestPublishToPyPi.groovy
@@ -31,7 +31,7 @@ class TestPublishToPyPi extends BuildPipelineTest {
 
         def twineCommands = getCommands('sh', 'twine')
         assertThat(twineCommands, hasItem(
-            'twine upload -r pypi dist'
+            'twine upload -r pypi dist/*'
         ))
 
         def signing = getCommands('signArtifacts', '')
@@ -46,7 +46,7 @@ class TestPublishToPyPi extends BuildPipelineTest {
 
         def twineCommands = getCommands('sh', 'twine')
         assertThat(twineCommands, hasItem(
-            'twine upload -r pypi test'
+            'twine upload -r pypi test/*'
         ))
         def signing = getCommands('signArtifacts', '')
         assertThat(signing, hasItem('{artifactPath=test, sigtype=.asc, platform=linux}'))

--- a/tests/jenkins/TestPublishToPyPi.groovy
+++ b/tests/jenkins/TestPublishToPyPi.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import jenkins.tests.BuildPipelineTest
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class TestPublishToPyPi extends BuildPipelineTest {
+
+    @Test
+    void setUp() {
+        this.registerLibTester(new PublishToPyPiLibTester())
+        super.setUp()
+        super.testPipeline('tests/jenkins/jobs/PublishToPyPi_Jenkinsfile')
+    }
+
+    @Test
+    void 'verify default run'(){
+        runScript('tests/jenkins/jobs/PublishToPyPi_Jenkinsfile')
+
+        def twineCommands = getCommands('sh', 'twine')
+        assertThat(twineCommands, hasItem(
+            'twine upload -r pypi dist'
+        ))
+
+        def signing = getCommands('signArtifacts', '')
+        def signing_sh = getCommands('sh', 'sign.sh')
+        assertThat(signing, hasItem('{artifactPath=dist, sigtype=.asc, platform=linux}'))
+        assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh dist --sigtype=.asc --platform=linux\n               '))
+    }
+
+    @Test
+    void 'verify custom dir'(){
+        runScript('tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile')
+
+        def twineCommands = getCommands('sh', 'twine')
+        assertThat(twineCommands, hasItem(
+            'twine upload -r pypi test'
+        ))
+        def signing = getCommands('signArtifacts', '')
+        assertThat(signing, hasItem('{artifactPath=test, sigtype=.asc, platform=linux}'))
+
+        def signing_sh = getCommands('sh', 'sign.sh')
+        assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh test --sigtype=.asc --platform=linux\n               '))
+
+    }
+    def getCommands(method, text) {
+        def shCommands = helper.callStack.findAll { call ->
+            call.methodName == method
+        }.collect { call ->
+            callArgsToString(call)
+        }.findAll { command ->
+            command.contains(text)
+        }
+        return shCommands
+    }
+}

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('publishToPyPi') {
+            steps {
+                script {
+                    publishToPyPi(artifactsPath: 'test')
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
@@ -1,0 +1,34 @@
+   PublishToPyPiWithDir_Jenkinsfile.run()
+      PublishToPyPiWithDir_Jenkinsfile.pipeline(groovy.lang.Closure)
+         PublishToPyPiWithDir_Jenkinsfile.echo(Executing on agent [label:none])
+         PublishToPyPiWithDir_Jenkinsfile.stage(publishToPyPi, groovy.lang.Closure)
+            PublishToPyPiWithDir_Jenkinsfile.script(groovy.lang.Closure)
+               PublishToPyPiWithDir_Jenkinsfile.publishToPyPi({artifactsPath=test})
+                  publishToPyPi.legacySCM(groovy.lang.Closure)
+                  publishToPyPi.library({identifier=jenkins@main, retriever=null})
+                  publishToPyPi.sh(echo args to test)
+                  publishToPyPi.sh(echo release test)
+                  publishToPyPi.signArtifacts({artifactPath=test, sigtype=.asc, platform=linux})
+                     signArtifacts.echo(PGP or Windows Signature Signing)
+                     signArtifacts.fileExists(/tmp/workspace/sign.sh)
+                     signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
+                     signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
+                     signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-role, variable=SIGNER_CLIENT_ROLE})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-external-id, variable=SIGNER_CLIENT_EXTERNAL_ID})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-unsigned-bucket, variable=SIGNER_CLIENT_UNSIGNED_BUCKET})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-signed-bucket, variable=SIGNER_CLIENT_SIGNED_BUCKET})
+                     signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], SIGNER_CLIENT_ROLE, SIGNER_CLIENT_EXTERNAL_ID, SIGNER_CLIENT_UNSIGNED_BUCKET, SIGNER_CLIENT_SIGNED_BUCKET], groovy.lang.Closure)
+                        signArtifacts.sh(
+                   #!/bin/bash
+                   set +x
+                   export ROLE=SIGNER_CLIENT_ROLE
+                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID
+                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET
+                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET
+
+                   /tmp/workspace/sign.sh test --sigtype=.asc --platform=linux
+               )
+                  publishToPyPi.usernamePassword({credentialsId=jenkins-opensearch-pypi-username, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
+                  publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
+                     publishToPyPi.sh(twine upload -r pypi test)

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('publishToPyPi') {
+            steps {
+                script {
+                    publishToPyPi()
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
@@ -1,0 +1,32 @@
+   PublishToPyPi_Jenkinsfile.run()
+      PublishToPyPi_Jenkinsfile.pipeline(groovy.lang.Closure)
+         PublishToPyPi_Jenkinsfile.echo(Executing on agent [label:none])
+         PublishToPyPi_Jenkinsfile.stage(publishToPyPi, groovy.lang.Closure)
+            PublishToPyPi_Jenkinsfile.script(groovy.lang.Closure)
+               PublishToPyPi_Jenkinsfile.publishToPyPi()
+                  publishToPyPi.legacySCM(groovy.lang.Closure)
+                  publishToPyPi.library({identifier=jenkins@main, retriever=null})
+                  publishToPyPi.signArtifacts({artifactPath=dist, sigtype=.asc, platform=linux})
+                     signArtifacts.echo(PGP or Windows Signature Signing)
+                     signArtifacts.fileExists(/tmp/workspace/sign.sh)
+                     signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
+                     signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
+                     signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-role, variable=SIGNER_CLIENT_ROLE})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-external-id, variable=SIGNER_CLIENT_EXTERNAL_ID})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-unsigned-bucket, variable=SIGNER_CLIENT_UNSIGNED_BUCKET})
+                     signArtifacts.string({credentialsId=jenkins-signer-client-signed-bucket, variable=SIGNER_CLIENT_SIGNED_BUCKET})
+                     signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], SIGNER_CLIENT_ROLE, SIGNER_CLIENT_EXTERNAL_ID, SIGNER_CLIENT_UNSIGNED_BUCKET, SIGNER_CLIENT_SIGNED_BUCKET], groovy.lang.Closure)
+                        signArtifacts.sh(
+                   #!/bin/bash
+                   set +x
+                   export ROLE=SIGNER_CLIENT_ROLE
+                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID
+                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET
+                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET
+
+                   /tmp/workspace/sign.sh dist --sigtype=.asc --platform=linux
+               )
+                  publishToPyPi.usernamePassword({credentialsId=jenkins-opensearch-pypi-username, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
+                  publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
+                     publishToPyPi.sh(twine upload -r pypi dist)

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
@@ -29,4 +29,4 @@
                )
                   publishToPyPi.usernamePassword({credentialsId=jenkins-opensearch-pypi-username, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
                   publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
-                     publishToPyPi.sh(twine upload -r pypi dist)
+                     publishToPyPi.sh(twine upload -r pypi dist/*)

--- a/tests/jenkins/lib-testers/PublishToPyPiLibTester.groovy
+++ b/tests/jenkins/lib-testers/PublishToPyPiLibTester.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.NullValue
+
+class PublishToPyPiLibTester extends LibFunctionTester {
+
+    private String artifactsPath = 'dist'
+
+    public PublishToPyPiLibTester(){}
+    public PublishToPyPiLibTester(String artifactsPath){
+        this.artifactsPath = artifactsPath
+    }
+
+    void configure(helper, binding){
+        binding.setVariable('GITHUB_BOT_TOKEN_NAME', 'github_bot_token_name')
+        helper.registerAllowedMethod("git", [Map])
+        helper.registerAllowedMethod("withCredentials", [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+    }
+    void parameterInvariantsAssertions(call){
+        assertThat(call.args.artifactsPath.toString(), notNullValue())
+    }
+
+    boolean expectedParametersMatcher(call) {
+        if (call.args.artifactsPath.isEmpty()) {
+            return (this.artifactsPath.equals('dist'))
+        }
+        return (call.args.artifactsPath.first().toString().equals(this.artifactsPath))
+    }
+
+    String libFunctionName(){
+        return 'publishToPyPi'
+    }
+
+}

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -22,6 +22,6 @@ void call(Map args = [:]) {
     )
 
     withCredentials([usernamePassword(credentialsId: 'jenkins-opensearch-pypi-username', usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
-            sh """twine upload -r pypi ${releaseArtifactsDir}"""
+            sh """twine upload -r pypi ${releaseArtifactsDir}/*"""
     }
 }

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -9,23 +9,19 @@
 
 /** Library to publish artifacts to PyPi registry with OpenSearch as maintainer
 @param Map args = [:] args A map of the following parameters
-@param args.repository <required> - Repository to be used to publish the artifact to npm
-@param args.tag <required> - Tag reference to be used to publish the artifact
-@param args.dir <optional> - The directory containing distribution files to upload to the repository. Defaults to 'dist/*'
-@param args.signArtifacts <optional> - Sign the artifacts to be uploaded to PyPi. Defaults to 'true'
+@param args.artifactsPath <optional> - The directory containing distribution files to upload to the repository. Defaults to 'dist/*'
 */
 void call(Map args = [:]) {
-    if (args.signArtifacts) {
-        lib = library(identifier: 'jenkins@pypi', retriever: legacySCM(scm))
-        signArtifacts(
-            artifactPath: args.dir,
-            sigtype: '.asc',
-            platform: 'linux'
-        )
-    }
+    lib = library(identifier: 'jenkins@main', retriever: legacySCM(scm))
+    String releaseArtifactsDir = args.artifactsPath ?: 'dist'
+
+    signArtifacts(
+        artifactPath: releaseArtifactsDir,
+        sigtype: '.asc',
+        platform: 'linux'
+    )
 
     withCredentials([usernamePassword(credentialsId: 'jenkins-opensearch-pypi-username', usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
-            def dist = args.dir ?: 'dist/*'
-            sh """twine upload -r pypi ${dist}"""
-        }
+            sh """twine upload -r pypi ${releaseArtifactsDir}"""
+    }
 }

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Library to publish artifacts to PyPi registry with OpenSearch as maintainer
+@param Map args = [:] args A map of the following parameters
+@param args.repository <required> - Repository to be used to publish the artifact to npm
+@param args.tag <required> - Tag reference to be used to publish the artifact
+@param args.dir <optional> - The directory containing distribution files to upload to the repository. Defaults to 'dist/*'
+@param args.signArtifacts <optional> - Sign the artifacts to be uploaded to PyPi. Defaults to 'true'
+*/
+void call(Map args = [:]) {
+
+    checkout([$class: 'GitSCM', branches: [[name: "${args.tag}" ]], userRemoteConfigs: [[url: "${args.repository}" ]]])
+
+    if (args.signArtifacts) {
+        lib = library(identifier: 'jenkins@pypi', retriever: legacySCM(scm))
+        signArtifacts(
+            artifactPath: args.dir,
+            sigtype: '.asc',
+            platform: 'linux'
+        )
+    }
+
+    withCredentials([usernamePassword(credentialsId: 'jenkins-opensearch-pypi-username', usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
+            def dist = args.dir ?: 'dist/*'
+            sh """twine upload -r pypi ${dist}"""
+        }
+}

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -15,9 +15,6 @@
 @param args.signArtifacts <optional> - Sign the artifacts to be uploaded to PyPi. Defaults to 'true'
 */
 void call(Map args = [:]) {
-
-    checkout([$class: 'GitSCM', branches: [[name: "${args.tag}" ]], userRemoteConfigs: [[url: "${args.repository}" ]]])
-
     if (args.signArtifacts) {
         lib = library(identifier: 'jenkins@pypi', retriever: legacySCM(scm))
         signArtifacts(


### PR DESCRIPTION
### Description
Add library to publish artifacts to PyPi. The library will sign all the artifacts before publishing on PyPi

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/2839 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
