### PR TITLE
Add shared lib call to Maven lib

### DIFF
--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -4,6 +4,8 @@
          PublishToMavenManifestYml_Jenkinsfile.stage(publish, groovy.lang.Closure)
             PublishToMavenManifestYml_Jenkinsfile.script(groovy.lang.Closure)
                PublishToMavenManifestYml_Jenkinsfile.publishToMaven({signingArtifactsPath=/path/to/signing/manifest.yml, mavenArtifactsPath=/path/to/maven/artifacts, autoPublish=false})
+                  publishToMaven.legacySCM(groovy.lang.Closure)
+                  publishToMaven.library({identifier=jenkins@main, retriever=null})
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing/manifest.yml, type=maven, platform=linux, sigtype=.asc})
                      signArtifacts.echo(PGP or Windows Signature Signing)
                      signArtifacts.fileExists(workspace/sign.sh)

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -4,6 +4,8 @@
          PublishToMaven_Jenkinsfile.stage(publish, groovy.lang.Closure)
             PublishToMaven_Jenkinsfile.script(groovy.lang.Closure)
                PublishToMaven_Jenkinsfile.publishToMaven({signingArtifactsPath=/path/to/signing, mavenArtifactsPath=/path/to/maven/artifacts, autoPublish=true})
+                  publishToMaven.legacySCM(groovy.lang.Closure)
+                  publishToMaven.library({identifier=jenkins@main, retriever=null})
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing, type=maven, platform=linux, sigtype=.asc})
                      signArtifacts.echo(PGP or Windows Signature Signing)
                      signArtifacts.fileExists(workspace/sign.sh)

--- a/vars/publishToMaven.groovy
+++ b/vars/publishToMaven.groovy
@@ -15,6 +15,7 @@
  */
 
 void call(Map args = [:]) {
+    lib = library(identifier: 'jenkins@main', retriever: legacySCM(scm))
     def autoPublish = args.autoPublish ?: false
     println("Signing Maven artifacts.")
     signArtifacts(


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Add shared lib call to Maven lib so that `signArtifacts` call can be detected by jenkins,

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
