### PR TITLE
Increase sleep time to 120 between parallel runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
     }
 }
 
-String version = '5.10.1'
+String version = '5.10.2'
 
 task updateVersion {
     doLast {

--- a/vars/runBenchmarkTestScript.groovy
+++ b/vars/runBenchmarkTestScript.groovy
@@ -58,7 +58,7 @@ void call(Map args = [:]) {
             if (args.insecure.toBoolean()) {
                 sleep(5)
             } else {
-                sleep(15)
+                sleep(120)
             }
         }
     }


### PR DESCRIPTION
### Description
Increase sleep time to 120 between parallel runs for benchmark test. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
