### PR TITLE
Make sure windows correctly switch java versions in integTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '5.10.0'
+String version = '5.10.1'
 
 task updateVersion {
     doLast {

--- a/vars/runIntegTestScript.groovy
+++ b/vars/runIntegTestScript.groovy
@@ -23,7 +23,7 @@ void call(Map args = [:]) {
     if (filename == 'opensearch' && platform == 'windows') { // Windows use scoop to switch the Java Version
         String javaVersionNumber = javaVersion.replaceAll("[^0-9]", "") // Only get number
         echo("Switching to Java ${javaVersionNumber} on Windows Docker Container")
-        sh("scoop reset `scoop list jdk | grep ${javaVersionNumber} | head -1 | cut -d ' ' -f1`")
+        sh("scoop reset `scoop list jdk | cut -d ' ' -f1 | grep ${javaVersionNumber} | head -1`")
     }
     echo "Possible Java Home: ${javaHomeCommand}"
 


### PR DESCRIPTION
### Description
Make sure windows correctly switch java versions in integTest

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4142

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
