### PR TITLE
[Backport 1.x] Fix path for signing artifacts using pypi lib (#45)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '1.3.0'
+String version = '1.3.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishToPyPi.groovy
+++ b/tests/jenkins/TestPublishToPyPi.groovy
@@ -51,8 +51,6 @@ class TestPublishToPyPi extends BuildPipelineTest {
         assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh /tmp/workspace/test --sigtype=.asc --platform=linux\n               '))
     }
 
-    }
-
     def getCommands(method, text) {
         def shCommands = helper.callStack.findAll { call ->
             call.methodName == method

--- a/tests/jenkins/TestPublishToPyPi.groovy
+++ b/tests/jenkins/TestPublishToPyPi.groovy
@@ -48,13 +48,9 @@ class TestPublishToPyPi extends BuildPipelineTest {
         assertThat(signing, hasItem('{artifactPath=/tmp/workspace/test, sigtype=.asc, platform=linux}'))
 
         def signing_sh = getCommands('sh', 'sign.sh')
-<<<<<<< HEAD
-        assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh test --sigtype=.asc --platform=linux\n               '))
-=======
         assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh /tmp/workspace/test --sigtype=.asc --platform=linux\n               '))
     }
 
->>>>>>> 6c719d8 (Fix path for signing artifacts using pypi lib (#45))
     }
 
     def getCommands(method, text) {

--- a/tests/jenkins/TestPublishToPyPi.groovy
+++ b/tests/jenkins/TestPublishToPyPi.groovy
@@ -25,13 +25,13 @@ class TestPublishToPyPi extends BuildPipelineTest {
         super.testPipeline('tests/jenkins/jobs/PublishToPyPi_Jenkinsfile')
         def twineCommands = getCommands('sh', 'twine')
         assertThat(twineCommands, hasItem(
-            'twine upload -r pypi dist/*'
+            'twine upload -r pypi /tmp/workspace/dist/*'
         ))
 
         def signing = getCommands('signArtifacts', '')
         def signing_sh = getCommands('sh', 'sign.sh')
-        assertThat(signing, hasItem('{artifactPath=dist, sigtype=.asc, platform=linux}'))
-        assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh dist --sigtype=.asc --platform=linux\n               '))
+        assertThat(signing, hasItem('{artifactPath=/tmp/workspace/dist, sigtype=.asc, platform=linux}'))
+        assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh /tmp/workspace/dist --sigtype=.asc --platform=linux\n               '))
     }
 
     @Test
@@ -42,13 +42,19 @@ class TestPublishToPyPi extends BuildPipelineTest {
 
         def twineCommands = getCommands('sh', 'twine')
         assertThat(twineCommands, hasItem(
-            'twine upload -r pypi test/*'
+            'twine upload -r pypi /tmp/workspace/test/*'
         ))
         def signing = getCommands('signArtifacts', '')
-        assertThat(signing, hasItem('{artifactPath=test, sigtype=.asc, platform=linux}'))
+        assertThat(signing, hasItem('{artifactPath=/tmp/workspace/test, sigtype=.asc, platform=linux}'))
 
         def signing_sh = getCommands('sh', 'sign.sh')
+<<<<<<< HEAD
         assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh test --sigtype=.asc --platform=linux\n               '))
+=======
+        assertThat(signing_sh, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh /tmp/workspace/test --sigtype=.asc --platform=linux\n               '))
+    }
+
+>>>>>>> 6c719d8 (Fix path for signing artifacts using pypi lib (#45))
     }
 
     def getCommands(method, text) {

--- a/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPiWithDir_Jenkinsfile.txt
@@ -6,7 +6,7 @@
                PublishToPyPiWithDir_Jenkinsfile.publishToPyPi({credentialId=pypi-token, artifactsPath=test})
                   publishToPyPi.legacySCM(groovy.lang.Closure)
                   publishToPyPi.library({identifier=jenkins@1.3.0, retriever=null})
-                  publishToPyPi.signArtifacts({artifactPath=test, sigtype=.asc, platform=linux})
+                  publishToPyPi.signArtifacts({artifactPath=/tmp/workspace/test, sigtype=.asc, platform=linux})
                      signArtifacts.echo(PGP or Windows Signature Signing)
                      signArtifacts.fileExists(/tmp/workspace/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
@@ -25,8 +25,8 @@
                    export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET
                    export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET
 
-                   /tmp/workspace/sign.sh test --sigtype=.asc --platform=linux
+                   /tmp/workspace/sign.sh /tmp/workspace/test --sigtype=.asc --platform=linux
                )
                   publishToPyPi.usernamePassword({credentialsId=pypi-token, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
                   publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
-                     publishToPyPi.sh(twine upload -r pypi test/*)
+                     publishToPyPi.sh(twine upload -r pypi /tmp/workspace/test/*)

--- a/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToPyPi_Jenkinsfile.txt
@@ -6,7 +6,7 @@
                PublishToPyPi_Jenkinsfile.publishToPyPi({credentialId=pypi-token})
                   publishToPyPi.legacySCM(groovy.lang.Closure)
                   publishToPyPi.library({identifier=jenkins@1.3.0, retriever=null})
-                  publishToPyPi.signArtifacts({artifactPath=dist, sigtype=.asc, platform=linux})
+                  publishToPyPi.signArtifacts({artifactPath=/tmp/workspace/dist, sigtype=.asc, platform=linux})
                      signArtifacts.echo(PGP or Windows Signature Signing)
                      signArtifacts.fileExists(/tmp/workspace/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
@@ -25,8 +25,8 @@
                    export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET
                    export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET
 
-                   /tmp/workspace/sign.sh dist --sigtype=.asc --platform=linux
+                   /tmp/workspace/sign.sh /tmp/workspace/dist --sigtype=.asc --platform=linux
                )
                   publishToPyPi.usernamePassword({credentialsId=pypi-token, usernameVariable=TWINE_USERNAME, passwordVariable=TWINE_PASSWORD})
                   publishToPyPi.withCredentials([[TWINE_USERNAME, TWINE_PASSWORD]], groovy.lang.Closure)
-                     publishToPyPi.sh(twine upload -r pypi dist/*)
+                     publishToPyPi.sh(twine upload -r pypi /tmp/workspace/dist/*)

--- a/vars/publishToPyPi.groovy
+++ b/vars/publishToPyPi.groovy
@@ -14,7 +14,7 @@
 */
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@1.3.0', retriever: legacySCM(scm))
-    String releaseArtifactsDir = args.artifactsPath ?: 'dist'
+    String releaseArtifactsDir = args.artifactsPath ? "${WORKSPACE}/${args.artifactsPath}" : "${WORKSPACE}/dist"
 
     signArtifacts(
         artifactPath: releaseArtifactsDir,


### PR DESCRIPTION
* Fix path for signing artifacts using pypi lib

Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>
(cherry picked from commit d3348219e25b2758a131b91f67f87dd0c6981ad9)

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
