### PR TITLE
Change the name of the newly built docker image in dockerPatch library

### DIFF
--- a/tests/jenkins/TestPatchDockerImage.groovy
+++ b/tests/jenkins/TestPatchDockerImage.groovy
@@ -18,9 +18,7 @@ class TestPatchDockerImage extends BuildPipelineTest {
     void setUp() {
         this.registerLibTester(new PatchDockerImageLibTester(
             'opensearch',
-            '1',
-            'true'
-            )
+            '1'            )
         )
         super.setUp()
     }

--- a/tests/jenkins/jobs/PatchDockerImage_Jenkinsfile
+++ b/tests/jenkins/jobs/PatchDockerImage_Jenkinsfile
@@ -15,8 +15,7 @@ pipeline {
                 script {
                     patchDockerImage(
                         product: "opensearch",
-                        tag: "1",
-                        re_release: "true"
+                        tag: "1"
                     )
                 }
             }

--- a/tests/jenkins/jobs/PatchDockerImage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PatchDockerImage_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          PatchDockerImage_Jenkinsfile.echo(Executing on agent [label:none])
          PatchDockerImage_Jenkinsfile.stage(Patch docker image, groovy.lang.Closure)
             PatchDockerImage_Jenkinsfile.script(groovy.lang.Closure)
-               PatchDockerImage_Jenkinsfile.patchDockerImage({product=opensearch, tag=1, re_release=true})
+               PatchDockerImage_Jenkinsfile.patchDockerImage({product=opensearch, tag=1})
                   patchDockerImage.legacySCM(groovy.lang.Closure)
                   patchDockerImage.library({identifier=jenkins@main, retriever=null})
                   patchDockerImage.sh(#!/bin/bash
@@ -13,7 +13,7 @@
     docker pull opensearchproject/opensearch:latest
     )
                   patchDockerImage.sh({script=docker inspect --format '{{ index .Config.Labels "org.label-schema.version"}}' opensearchproject/opensearch:1, returnStdout=true})
-                  patchDockerImage.sh({script=docker inspect --format '{{ index .Config.Labels "org.label-schema.build-date"}}' opensearchproject/opensearch:1, returnStdout=true})
+                  patchDockerImage.sh({script=date +%Y%m%d, returnStdout=true})
                   patchDockerImage.sh({script=docker inspect --format '{{ index .Config.Labels "org.label-schema.description"}}' opensearchproject/opensearch:1, returnStdout=true})
                   patchDockerImage.sh({script=docker inspect --format '{{ index .Config.Labels "org.label-schema.version"}}' opensearchproject/opensearch:latest, returnStdout=true})
                   patchDockerImage.readYaml({file=manifests/1.3.0/opensearch-1.3.0.yml})

--- a/tests/jenkins/lib-testers/PatchDockerImageLibtester.groovy
+++ b/tests/jenkins/lib-testers/PatchDockerImageLibtester.groovy
@@ -16,12 +16,10 @@ class PatchDockerImageLibTester extends LibFunctionTester {
 
     private String product
     private String tag
-    private String re_release
 
-    public PatchDockerImageLibTester(product, tag, re_release){
+    public PatchDockerImageLibTester(product, tag){
         this.product = product
         this.tag = tag
-        this.re_release = re_release
     }
 
     void configure(helper, binding) {
@@ -34,8 +32,8 @@ class PatchDockerImageLibTester extends LibFunctionTester {
         helper.addShMock("""docker inspect --format '{{ index .Config.Labels "org.label-schema.description"}}' opensearchproject/opensearch:1""") { script ->
             return [stdout: "7756", exitValue: 0]
         }
-        helper.addShMock("""docker inspect --format '{{ index .Config.Labels "org.label-schema.build-date"}}' opensearchproject/opensearch:1""") { script ->
-            return [stdout: "2023-06-19T19:12:59Z", exitValue: 0]
+        helper.addShMock("""date +%Y%m%d""") { script ->
+            return [stdout: "20230619", exitValue: 0]
         }
         helper.addShMock("""docker inspect --format '{{ index .Config.Labels "org.label-schema.version"}}' opensearchproject/opensearch:latest""") { script ->
             return [stdout: "2.5.0", exitValue: 0]


### PR DESCRIPTION
### Description
Resolve the date issue in the name of the docker image and remove the re-release argument that is passed through the jenkins job.
### Issues Resolved
Adresses https://github.com/opensearch-project/opensearch-build/issues/4176

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
