### PR TITLE
Fix verification of signed gems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '1.4.1'
+String version = '1.4.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishToRubyGems.groovy
+++ b/tests/jenkins/TestPublishToRubyGems.groovy
@@ -27,7 +27,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         def curlCommands = getCommands('sh', 'curl')
         def gemCommands = getCommands('sh', 'gem')
         assertThat(curlCommands, hasItem(
-            "curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()
+            "cd /tmp/workspace/dist && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()
         ))
         assertThat(gemCommands, hasItem("\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
@@ -40,7 +40,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         def curlCommands = getCommands('sh', 'curl')
         def gemCommands = getCommands('sh', 'gem')
         assertThat(curlCommands, hasItem(
-            "curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()))
+            "cd /tmp/workspace/test && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()))
         assertThat(gemCommands, hasItem("\n        gem cert --add /tmp/workspace/certificate/path\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 

--- a/tests/jenkins/TestPublishToRubyGems.groovy
+++ b/tests/jenkins/TestPublishToRubyGems.groovy
@@ -12,7 +12,6 @@ package jenkins.tests
 import jenkins.tests.BuildPipelineTest
 import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
 import static org.hamcrest.CoreMatchers.hasItem
-import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
@@ -4,6 +4,14 @@
          PublishToRubyGemWithArgs_Jenkinsfile.stage(publishRubyGems, groovy.lang.Closure)
             PublishToRubyGemWithArgs_Jenkinsfile.script(groovy.lang.Closure)
                PublishToRubyGemWithArgs_Jenkinsfile.publishToRubyGems({apiKeyCredentialId=ruby-api-key, gemsDir=test, publicCertPath=certificate/path})
+                  publishToRubyGems.sh(
+        gem cert --add /tmp/workspace/certificate/path
+        cd /tmp/workspace/test && gemNameWithVersion=$(ls *.gem)
+        gem install $gemNameWithVersion
+        gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+.gem$)//g')
+        gem uninstall $gemName
+        gem install $gemNameWithVersion -P HighSecurity
+    )
                   publishToRubyGems.string({credentialsId=ruby-api-key, variable=API_KEY})
                   publishToRubyGems.withCredentials([API_KEY], groovy.lang.Closure)
-                     publishToRubyGems.sh(gem cert --add /tmp/workspace/certificate/path &&             cd /tmp/workspace/test && gem install `ls *.gem` -P HighSecurity &&             curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)
+                     publishToRubyGems.sh(curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)

--- a/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
@@ -14,4 +14,4 @@
     )
                   publishToRubyGems.string({credentialsId=ruby-api-key, variable=API_KEY})
                   publishToRubyGems.withCredentials([API_KEY], groovy.lang.Closure)
-                     publishToRubyGems.sh(curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)
+                     publishToRubyGems.sh(cd /tmp/workspace/test && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)

--- a/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
@@ -4,6 +4,14 @@
          PublishToRubyGems_JenkinsFile.stage(publishRubyGems, groovy.lang.Closure)
             PublishToRubyGems_JenkinsFile.script(groovy.lang.Closure)
                PublishToRubyGems_JenkinsFile.publishToRubyGems({apiKeyCredentialId=ruby-api-key})
+                  publishToRubyGems.sh(
+        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem
+        cd /tmp/workspace/dist && gemNameWithVersion=$(ls *.gem)
+        gem install $gemNameWithVersion
+        gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+.gem$)//g')
+        gem uninstall $gemName
+        gem install $gemNameWithVersion -P HighSecurity
+    )
                   publishToRubyGems.string({credentialsId=ruby-api-key, variable=API_KEY})
                   publishToRubyGems.withCredentials([API_KEY], groovy.lang.Closure)
-                     publishToRubyGems.sh(gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem &&             cd /tmp/workspace/dist && gem install `ls *.gem` -P HighSecurity &&             curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)
+                     publishToRubyGems.sh(curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)

--- a/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
@@ -14,4 +14,4 @@
     )
                   publishToRubyGems.string({credentialsId=ruby-api-key, variable=API_KEY})
                   publishToRubyGems.withCredentials([API_KEY], groovy.lang.Closure)
-                     publishToRubyGems.sh(curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)
+                     publishToRubyGems.sh(cd /tmp/workspace/dist && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems)

--- a/vars/publishToRubyGems.groovy
+++ b/vars/publishToRubyGems.groovy
@@ -30,6 +30,6 @@ void call(Map args = [:]) {
     """
 
     withCredentials([string(credentialsId: "${args.apiKeyCredentialId}", variable: 'API_KEY')]) {
-        sh "curl --fail --data-binary @`ls *.gem` -H 'Authorization:${API_KEY}' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems"
+        sh "cd ${releaseArtifactsDir} && curl --fail --data-binary @`ls *.gem` -H 'Authorization:${API_KEY}' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems"
     }
 }

--- a/vars/publishToRubyGems.groovy
+++ b/vars/publishToRubyGems.groovy
@@ -14,13 +14,27 @@ Note: Please make sure the gem is already signed.
 @param args.gemsDir <optional> - The directory containing the gem to be published. Defaults to 'dist'
 @params args.publicCertPath <optional> - The relative path to public key. Defaults to 'certs/opensearch-rubygems.pem'
 */
+
+import java.util.logging.Logger;
+
+log = Logger.getLogger("InfoLogging");
+
 void call(Map args = [:]) {
     String releaseArtifactsDir = args.gemsDir ? "${WORKSPACE}/${args.gemsDir}" : "${WORKSPACE}/dist"
     String certPath = args.publicCertPath ? "${WORKSPACE}/${args.publicCertPath}" : "${WORKSPACE}/certs/opensearch-rubygems.pem"
 
+    sh "gem cert --add ${certPath} && cd ${releaseArtifactsDir}"
+    log.info('Verifying the gem signature')
+    def gemNameWithVersion = sh 'ls *.gem'
+    sh """
+        gem install '${gemNameWithVersion}';
+        gemName=$(echo ${gemNameWithVersion} | sed -E 's/(-[0-9.]+.gem$)//g');
+        gem uninstall ${gemName};
+        gem install ${gemNameWithVersion} -P HighSecurity;
+    """
+
+    log.info('Publishing the gem')
     withCredentials([string(credentialsId: "${args.apiKeyCredentialId}", variable: 'API_KEY')]) {
-        sh """gem cert --add ${certPath} && \
-            cd ${releaseArtifactsDir} && gem install `ls *.gem` -P HighSecurity && \
-            curl --fail --data-binary @`ls *.gem` -H 'Authorization:${API_KEY}' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems"""
+        sh "curl --fail --data-binary @${gemName}` -H 'Authorization:${API_KEY}' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems"
         }
 }


### PR DESCRIPTION
### Description
The `-P HighSecurity` option checks that even dependent gems are signed which might not be necessarily true. The `MediumSecuriy` checks the signatures for signed gems. For unsigned ones, it just ignores.
Hence following this method where we install the gems normally first so that all the dependencies get installed and then uninstall the gem that is to be published and reinstall using `-P HighSecurity`


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
