### PR TITLE
block OSD issue creation when more than 1 component fail

### DIFF
--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -20,6 +20,13 @@ def call(Map args = [:]){
             println(matched.split(" ")[0].trim())
             failedComponents.add(matched.split(" ")[0].trim())
         }
+        /* Due to an existing issue with queryWorkbench plugin breaking OSD during bootstrapping, there are false positive
+           issues getting created against OSD repo. Adding a temp check to ignore issue creation against OSD repo in-case
+           there are more than 1 failures reported for OSD build.
+         */
+        if (failedComponents.contains("OpenSearch-Dashboards") && failedComponents.size() > 1) {
+            failedComponents.removeElement("OpenSearch-Dashboards")
+        }
 
         def yamlFile = readYaml(file: "manifests/${INPUT_MANIFEST}")
         def currentVersion = yamlFile.build.version


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
Block OSD issue creation when more than 1 component fail. This is to avoid false positive issues getting created when queryWorkbench build is failing while trying to bootstrap OSD. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
