### PR TITLE
Add credential arg for pypi

### DIFF
--- a/tests/jenkins/TestPublishToPyPi.groovy
+++ b/tests/jenkins/TestPublishToPyPi.groovy
@@ -20,7 +20,7 @@ class TestPublishToPyPi extends BuildPipelineTest {
 
     @Test
     void testWithDefaults() {
-        this.registerLibTester(new PublishToPyPiLibTester())
+        this.registerLibTester(new PublishToPyPiLibTester('pypi-token'))
         super.setUp()
         super.testPipeline('tests/jenkins/jobs/PublishToPyPi_Jenkinsfile')
         def twineCommands = getCommands('sh', 'twine')
@@ -36,7 +36,7 @@ class TestPublishToPyPi extends BuildPipelineTest {
 
     @Test
     void testWithCustomDir() {
-        this.registerLibTester(new PublishToPyPiLibTester('test'))
+        this.registerLibTester(new PublishToPyPiLibTester('pypi-token', 'test'))
         super.setUp()
         super.testPipeline('tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile')
 

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('publishToPyPi') {
             steps {
                 script {
-                    publishToPyPi(artifactsPath: 'test')
+                    publishToPyPi(credentialsId: 'pypi-token', artifactsPath: 'test')
                 }
             }
         }

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('publishToPyPi') {
             steps {
                 script {
-                    publishToPyPi(credentialsId: 'pypi-token', artifactsPath: 'test')
+                    publishToPyPi(credentialId: 'pypi-token', artifactsPath: 'test')
                 }
             }
         }

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          PublishToPyPiWithDir_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToPyPiWithDir_Jenkinsfile.stage(publishToPyPi, groovy.lang.Closure)
             PublishToPyPiWithDir_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToPyPiWithDir_Jenkinsfile.publishToPyPi({artifactsPath=test})
+               PublishToPyPiWithDir_Jenkinsfile.publishToPyPi({credentialsId=pypi-token, artifactsPath=test})
                   publishToPyPi.legacySCM(groovy.lang.Closure)
                   publishToPyPi.library({identifier=jenkins@main, retriever=null})
                   publishToPyPi.signArtifacts({artifactPath=test, sigtype=.asc, platform=linux})
@@ -27,6 +27,6 @@
 
                    /tmp/workspace/sign.sh test --sigtype=.asc --platform=linux
                )
-                  publishToPyPi.usernamePassword({credentialsId=jenkins-opensearch-pypi-credentials, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
+                  publishToPyPi.usernamePassword({credentialsId=pypi-token, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
                   publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
                      publishToPyPi.sh(twine upload -r pypi test/*)

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          PublishToPyPiWithDir_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToPyPiWithDir_Jenkinsfile.stage(publishToPyPi, groovy.lang.Closure)
             PublishToPyPiWithDir_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToPyPiWithDir_Jenkinsfile.publishToPyPi({credentialsId=pypi-token, artifactsPath=test})
+               PublishToPyPiWithDir_Jenkinsfile.publishToPyPi({credentialId=pypi-token, artifactsPath=test})
                   publishToPyPi.legacySCM(groovy.lang.Closure)
                   publishToPyPi.library({identifier=jenkins@main, retriever=null})
                   publishToPyPi.signArtifacts({artifactPath=test, sigtype=.asc, platform=linux})

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('publishToPyPi') {
             steps {
                 script {
-                    publishToPyPi(credentialsId: 'pypi-token')
+                    publishToPyPi(credentialId: 'pypi-token')
                 }
             }
         }

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('publishToPyPi') {
             steps {
                 script {
-                    publishToPyPi()
+                    publishToPyPi(credentialsId: 'pypi-token')
                 }
             }
         }

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          PublishToPyPi_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToPyPi_Jenkinsfile.stage(publishToPyPi, groovy.lang.Closure)
             PublishToPyPi_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToPyPi_Jenkinsfile.publishToPyPi()
+               PublishToPyPi_Jenkinsfile.publishToPyPi({credentialsId=pypi-token})
                   publishToPyPi.legacySCM(groovy.lang.Closure)
                   publishToPyPi.library({identifier=jenkins@main, retriever=null})
                   publishToPyPi.signArtifacts({artifactPath=dist, sigtype=.asc, platform=linux})
@@ -27,6 +27,6 @@
 
                    /tmp/workspace/sign.sh dist --sigtype=.asc --platform=linux
                )
-                  publishToPyPi.usernamePassword({credentialsId=jenkins-opensearch-pypi-credentials, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
+                  publishToPyPi.usernamePassword({credentialsId=pypi-token, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
                   publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
                      publishToPyPi.sh(twine upload -r pypi dist/*)

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          PublishToPyPi_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToPyPi_Jenkinsfile.stage(publishToPyPi, groovy.lang.Closure)
             PublishToPyPi_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToPyPi_Jenkinsfile.publishToPyPi({credentialsId=pypi-token})
+               PublishToPyPi_Jenkinsfile.publishToPyPi({credentialId=pypi-token})
                   publishToPyPi.legacySCM(groovy.lang.Closure)
                   publishToPyPi.library({identifier=jenkins@main, retriever=null})
                   publishToPyPi.signArtifacts({artifactPath=dist, sigtype=.asc, platform=linux})

--- a/tests/jenkins/lib-testers/PublishToPyPiLibTester.groovy
+++ b/tests/jenkins/lib-testers/PublishToPyPiLibTester.groovy
@@ -13,13 +13,13 @@ import static org.hamcrest.CoreMatchers.NullValue
 class PublishToPyPiLibTester extends LibFunctionTester {
 
     private String artifactsPath = 'dist'
-    private String credentialsId
+    private String credentialId
 
-    public PublishToPyPiLibTester(String credentialsId) {
-        this.credentialsId = credentialsId
+    public PublishToPyPiLibTester(String credentialId) {
+        this.credentialId = credentialId
     }
-    public PublishToPyPiLibTester(String credentialsId, String artifactsPath) {
-        this.credentialsId = credentialsId
+    public PublishToPyPiLibTester(String credentialId, String artifactsPath) {
+        this.credentialId = credentialId
         this.artifactsPath = artifactsPath
     }
 
@@ -30,11 +30,11 @@ class PublishToPyPiLibTester extends LibFunctionTester {
     }
     void parameterInvariantsAssertions(call){
         assertThat(call.args.artifactsPath.toString(), notNullValue())
-        assertThat(call.args.credentialsId.toString(), notNullValue())
+        assertThat(call.args.credentialId.toString(), notNullValue())
     }
 
     boolean expectedParametersMatcher(call) {
-        return call.args.credentialsId.first().toString().equals(this.credentialsId)
+        return call.args.credentialId.first().toString().equals(this.credentialId)
     }
 
     boolean expectedParametersMatcherArtifact(call){

--- a/tests/jenkins/lib-testers/PublishToPyPiLibTester.groovy
+++ b/tests/jenkins/lib-testers/PublishToPyPiLibTester.groovy
@@ -13,25 +13,31 @@ import static org.hamcrest.CoreMatchers.NullValue
 class PublishToPyPiLibTester extends LibFunctionTester {
 
     private String artifactsPath = 'dist'
+    private String credentialsId
 
-    public PublishToPyPiLibTester(){}
-    public PublishToPyPiLibTester(String artifactsPath){
+    public PublishToPyPiLibTester(String credentialsId) {
+        this.credentialsId = credentialsId
+    }
+    public PublishToPyPiLibTester(String credentialsId, String artifactsPath) {
+        this.credentialsId = credentialsId
         this.artifactsPath = artifactsPath
     }
 
     void configure(helper, binding){
         binding.setVariable('GITHUB_BOT_TOKEN_NAME', 'github_bot_token_name')
         helper.registerAllowedMethod("git", [Map])
-        helper.registerAllowedMethod("withCredentials", [Map, Closure], { args, closure ->
-            closure.delegate = delegate
-            return helper.callClosure(closure)
-        })
+        helper.registerAllowedMethod("withCredentials", [Map])
     }
     void parameterInvariantsAssertions(call){
         assertThat(call.args.artifactsPath.toString(), notNullValue())
+        assertThat(call.args.credentialsId.toString(), notNullValue())
     }
 
     boolean expectedParametersMatcher(call) {
+        return call.args.credentialsId.first().toString().equals(this.credentialsId)
+    }
+
+    boolean expectedParametersMatcherArtifact(call){
         if (call.args.artifactsPath.isEmpty()) {
             return (this.artifactsPath.equals('dist'))
         }

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -9,7 +9,7 @@
 
 /** Library to publish artifacts to PyPi registry with OpenSearch as maintainer
 @param Map args = [:] args A map of the following parameters
-@param args.credentialsId <required> - Credential id consisting token for publishing the package
+@param args.credentialId <required> - Credential id consisting token for publishing the package
 @param args.artifactsPath <optional> - The directory containing distribution files to upload to the repository. Defaults to 'dist/*'
 */
 void call(Map args = [:]) {
@@ -22,7 +22,7 @@ void call(Map args = [:]) {
         platform: 'linux'
     )
 
-    withCredentials([usernamePassword(credentialsId: args.credentialsId, usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
+    withCredentials([usernamePassword(credentialsId: args.credentialId, usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
             sh """twine upload -r pypi ${releaseArtifactsDir}/*"""
     }
 }

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -9,6 +9,7 @@
 
 /** Library to publish artifacts to PyPi registry with OpenSearch as maintainer
 @param Map args = [:] args A map of the following parameters
+@param args.credentialsId <required>
 @param args.artifactsPath <optional> - The directory containing distribution files to upload to the repository. Defaults to 'dist/*'
 */
 void call(Map args = [:]) {
@@ -21,7 +22,7 @@ void call(Map args = [:]) {
         platform: 'linux'
     )
 
-    withCredentials([usernamePassword(credentialsId: 'jenkins-opensearch-pypi-credentials', usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
+    withCredentials([usernamePassword(credentialsId: args.credentialsId, usernameVariable: 'TWINE_USERNAME', passwordVariable: 'TWINE_PASSWORD')]) {
             sh """twine upload -r pypi ${releaseArtifactsDir}/*"""
     }
 }

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -9,7 +9,7 @@
 
 /** Library to publish artifacts to PyPi registry with OpenSearch as maintainer
 @param Map args = [:] args A map of the following parameters
-@param args.credentialsId <required>
+@param args.credentialsId <required> - Credential id consisting token for publishing the package
 @param args.artifactsPath <optional> - The directory containing distribution files to upload to the repository. Defaults to 'dist/*'
 */
 void call(Map args = [:]) {


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Depending on the package, pypi gives an option to scope the automation token as per package. This change gives us an option to specify the same

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
