### PR TITLE
Fix download and untar in standard release pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '1.5.1'
+String version = '1.5.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
+++ b/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
@@ -115,7 +115,7 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
         def cmd = getCommands('sh').findAll{
             c -> c.contains('curl')
         }
-        assertThat(cmd, hasItem("curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 | tar -xzv"))
+        assertThat(cmd, hasItem("curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"))
         assertThat(cmd, hasItem("{script=curl -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/name/releases/1234/assets, returnStdout=true}"))
     }
 

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
@@ -14,7 +14,7 @@ bbb
 ccc
 })
                      standardReleasePipelineWithGenericTrigger.echo(Downloading artifacts from https://api.github.com/repos/owner/reponame/releases/assets/123456)
-                     standardReleasePipelineWithGenericTrigger.sh(curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 | tar -xzv)
+                     standardReleasePipelineWithGenericTrigger.sh(curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 -o artifacts.tar.gz && tar -xvf artifacts.tar.gz)
             standardReleasePipelineWithGenericTrigger.stage(Release, groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                   StandardReleasePipelineWithGenericTriggers_Jenkinsfile.echo(fakePublishToMaven [mavenArtifactsPath:/maven, autoPublish:true])

--- a/vars/standardReleasePipelineWithGenericTrigger.groovy
+++ b/vars/standardReleasePipelineWithGenericTrigger.groovy
@@ -79,7 +79,7 @@ void call(Map args = [:], Closure body) {
                                         }
                                     }
                                 echo "Downloading artifacts from $assetUrl"
-                                sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} && tar -xzv *.tar.gz"
+                                sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"
                             }
                         }
                     }

--- a/vars/standardReleasePipelineWithGenericTrigger.groovy
+++ b/vars/standardReleasePipelineWithGenericTrigger.groovy
@@ -79,7 +79,7 @@ void call(Map args = [:], Closure body) {
                                         }
                                     }
                                 echo "Downloading artifacts from $assetUrl"
-                                sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} | tar -xzv"
+                                sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} && tar -xzv *.tar.gz"
                             }
                         }
                     }


### PR DESCRIPTION
### Description
The piping of curl into tar was resulting in incomplete download error while unzipping the tarball for large files.
Hence, fixing it by first completely downloading the release asset and then attempting the unzipping. Also removes the `z` option from tar command which checks if it's an actual gzip. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
