### PR TITLE
Added source code linting to Groovy code and Jenkinsfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+---
+default_stages: [commit]
+repos:
+  - repo: local
+    hooks:
+      - id: npm-groovy-lint
+        stages: [commit]
+        name: npm-groovy-lint
+        entry: bash -c 'npm-groovy-lint tests/jenkins'
+        language: system
+        types: [groovy]
+        description: Groovy & Jenkinsfile Linter
+  
+  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,5 +10,3 @@ repos:
         language: system
         types: [groovy]
         description: Groovy & Jenkinsfile Linter
-  
-  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: npm-groovy-lint
         stages: [commit]
         name: npm-groovy-lint
-        entry: bash -c 'npm-groovy-lint tests/jenkins'
+        entry: bash -c 'npm-groovy-lint tests/jenkins src/jenkins'
         language: system
         types: [groovy]
         description: Groovy & Jenkinsfile Linter


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Created a pre-commit hook to run a linter for groovy and jenkinsfiles.

### Issues Resolved
[#320](https://github.com/opensearch-project/opensearch-build-libraries/issues/320)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
