### PR TITLE
Fix return for build Failure messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '5.4.1'
+String version = '5.5.0'
 
 task updateVersion {
     doLast {

--- a/vars/buildMessage.groovy
+++ b/vars/buildMessage.groovy
@@ -6,9 +6,9 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
- /** Library to find a pattern in jenkins build log.
+ /** Library to search string in jenkins build log.
  @param Map args = [:] args A map of the following parameters
- @param args.search <required> - Use 'pass' to get the components passed and 'fail' for components failed.
+ @param args.search <required> - String to be searched in build logs.
  */
 import com.cloudbees.groovy.cps.NonCPS
 import org.apache.commons.io.IOUtils
@@ -29,9 +29,8 @@ def call(Map args = [:]){
             message.add(line)
         }
     }
-    //if no match returns as Build failed
-    if(message.isEmpty()){
-        message=["The search QUERY_STRING not identified in build log"]
+    if (message.isEmpty()) {
+        message = null
     }
     return message
 }

--- a/vars/createBuildFailureGithubIssue.groovy
+++ b/vars/createBuildFailureGithubIssue.groovy
@@ -16,7 +16,7 @@ void call(Map args = [:]) {
     def failureMessages = args.message
     List<String> failedComponents = []
 
-    if (failureMessages.size() == 1 && failureMessages[0] == 'Build failed') {
+    if (failureMessages == null) {
         println('No component failed, skip creating github issue.')
     }
     else {


### PR DESCRIPTION
### Description
In case of no string found the message should return null. This PR fixes the same. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
