### PR TITLE
Support switching ruby gems version and fix regex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '1.5.4'
+String version = '1.5.5'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishToRubyGems.groovy
+++ b/tests/jenkins/TestPublishToRubyGems.groovy
@@ -28,7 +28,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         assertThat(curlCommands, hasItem(
             "cd /tmp/workspace/dist && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()
         ))
-        assertThat(gemCommands, hasItem("\n        rvm install 2.6.0 && rvm use 2.6.0\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
+        assertThat(gemCommands, hasItem("#!/bin/bash\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 
     @Test
@@ -40,7 +40,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         def gemCommands = getCommands('sh', 'gem')
         assertThat(curlCommands, hasItem(
             "cd /tmp/workspace/test && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()))
-        assertThat(gemCommands, hasItem("\n        rvm install jruby-9.3.0.0 && rvm use jruby-9.3.0.0\n        gem cert --add /tmp/workspace/certificate/path\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
+        assertThat(gemCommands, hasItem("#!/bin/bash\n        gem cert --add /tmp/workspace/certificate/path\n        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use jruby-9.3.0.0 && ruby --version\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 
     def getCommands(method, text) {

--- a/tests/jenkins/TestPublishToRubyGems.groovy
+++ b/tests/jenkins/TestPublishToRubyGems.groovy
@@ -28,7 +28,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         assertThat(curlCommands, hasItem(
             "cd /tmp/workspace/dist && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()
         ))
-        assertThat(gemCommands, hasItem("\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
+        assertThat(gemCommands, hasItem("\n        rvm install 2.6.0 && rvm use 2.6.0\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 
     @Test
@@ -40,7 +40,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         def gemCommands = getCommands('sh', 'gem')
         assertThat(curlCommands, hasItem(
             "cd /tmp/workspace/test && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()))
-        assertThat(gemCommands, hasItem("\n        gem cert --add /tmp/workspace/certificate/path\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
+        assertThat(gemCommands, hasItem("\n        rvm install jruby-9.3.0.0 && rvm use jruby-9.3.0.0\n        gem cert --add /tmp/workspace/certificate/path\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 
     def getCommands(method, text) {

--- a/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('publishRubyGems'){
             steps {
                 script {
-                    publishToRubyGems(apiKeyCredentialId: 'ruby-api-key', gemsDir: 'test', publicCertPath: 'certificate/path')
+                    publishToRubyGems(apiKeyCredentialId: 'ruby-api-key', gemsDir: 'test', publicCertPath: 'certificate/path', rubyVersion: 'jruby-9.3.0.0')
                 }
             }
         }

--- a/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
@@ -4,9 +4,9 @@
          PublishToRubyGemWithArgs_Jenkinsfile.stage(publishRubyGems, groovy.lang.Closure)
             PublishToRubyGemWithArgs_Jenkinsfile.script(groovy.lang.Closure)
                PublishToRubyGemWithArgs_Jenkinsfile.publishToRubyGems({apiKeyCredentialId=ruby-api-key, gemsDir=test, publicCertPath=certificate/path, rubyVersion=jruby-9.3.0.0})
-                  publishToRubyGems.sh(
-        rvm install jruby-9.3.0.0 && rvm use jruby-9.3.0.0
+                  publishToRubyGems.sh(#!/bin/bash
         gem cert --add /tmp/workspace/certificate/path
+        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use jruby-9.3.0.0 && ruby --version
         cd /tmp/workspace/test && gemNameWithVersion=$(ls *.gem)
         gem install $gemNameWithVersion
         gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem$)//g')

--- a/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
@@ -3,12 +3,13 @@
          PublishToRubyGemWithArgs_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToRubyGemWithArgs_Jenkinsfile.stage(publishRubyGems, groovy.lang.Closure)
             PublishToRubyGemWithArgs_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToRubyGemWithArgs_Jenkinsfile.publishToRubyGems({apiKeyCredentialId=ruby-api-key, gemsDir=test, publicCertPath=certificate/path})
+               PublishToRubyGemWithArgs_Jenkinsfile.publishToRubyGems({apiKeyCredentialId=ruby-api-key, gemsDir=test, publicCertPath=certificate/path, rubyVersion=jruby-9.3.0.0})
                   publishToRubyGems.sh(
+        rvm install jruby-9.3.0.0 && rvm use jruby-9.3.0.0
         gem cert --add /tmp/workspace/certificate/path
         cd /tmp/workspace/test && gemNameWithVersion=$(ls *.gem)
         gem install $gemNameWithVersion
-        gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+.gem$)//g')
+        gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem$)//g')
         gem uninstall $gemName
         gem install $gemNameWithVersion -P HighSecurity
     )

--- a/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
@@ -4,9 +4,9 @@
          PublishToRubyGems_JenkinsFile.stage(publishRubyGems, groovy.lang.Closure)
             PublishToRubyGems_JenkinsFile.script(groovy.lang.Closure)
                PublishToRubyGems_JenkinsFile.publishToRubyGems({apiKeyCredentialId=ruby-api-key})
-                  publishToRubyGems.sh(
-        rvm install 2.6.0 && rvm use 2.6.0
+                  publishToRubyGems.sh(#!/bin/bash
         gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem
+        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version
         cd /tmp/workspace/dist && gemNameWithVersion=$(ls *.gem)
         gem install $gemNameWithVersion
         gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem$)//g')

--- a/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
@@ -5,10 +5,11 @@
             PublishToRubyGems_JenkinsFile.script(groovy.lang.Closure)
                PublishToRubyGems_JenkinsFile.publishToRubyGems({apiKeyCredentialId=ruby-api-key})
                   publishToRubyGems.sh(
+        rvm install 2.6.0 && rvm use 2.6.0
         gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem
         cd /tmp/workspace/dist && gemNameWithVersion=$(ls *.gem)
         gem install $gemNameWithVersion
-        gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+.gem$)//g')
+        gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem$)//g')
         gem uninstall $gemName
         gem install $gemNameWithVersion -P HighSecurity
     )

--- a/vars/publishToRubyGems.groovy
+++ b/vars/publishToRubyGems.groovy
@@ -13,18 +13,21 @@ Note: Please make sure the gem is already signed.
 @param args.apiKeyCredentialId <required> - Credential id consisting api key for publishing the gem to rubyGems.org
 @param args.gemsDir <optional> - The directory containing the gem to be published. Defaults to 'dist'
 @params args.publicCertPath <optional> - The relative path to public key. Defaults to 'certs/opensearch-rubygems.pem'
+@params args.rubyVersion <optional> - Ruby version to be used. Defaults to 2.6.0
 */
 
 
 void call(Map args = [:]) {
     String releaseArtifactsDir = args.gemsDir ? "${WORKSPACE}/${args.gemsDir}" : "${WORKSPACE}/dist"
     String certPath = args.publicCertPath ? "${WORKSPACE}/${args.publicCertPath}" : "${WORKSPACE}/certs/opensearch-rubygems.pem"
+    String rubyVersion = args.rubyVersion ?: '2.6.0'
 
     sh """
+        rvm install ${rubyVersion} && rvm use ${rubyVersion}
         gem cert --add ${certPath}
         cd ${releaseArtifactsDir} && gemNameWithVersion=\$(ls *.gem)
         gem install \$gemNameWithVersion
-        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+.gem\$)//g')
+        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')
         gem uninstall \$gemName
         gem install \$gemNameWithVersion -P HighSecurity
     """

--- a/vars/publishToRubyGems.groovy
+++ b/vars/publishToRubyGems.groovy
@@ -8,7 +8,7 @@
  */
 
 /** Library to publish ruby gems to rubygems.org registry with OpenSearch as the owner.
-Note: Please make sure the gem is already signed.
+Note: Please make sure the gem is already signed. For ruby versions, they to be preinstalled as a part of docker. See the default docker file: https://github.com/opensearch-project/opensearch-build/blob/main/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
 @param Map args = [:] args A map of the following parameters
 @param args.apiKeyCredentialId <required> - Credential id consisting api key for publishing the gem to rubyGems.org
 @param args.gemsDir <optional> - The directory containing the gem to be published. Defaults to 'dist'
@@ -22,9 +22,9 @@ void call(Map args = [:]) {
     String certPath = args.publicCertPath ? "${WORKSPACE}/${args.publicCertPath}" : "${WORKSPACE}/certs/opensearch-rubygems.pem"
     String rubyVersion = args.rubyVersion ?: '2.6.0'
 
-    sh """
-        rvm install ${rubyVersion} && rvm use ${rubyVersion}
+    sh """#!/bin/bash
         gem cert --add ${certPath}
+        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use ${rubyVersion} && ruby --version
         cd ${releaseArtifactsDir} && gemNameWithVersion=\$(ls *.gem)
         gem install \$gemNameWithVersion
         gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The recent run for rubyGems failed for logstash-output-opensearch because instead of ruby it is build on jruby. https://build.ci.opensearch.org/job/logstash-output-opensearch-release/3/console
In order to fix that, this change adds the enhancement to install any ruby or jruby version as a parameter and installs it on the go.
It is required only for gem signature validation and not for building. 
This change also fixes the regex which is used to retrieve the gem name. 

### Issues Resolved
related: https://github.com/opensearch-project/opensearch-build/issues/3139

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
