### PR TITLE
Fix build log parsing for GH issue creation

### DIFF
--- a/tests/data/opensearch-2.0.0.yml
+++ b/tests/data/opensearch-2.0.0.yml
@@ -27,3 +27,15 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: geospatial
+    repository: https://github.com/opensearch-project/geospatial.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/tests/jenkins/TestCreateBuildFailureGithubIssue.groovy
+++ b/tests/jenkins/TestCreateBuildFailureGithubIssue.groovy
@@ -20,15 +20,16 @@ class TestCreateBuildFailureGithubIssue extends BuildPipelineTest {
     @Override
     @Before
     void setUp() {
-        this.registerLibTester(new CreateBuildFailureGithubIssueLibTester(['Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot']))
+        this.registerLibTester(new CreateBuildFailureGithubIssueLibTester(["Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot", "Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer", "Error building asynchronous-search, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component asynchronous-search", "Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial", "Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component performance-analyzer"]))
         super.setUp()
     }
 
     @Test
     public void testCreateGithubIssue() {
         helper.addShMock('gh issue list --repo https://github.com/opensearch-project/OpenSearch.git -S "[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0 in:title" --label autocut,v2.0.0', '', 0)
+        helper.addShMock('gh issue list --repo https://github.com/opensearch-project/performance-analyzer.git -S "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0 in:title" --label autocut,v2.0.0', '', 0)
         super.testPipeline('tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile')
-        assertThat(getCommands('sh', 'create'), hasItem('{script=gh issue create --title \"[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0\" --body \"***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.\n                      The distribution build for OpenSearch has failed for version: 2.0.0.\n                      Please see build log at www.example.com/jobs/test/123/consoleFull\" --label autocut,v2.0.0 --label \"untriaged\" --repo https://github.com/opensearch-project/OpenSearch.git, returnStdout=true}'))
+        assertThat(getCommands('sh', 'create'), hasItem('{script=gh issue create --title \"[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0\" --body \"***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.\n                      The distribution build for performance-analyzer has failed for version: 2.0.0.\n                      Please see build log at www.example.com/jobs/test/123/consoleFull\" --label autocut,v2.0.0 --label \"untriaged\" --repo https://github.com/opensearch-project/performance-analyzer.git, returnStdout=true}'))
     }
 
     @Test

--- a/tests/jenkins/jobs/CreateBuildFailureGithubExistingIssueCheck_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CreateBuildFailureGithubExistingIssueCheck_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          CreateBuildFailureGithubIssue_Jenkinsfile.echo(Executing on agent [label:none])
          CreateBuildFailureGithubIssue_Jenkinsfile.stage(notify, groovy.lang.Closure)
             CreateBuildFailureGithubIssue_Jenkinsfile.script(groovy.lang.Closure)
-               CreateBuildFailureGithubIssue_Jenkinsfile.createBuildFailureGithubIssue({message=[Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot], inputManifestPath=tests/data/opensearch-2.0.0.yml})
+               CreateBuildFailureGithubIssue_Jenkinsfile.createBuildFailureGithubIssue({message=[Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot, Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer, Error building asynchronous-search, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component asynchronous-search, Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial, Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component performance-analyzer], inputManifestPath=tests/data/opensearch-2.0.0.yml})
                   createBuildFailureGithubIssue.legacySCM(groovy.lang.Closure)
                   createBuildFailureGithubIssue.library({identifier=jenkins@main, retriever=null})
                   createBuildFailureGithubIssue.readYaml({file=tests/data/opensearch-2.0.0.yml})
@@ -18,5 +18,31 @@
                         createGithubIssue.sh({script=gh issue comment bbb
 ccc --repo https://github.com/opensearch-project/OpenSearch.git --body "***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.
                       The distribution build for OpenSearch has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                  createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
+                  createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/geospatial.git, issueTitle=[AUTOCUT] Distribution Build Failed for geospatial-2.0.0, issueBody=***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
+                      The distribution build for geospatial has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                     createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                     createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/geospatial.git -S "[AUTOCUT] Distribution Build Failed for geospatial-2.0.0 in:title" --label autocut,v2.0.0, returnStdout=true})
+                        createGithubIssue.println(Issue already exists, adding a comment.)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/geospatial.git -S "[AUTOCUT] Distribution Build Failed for geospatial-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
+                        createGithubIssue.sh({script=gh issue comment bbb
+ccc --repo https://github.com/opensearch-project/geospatial.git --body "***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
+                      The distribution build for geospatial has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                  createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
+                  createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/performance-analyzer.git, issueTitle=[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0, issueBody=***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
+                      The distribution build for performance-analyzer has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                     createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                     createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/performance-analyzer.git -S "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0 in:title" --label autocut,v2.0.0, returnStdout=true})
+                        createGithubIssue.println(Issue already exists, adding a comment.)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/performance-analyzer.git -S "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
+                        createGithubIssue.sh({script=gh issue comment bbb
+ccc --repo https://github.com/opensearch-project/performance-analyzer.git --body "***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
+                      The distribution build for performance-analyzer has failed for version: 2.0.0.
                       Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})

--- a/tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile
+++ b/tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             steps {
                 script {
                     createBuildFailureGithubIssue(
-                        message: ["Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot"],
+                        message: ["Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot", "Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer", "Error building asynchronous-search, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component asynchronous-search", "Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial", "Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component performance-analyzer"],
                         inputManifestPath: 'tests/data/opensearch-2.0.0.yml'
                     )
                 }

--- a/tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          CreateBuildFailureGithubIssue_Jenkinsfile.echo(Executing on agent [label:none])
          CreateBuildFailureGithubIssue_Jenkinsfile.stage(notify, groovy.lang.Closure)
             CreateBuildFailureGithubIssue_Jenkinsfile.script(groovy.lang.Closure)
-               CreateBuildFailureGithubIssue_Jenkinsfile.createBuildFailureGithubIssue({message=[Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot], inputManifestPath=tests/data/opensearch-2.0.0.yml})
+               CreateBuildFailureGithubIssue_Jenkinsfile.createBuildFailureGithubIssue({message=[Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot, Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer, Error building asynchronous-search, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component asynchronous-search, Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial, Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component performance-analyzer], inputManifestPath=tests/data/opensearch-2.0.0.yml})
                   createBuildFailureGithubIssue.legacySCM(groovy.lang.Closure)
                   createBuildFailureGithubIssue.library({identifier=jenkins@main, retriever=null})
                   createBuildFailureGithubIssue.readYaml({file=tests/data/opensearch-2.0.0.yml})
@@ -16,4 +16,27 @@
                         createGithubIssue.sh({script=gh issue create --title "[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0" --body "***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.
                       The distribution build for OpenSearch has failed for version: 2.0.0.
                       Please see build log at www.example.com/jobs/test/123/consoleFull" --label autocut,v2.0.0 --label "untriaged" --repo https://github.com/opensearch-project/OpenSearch.git, returnStdout=true})
+                  createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
+                  createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/geospatial.git, issueTitle=[AUTOCUT] Distribution Build Failed for geospatial-2.0.0, issueBody=***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
+                      The distribution build for geospatial has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                     createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                     createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/geospatial.git -S "[AUTOCUT] Distribution Build Failed for geospatial-2.0.0 in:title" --label autocut,v2.0.0, returnStdout=true})
+                        createGithubIssue.println(Issue already exists, adding a comment.)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/geospatial.git -S "[AUTOCUT] Distribution Build Failed for geospatial-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
+                        createGithubIssue.sh({script=gh issue comment bbb
+ccc --repo https://github.com/opensearch-project/geospatial.git --body "***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
+                      The distribution build for geospatial has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                  createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
+                  createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/performance-analyzer.git, issueTitle=[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0, issueBody=***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
+                      The distribution build for performance-analyzer has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                     createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                     createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                        createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/performance-analyzer.git -S "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0 in:title" --label autocut,v2.0.0, returnStdout=true})
+                        createGithubIssue.sh({script=gh issue create --title "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0" --body "***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
+                      The distribution build for performance-analyzer has failed for version: 2.0.0.
+                      Please see build log at www.example.com/jobs/test/123/consoleFull" --label autocut,v2.0.0 --label "untriaged" --repo https://github.com/opensearch-project/performance-analyzer.git, returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})

--- a/vars/createBuildFailureGithubIssue.groovy
+++ b/vars/createBuildFailureGithubIssue.groovy
@@ -21,11 +21,11 @@ void call(Map args = [:]) {
     }
     else {
         for (message in failureMessages.unique()) {
-            java.util.regex.Matcher match = (message =~ /(?<=\bcomponent\s).*/)
+            java.util.regex.Matcher match = (message =~ /(?<=\bError building\s).*/)
             String matched = match[0]
-            println(matched.split(" ")[0].trim())
-            failedComponents.add(matched.split(" ")[0].trim())
-        }
+            failedComponents.add(matched.split(" ")[0].split(",")[0].trim())
+            }
+            failedComponents = failedComponents.unique()
         /* Due to an existing issue with queryWorkbench plugin breaking OSD during bootstrapping, there are false positive
            issues getting created against OSD repo. Adding a temp check to ignore issue creation against OSD repo in-case
            there are more than 1 failures reported for OSD build.


### PR DESCRIPTION
### Description
See the log failure https://build.ci.opensearch.org/view/Build/job/distribution-build-opensearch/8265/console
Due to continue-on-error the logs are getting overridden between gradle and python logs. 
This PR fixes the regex to parse the log based on Error building and not component. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
