### PR TITLE
Fix publishing to Nuget syntax and refactor find

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '2.1.1'
+String version = '2.1.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishToNuget.groovy
+++ b/tests/jenkins/TestPublishToNuget.groovy
@@ -36,22 +36,22 @@ class TestPublishToNuget extends BuildPipelineTest {
     }
 
     @Test
-    void 'verify build command'(){
+    void verify_build_command(){
         runScript('tests/jenkins/jobs/PublishToNuget_Jenkinsfile')
 
-        def buildCommands = getShellCommands('build')
-        assertThat(buildCommands, hasItem('\n    dotnet build /tmp/workspace/test-solution-file.sln --configuration Release\n    find src -name OpenSearch*.dll>/tmp/workspace/dlls.txt\n    '))
+        def buildCommand = getShellCommands('dotnet build')
+        assertThat(buildCommand, hasItem('\n    dotnet build /tmp/workspace/test-solution-file.sln --configuration Release\n    find src/OpenSearch.*/bin/Release/*/*.dll -type f -regextype posix-extended -regex \"src/([^/]+)/bin/Release/[^/]+/\\1\\.dll\">/tmp/workspace/dlls.txt\n    '))
     }
 
     @Test
-    void 'verify_pack_command'(){
+    void verify_pack_command(){
         runScript('tests/jenkins/jobs/PublishToNuget_Jenkinsfile')
         def packCommand = getShellCommands('pack')
-        assertThat(packCommand, hasItem('\n            dotnet pack /tmp/workspace/test-solution-file.sln --configuration Release --no-build\n            for package in `find src -name OpenSearch*.nupkg`\n                do\n                    dotnet nuget push $package --api-key API_KEY --source https://api.nuget.org/v3/index.json\n                done\n        '))
+        assertThat(packCommand, hasItem('\n        dotnet pack /tmp/workspace/test-solution-file.sln --configuration Release --no-build\n        find src -name OpenSearch*.nupkg > /tmp/workspace/nupkg.txt\n    '))
     }
 
     @Test
-    void 'verify_signer_call'(){
+    void verify_signer_call(){
         runScript('tests/jenkins/jobs/PublishToNuget_Jenkinsfile')
         def signcommand = getShellCommands('sign.sh')
         assertThat(signcommand, hasItems('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_WINDOWS_ROLE\n                   export EXTERNAL_ID=SIGNER_WINDOWS_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_WINDOWS_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_WINDOWS_SIGNED_BUCKET\n                   export PROFILE_IDENTIFIER=SIGNER_WINDOWS_PROFILE_IDENTIFIER\n                   export PLATFORM_IDENTIFIER=SIGNER_WINDOWS_PLATFORM_IDENTIFIER\n\n                   /tmp/workspace/opensearch-build/sign.sh /tmp/workspace/one.dll --platform windows --overwrite \n               ',
@@ -59,6 +59,15 @@ class TestPublishToNuget extends BuildPipelineTest {
         '\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_WINDOWS_ROLE\n                   export EXTERNAL_ID=SIGNER_WINDOWS_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_WINDOWS_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_WINDOWS_SIGNED_BUCKET\n                   export PROFILE_IDENTIFIER=SIGNER_WINDOWS_PROFILE_IDENTIFIER\n                   export PLATFORM_IDENTIFIER=SIGNER_WINDOWS_PLATFORM_IDENTIFIER\n\n                   /tmp/workspace/opensearch-build/sign.sh /tmp/workspace/three.dll --platform windows --overwrite \n               '))
     }
 
+    @Test
+    void verify_push_command(){
+        runScript('tests/jenkins/jobs/PublishToNuget_Jenkinsfile')
+        def pushCommand = getShellCommands('push')
+        assertThat(pushCommand, hasItems(
+            'dotnet nuget push /tmp/workspace/src/net/one.nupkg --api-key API_KEY --source https://api.nuget.org/v3/index.json',
+            'dotnet nuget push /tmp/workspace/src/net/two.nupkg --api-key API_KEY --source https://api.nuget.org/v3/index.json',
+            'dotnet nuget push /tmp/workspace/src/net/three.nupkg --api-key API_KEY --source https://api.nuget.org/v3/index.json'))
+    }
     def getShellCommands(searchString) {
         def shCommands = helper.callStack.findAll { call ->
             call.methodName == 'sh'

--- a/tests/jenkins/jobs/PublishToNuget_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToNuget_Jenkinsfile.txt
@@ -9,7 +9,7 @@
                   publishToNuget.checkout({$class=GitSCM, branches=[{name=1.2.0}], userRemoteConfigs=[{url=https://github.com/opensearch-project/opensearch-net}]})
                   publishToNuget.sh(
     dotnet build /tmp/workspace/test-solution-file.sln --configuration Release
-    find src -name OpenSearch*.dll>/tmp/workspace/dlls.txt
+    find src/OpenSearch.*/bin/Release/*/*.dll -type f -regextype posix-extended -regex "src/([^/]+)/bin/Release/[^/]+/\1\.dll">/tmp/workspace/dlls.txt
     )
                   publishToNuget.readFile({file=/tmp/workspace/dlls.txt})
                   publishToNuget.signArtifacts({artifactPath=/tmp/workspace/one.dll, platform=windows, overwrite=true})
@@ -90,12 +90,13 @@
 
                    /tmp/workspace/opensearch-build/sign.sh /tmp/workspace/three.dll --platform windows --overwrite 
                )
+                  publishToNuget.sh(
+        dotnet pack /tmp/workspace/test-solution-file.sln --configuration Release --no-build
+        find src -name OpenSearch*.nupkg > /tmp/workspace/nupkg.txt
+    )
                   publishToNuget.string({credentialsId=net-api-key, variable=API_KEY})
                   publishToNuget.withCredentials([API_KEY], groovy.lang.Closure)
-                     publishToNuget.sh(
-            dotnet pack /tmp/workspace/test-solution-file.sln --configuration Release --no-build
-            for package in `find src -name OpenSearch*.nupkg`
-                do
-                    dotnet nuget push $package --api-key API_KEY --source https://api.nuget.org/v3/index.json
-                done
-        )
+                     publishToNuget.readFile({file=/tmp/workspace/nupkg.txt})
+                     publishToNuget.sh(dotnet nuget push /tmp/workspace/src/net/one.nupkg --api-key API_KEY --source https://api.nuget.org/v3/index.json)
+                     publishToNuget.sh(dotnet nuget push /tmp/workspace/src/net/two.nupkg --api-key API_KEY --source https://api.nuget.org/v3/index.json)
+                     publishToNuget.sh(dotnet nuget push /tmp/workspace/src/net/three.nupkg --api-key API_KEY --source https://api.nuget.org/v3/index.json)

--- a/tests/jenkins/lib-testers/PublishToNugetLibTester.groovy
+++ b/tests/jenkins/lib-testers/PublishToNugetLibTester.groovy
@@ -29,6 +29,7 @@ class PublishToNugetLibTester extends LibFunctionTester {
         helper.registerAllowedMethod('git', [Map])
         helper.addFileExistsMock('/tmp/workspace/sign.sh', false)
         helper.addReadFileMock('/tmp/workspace/dlls.txt', 'one.dll \n two.dll \n three.dll')
+        helper.addReadFileMock('/tmp/workspace/nupkg.txt', 'src/net/one.nupkg \n src/net/two.nupkg \n src/net/three.nupkg')
         helper.registerAllowedMethod("withCredentials", [Map, Closure], { args, closure ->
             closure.delegate = delegate
             return helper.callClosure(closure)


### PR DESCRIPTION
### Description
The recent release for dot net client failed because of bash syntax issue. This change is trying to use bash as much less as possible. Also refactored the code a bit as suggested by dotnet team so that only the necessary DLLs are signed, as the DLLs get duped between bin & obj folders (and between projects) during build we only want to sign the one from bin/Release folder. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
