### PR TITLE
Add jar signer specs to signArtifacts

### DIFF
--- a/tests/jenkins/TestSignArtifacts.groovy
+++ b/tests/jenkins/TestSignArtifacts.groovy
@@ -26,6 +26,7 @@ class TestSignArtifacts extends BuildPipelineTest {
         this.registerLibTester(new SignArtifactsLibTester(null, 'linux', "${this.workspace}/file.yml", 'maven', null))
         this.registerLibTester(new SignArtifactsLibTester(null, 'windows', "${this.workspace}/the_msi.msi", null, null, true))
         this.registerLibTester(new SignArtifactsLibTester(null, 'mac', "${this.workspace}/the_pkg.pkg", null, null, true))
+        this.registerLibTester(new SignArtifactsLibTester(null, 'jar_signer', "${this.workspace}/the_jar.jar", null, null, true))
         super.setUp()
     }
 
@@ -40,6 +41,7 @@ class TestSignArtifacts extends BuildPipelineTest {
 
         def signCommands = getShellCommands('sign.sh')
         assertThat(signCommands, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=SIGNER_CLIENT_ROLE\n                   export EXTERNAL_ID=SIGNER_CLIENT_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=SIGNER_CLIENT_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=SIGNER_CLIENT_SIGNED_BUCKET\n\n                   /tmp/workspace/sign.sh /tmp/workspace/artifacts --sigtype .sig --platform linux\n               '))
+        assertThat(signCommands, hasItem('\n                   #!/bin/bash\n                   set +x\n                   export ROLE=JAR_SIGNER_ROLE\n                   export EXTERNAL_ID=JAR_SIGNER_EXTERNAL_ID\n                   export UNSIGNED_BUCKET=JAR_SIGNER_UNSIGNED_BUCKET\n                   export SIGNED_BUCKET=JAR_SIGNER_SIGNED_BUCKET\n                   /tmp/workspace/sign.sh /tmp/workspace/the_jar.jar --platform jar_signer --overwrite \n               '))
     }
 
     @Test

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile
@@ -42,7 +42,13 @@ pipeline {
                         artifactPath: "${WORKSPACE}/the_pkg.pkg",
                         platform: 'mac',
                         overwrite: true
-                        )   
+                        )
+
+                    signArtifacts(
+                        artifactPath: "${WORKSPACE}/the_jar.jar",
+                        platform: 'jar_signer',
+                        overwrite: true
+                        ) 
                 }
             }
         }

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
@@ -160,3 +160,20 @@
                    export SIGNED_BUCKET=SIGNER_MAC_SIGNED_BUCKET
                    /tmp/workspace/sign.sh /tmp/workspace/the_pkg.pkg --platform mac --overwrite 
                )
+               SignArtifacts_Jenkinsfile.signArtifacts({artifactPath=/tmp/workspace/the_jar.jar, platform=jar_signer, overwrite=true})
+                  signArtifacts.fileExists(/tmp/workspace/sign.sh)
+                  signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
+                  signArtifacts.string({credentialsId=jenkins-jar-signer-role, variable=JAR_SIGNER_ROLE})
+                  signArtifacts.string({credentialsId=jenkins-jar-signer-external-id, variable=JAR_SIGNER_EXTERNAL_ID})
+                  signArtifacts.string({credentialsId=jenkins-jar-signer-unsigned-bucket, variable=JAR_SIGNER_UNSIGNED_BUCKET})
+                  signArtifacts.string({credentialsId=jenkins-jar-signer-signed-bucket, variable=JAR_SIGNER_SIGNED_BUCKET})
+                  signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], JAR_SIGNER_ROLE, JAR_SIGNER_EXTERNAL_ID, JAR_SIGNER_UNSIGNED_BUCKET, JAR_SIGNER_SIGNED_BUCKET], groovy.lang.Closure)
+                     signArtifacts.sh(
+                   #!/bin/bash
+                   set +x
+                   export ROLE=JAR_SIGNER_ROLE
+                   export EXTERNAL_ID=JAR_SIGNER_EXTERNAL_ID
+                   export UNSIGNED_BUCKET=JAR_SIGNER_UNSIGNED_BUCKET
+                   export SIGNED_BUCKET=JAR_SIGNER_SIGNED_BUCKET
+                   /tmp/workspace/sign.sh /tmp/workspace/the_jar.jar --platform jar_signer --overwrite 
+               )

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -154,6 +154,24 @@ void call(Map args = [:]) {
                """
                 }
         }
+        else if (args.platform == 'jar_signer') {
+            println('Using jar signing')
+            withCredentials([usernamePassword(credentialsId: "${GITHUB_BOT_TOKEN_NAME}", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN'),
+                string(credentialsId: 'jenkins-jar-signer-role', variable: 'JAR_SIGNER_ROLE'),
+                string(credentialsId: 'jenkins-jar-signer-external-id', variable: 'JAR_SIGNER_EXTERNAL_ID'),
+                string(credentialsId: 'jenkins-jar-signer-unsigned-bucket', variable: 'JAR_SIGNER_UNSIGNED_BUCKET'),
+                string(credentialsId: 'jenkins-jar-signer-signed-bucket', variable: 'JAR_SIGNER_SIGNED_BUCKET')]) {
+                sh """
+                   #!/bin/bash
+                   set +x
+                   export ROLE=$JAR_SIGNER_ROLE
+                   export EXTERNAL_ID=$JAR_SIGNER_EXTERNAL_ID
+                   export UNSIGNED_BUCKET=$JAR_SIGNER_UNSIGNED_BUCKET
+                   export SIGNED_BUCKET=$JAR_SIGNER_SIGNED_BUCKET
+                   ${workdir}/sign.sh ${arguments}
+               """
+                }
+        }
         else {
             println('Using PGP signing')
             importPGPKey()


### PR DESCRIPTION
### Description
Add jar signer specs to signArtifacts

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3895

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
