### PR TITLE
bump testHarnessVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ sourceSets {
 
 sharedLibrary {
     coreVersion = '2.387.1' // https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-core/
-    testHarnessVersion = '2002.v0b_78b_a_d69e5d' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
+    testHarnessVersion = '2085.va_c531db_287b_d' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
     pluginDependencies {
         workflowCpsGlobalLibraryPluginVersion = '570.v21311f4951f8' // https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/workflow/workflow-cps-global-lib/
         // see https://mvnrepository.com/artifact/org.jenkins-ci.plugins/<name>?repo=jenkins-releases for latest


### PR DESCRIPTION
### Description
Bump testHarnessVersion to [2085.va_c531db_287b_d](https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness/2085.va_c531db_287b_d) for addressing a few CVEs as following 

### Issues Resolved


CVE | Vulnerable Library
-- | --
CVE-2023-36478 | jetty-http-10.0.15.jar
CVE-2023-40167 | jetty-http-10.0.15.jar
WS-2023-0236 | jetty-xml-10.0.15.jar



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
