### PR TITLE
Limit max workers for windows gradle check.

### DIFF
--- a/tests/jenkins/jobs/RunGradleCheck_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunGradleCheck_Jenkinsfile.txt
@@ -57,7 +57,13 @@
 
                 echo "Start gradlecheck"
                 GRADLE_CHECK_STATUS=0
-                ./gradlew clean && ./gradlew check -Dtests.coverage=true --no-daemon --no-scan || GRADLE_CHECK_STATUS=1
+                
+                if (uname -s | grep -i NT); then
+                   echo "Start gradlecheck on windows"
+                   ./gradlew clean && ./gradlew check --max-workers 8 -Dtests.coverage=true --no-daemon --no-scan || GRADLE_CHECK_STATUS=1
+                else
+                   ./gradlew clean && ./gradlew check -Dtests.coverage=true --no-daemon --no-scan || GRADLE_CHECK_STATUS=1
+                fi
 
                 if [ "$GRADLE_CHECK_STATUS" != 0 ]; then
                     echo Gradle Check Failed!

--- a/vars/runGradleCheck.groovy
+++ b/vars/runGradleCheck.groovy
@@ -71,7 +71,13 @@ void call(Map args = [:]) {
 
                 echo "Start gradlecheck"
                 GRADLE_CHECK_STATUS=0
-                ./gradlew clean && ./gradlew check -Dtests.coverage=true --no-daemon --no-scan || GRADLE_CHECK_STATUS=1
+                
+                if (uname -s | grep -i NT); then
+                   echo "Start gradlecheck on windows"
+                   ./gradlew clean && ./gradlew check --max-workers 8 -Dtests.coverage=true --no-daemon --no-scan || GRADLE_CHECK_STATUS=1
+                else
+                   ./gradlew clean && ./gradlew check -Dtests.coverage=true --no-daemon --no-scan || GRADLE_CHECK_STATUS=1
+                fi
 
                 if [ "\$GRADLE_CHECK_STATUS" != 0 ]; then
                     echo Gradle Check Failed!


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Windows gradle checks are running into oom issues - see https://build.ci.opensearch.org/job/gradle-check/9515/consoleFull.
I believe this is because the hosts used are limited to 32GB of RAM while spawning threads up to the amount of available cores.  Each worker is allowed max 3GB of ram, so we can easily run oom if too many threads with over 10 workers spawned running expensive tests. This PR limits the max to 8 workers to avoid this scenario.

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build-libraries/issues/113

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
