### PR TITLE
Add a wrapper library to validate artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '2.1.2'
+String version = '2.2.0'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestValidateArtifacts.groovy
+++ b/tests/jenkins/TestValidateArtifacts.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.equalTo
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.hasItem
+
+class TestValidateArtifacts extends BuildPipelineTest {
+
+    @Before
+    void setUp() {
+
+        this.registerLibTester(new ValidateArtifactsLibTester('1.0.0', 'foo'))
+
+        super.setUp()
+    }
+
+    @Test
+    void validateArtifacts() {
+        super.testPipeline('tests/jenkins/jobs/ValidateArtifacts_Jenkinsfile')
+    }
+
+    @Test
+    void checkScriptcall(){
+        runScript('tests/jenkins/jobs/ValidateArtifacts_Jenkinsfile')
+        def shcommand =  helper.callStack.findAll { call ->
+            call.methodName == 'sh'
+        }.collect { call ->
+            callArgsToString(call)
+        }
+        assertThat(shcommand.size(), equalTo(1))
+        assertThat(shcommand, hasItem('/tmp/workspace/validation.sh  --version 1.0.0 --project foo'))
+    }
+}

--- a/tests/jenkins/jobs/ValidateArtifacts_Jenkinsfile
+++ b/tests/jenkins/jobs/ValidateArtifacts_Jenkinsfile
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('validate') {
+            steps {
+                script {
+                    validateArtifacts(
+                            version: '1.0.0',
+                            project: 'foo'
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/ValidateArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/ValidateArtifacts_Jenkinsfile.txt
@@ -1,0 +1,8 @@
+   ValidateArtifacts_Jenkinsfile.run()
+      ValidateArtifacts_Jenkinsfile.pipeline(groovy.lang.Closure)
+         ValidateArtifacts_Jenkinsfile.echo(Executing on agent [label:none])
+         ValidateArtifacts_Jenkinsfile.stage(validate, groovy.lang.Closure)
+            ValidateArtifacts_Jenkinsfile.script(groovy.lang.Closure)
+               ValidateArtifacts_Jenkinsfile.validateArtifacts({version=1.0.0, project=foo})
+                  validateArtifacts.fileExists(/tmp/workspace/validation.sh)
+                  validateArtifacts.sh(/tmp/workspace/validation.sh  --version 1.0.0 --project foo)

--- a/tests/jenkins/lib-testers/ValidateArtifactsLibTester.groovy
+++ b/tests/jenkins/lib-testers/ValidateArtifactsLibTester.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class ValidateArtifactsLibTester extends LibFunctionTester {
+
+    private String version
+    private String project
+
+    public ValidateArtifactsLibTester(version, project) {
+        this.version = version
+        this.project = project
+    }
+
+    void configure(helper, binding) {
+        helper.addFileExistsMock('/tmp/workspace/validation.sh', true)
+    }
+
+    void parameterInvariantsAssertions(call) {
+        assertThat(call.args.version.first(), notNullValue())
+        assertThat(call.args.project.first(), notNullValue())
+    }
+
+    boolean expectedParametersMatcher(call) {
+        return call.args.version.first().toString().equals(this.version)
+            && call.args.project.first().toString().equals(this.project)
+    }
+
+    String libFunctionName() {
+        return 'validateArtifacts'
+    }
+
+}

--- a/vars/validateArtifacts.groovy
+++ b/vars/validateArtifacts.groovy
@@ -13,7 +13,7 @@ Wrapper that runs validation.sh script with provided args.
 */
 void call(Map args = [:]) {
     if (!fileExists("$WORKSPACE/validation.sh")) {
-        println("Validation.sh script not found, exit 1")
+        println("Validation.sh script not found in the workspace: ${WORKSPACE}, exit 1")
         System.exit(1)
     }
     String arguments = generateArguments(args)

--- a/vars/validateArtifacts.groovy
+++ b/vars/validateArtifacts.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+SignArtifacts signs the given artifacts and saves the signature in the same directory.
+@param Map[version] <Required> - Version of the opensearch artifact that needs to be validated.
+@param Map[distribution] <Optional> - Choose distribution type among [tar(default),rpm,yum,docker].
+@param Map[architecture] <Optional> - Select the architecture type among [x64(default) and arm64].
+@param Map[platform] <Optional> - The distribution platform.
+@param Map[docker_source] <Optional> - Specify the docker source from [DockerHub(default), ECR] to pull the docker image.
+@param Map[os_build_number]<Optional> - Specify Opensearch build number from opensearchstaging if required.
+@param Map[osd_build_number]<Optional> - Specify Opensearch-Dashboard build number from opensearchstaging if required.
+*/
+void call(Map args = [:]) {
+        String workdir = "${WORKSPACE}"
+        echo 'Validating artifacts'
+
+        if (!fileExists("$WORKSPACE/validation.sh")) {
+            dir('opensearch-build') {
+                git url: 'https://github.com/opensearch-build.git', branch: 'main'
+                workdir = "${WORKSPACE}/opensearch-build"
+            }
+        }
+
+        String arguments = generateArguments(args)
+
+        sh """
+                   ${workdir}/validation.sh ${arguments}
+               """
+}
+
+String generateArguments(args) {
+    String arguments = ""
+
+    // generation of command line arguments
+    args.each { key, value -> arguments += " --${key } ${value }" }
+    return arguments
+}

--- a/vars/validateArtifacts.groovy
+++ b/vars/validateArtifacts.groovy
@@ -8,37 +8,21 @@
  */
 
 /**
-SignArtifacts signs the given artifacts and saves the signature in the same directory.
-@param Map[version] <Required> - Version of the opensearch artifact that needs to be validated.
-@param Map[distribution] <Optional> - Choose distribution type among [tar(default),rpm,yum,docker].
-@param Map[architecture] <Optional> - Select the architecture type among [x64(default) and arm64].
-@param Map[platform] <Optional> - The distribution platform.
-@param Map[docker_source] <Optional> - Specify the docker source from [DockerHub(default), ECR] to pull the docker image.
-@param Map[os_build_number]<Optional> - Specify Opensearch build number from opensearchstaging if required.
-@param Map[osd_build_number]<Optional> - Specify Opensearch-Dashboard build number from opensearchstaging if required.
+Wrapper that runs validation.sh script with provided args.
+@param Map[<any>] <Required> - Any arguments that you want to be passed to validation.sh script. eg: version: 1.0.0 will be passed as --version 1.0.0
 */
 void call(Map args = [:]) {
-        String workdir = "${WORKSPACE}"
-        echo 'Validating artifacts'
-
-        if (!fileExists("$WORKSPACE/validation.sh")) {
-            dir('opensearch-build') {
-                git url: 'https://github.com/opensearch-build.git', branch: 'main'
-                workdir = "${WORKSPACE}/opensearch-build"
-            }
-        }
-
-        String arguments = generateArguments(args)
-
-        sh """
-                   ${workdir}/validation.sh ${arguments}
-               """
+    if (!fileExists("$WORKSPACE/validation.sh")) {
+        println("Validation.sh script not found, exit 1")
+        System.exit(1)
+    }
+    String arguments = generateArguments(args)
+    sh "${WORKSPACE}/validation.sh ${arguments}"
 }
 
 String generateArguments(args) {
-    String arguments = ""
-
-    // generation of command line arguments
+    String arguments = ''
+    // generate of command line arguments
     args.each { key, value -> arguments += " --${key } ${value }" }
     return arguments
 }


### PR DESCRIPTION
### Description
This library will be responsible for running validation.sh script from the workspace. It will hard exit if validation.sh is not found. The args are variable so its generic enough to be used by project

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
