### PR TITLE
Add more details to build failure message

### DIFF
--- a/tests/jenkins/TestCreateBuildFailureGithubIssue.groovy
+++ b/tests/jenkins/TestCreateBuildFailureGithubIssue.groovy
@@ -38,7 +38,7 @@ class TestCreateBuildFailureGithubIssue extends BuildPipelineTest {
             return [stdout: "", exitValue: 0]
         }
         super.testPipeline('tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile')
-        assertThat(getCommands('sh', 'create'), hasItem('{script=gh issue create --title \"[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0\" --body \"***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.\n                      The distribution build for performance-analyzer has failed for version: 2.0.0.\n                      Please see build log at www.example.com/jobs/test/123/consoleFull\" --label autocut,v2.0.0 --label \"untriaged\" --repo https://github.com/opensearch-project/performance-analyzer.git, returnStdout=true}'))
+        assertThat(getCommands('sh', 'create'), hasItem('{script=gh issue create --title \"[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0\" --body \"***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.\n                      The distribution build for performance-analyzer has failed for version: 2.0.0.\n                      Please see build log at www.example.com/job/build_url/32/display/redirect.\n                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details\" --label autocut,v2.0.0 --label \"untriaged\" --repo https://github.com/opensearch-project/performance-analyzer.git, returnStdout=true}'))
     }
 
     @Test
@@ -54,7 +54,7 @@ class TestCreateBuildFailureGithubIssue extends BuildPipelineTest {
         }
         super.testPipeline('tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile', 'tests/jenkins/jobs/CreateBuildFailureGithubExistingIssueCheck_Jenkinsfile')
         assertThat(getCommands('println', ''), hasItem('Issue already exists, adding a comment'))
-        assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment bbb\nccc --repo https://github.com/opensearch-project/OpenSearch.git --body \"***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.\n                      The distribution build for OpenSearch has failed for version: 2.0.0.\n                      Please see build log at www.example.com/jobs/test/123/consoleFull\", returnStdout=true}"))
+        assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment bbb\nccc --repo https://github.com/opensearch-project/OpenSearch.git --body \"***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.\n                      The distribution build for OpenSearch has failed for version: 2.0.0.\n                      Please see build log at www.example.com/job/build_url/32/display/redirect.\n                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details\", returnStdout=true}"))
     }
 
     def getCommands(method, text) {

--- a/tests/jenkins/jobs/CreateBuildFailureGithubExistingIssueCheck_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CreateBuildFailureGithubExistingIssueCheck_Jenkinsfile.txt
@@ -9,7 +9,8 @@
                   createBuildFailureGithubIssue.readYaml({file=tests/data/opensearch-2.0.0.yml})
                   createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/OpenSearch.git, issueTitle=[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0, issueBody=***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.
                       The distribution build for OpenSearch has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details, label=autocut,v2.0.0})
                      createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                      createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/OpenSearch.git -S "[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
@@ -19,11 +20,13 @@
                         createGithubIssue.sh({script=gh issue comment bbb
 ccc --repo https://github.com/opensearch-project/OpenSearch.git --body "***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.
                       The distribution build for OpenSearch has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details", returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
                   createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/geospatial.git, issueTitle=[AUTOCUT] Distribution Build Failed for geospatial-2.0.0, issueBody=***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
                       The distribution build for geospatial has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details, label=autocut,v2.0.0})
                      createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                      createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/geospatial.git -S "[AUTOCUT] Distribution Build Failed for geospatial-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
@@ -33,11 +36,13 @@ ccc --repo https://github.com/opensearch-project/OpenSearch.git --body "***Recei
                         createGithubIssue.sh({script=gh issue comment bbb
 ccc --repo https://github.com/opensearch-project/geospatial.git --body "***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
                       The distribution build for geospatial has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details", returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
                   createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/performance-analyzer.git, issueTitle=[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0, issueBody=***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
                       The distribution build for performance-analyzer has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details, label=autocut,v2.0.0})
                      createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                      createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/performance-analyzer.git -S "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
@@ -47,5 +52,6 @@ ccc --repo https://github.com/opensearch-project/geospatial.git --body "***Recei
                         createGithubIssue.sh({script=gh issue comment bbb
 ccc --repo https://github.com/opensearch-project/performance-analyzer.git --body "***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
                       The distribution build for performance-analyzer has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details", returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})

--- a/tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CreateBuildFailureGithubIssue_Jenkinsfile.txt
@@ -9,7 +9,8 @@
                   createBuildFailureGithubIssue.readYaml({file=tests/data/opensearch-2.0.0.yml})
                   createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/OpenSearch.git, issueTitle=[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0, issueBody=***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.
                       The distribution build for OpenSearch has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details, label=autocut,v2.0.0})
                      createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                      createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/OpenSearch.git -S "[AUTOCUT] Distribution Build Failed for OpenSearch-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
@@ -19,11 +20,13 @@
                         createGithubIssue.sh({script=gh issue comment bbb
 ccc --repo https://github.com/opensearch-project/OpenSearch.git --body "***Received Error***: **Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot**.
                       The distribution build for OpenSearch has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details", returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
                   createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/geospatial.git, issueTitle=[AUTOCUT] Distribution Build Failed for geospatial-2.0.0, issueBody=***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
                       The distribution build for geospatial has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details, label=autocut,v2.0.0})
                      createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                      createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/geospatial.git -S "[AUTOCUT] Distribution Build Failed for geospatial-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
@@ -33,11 +36,13 @@ ccc --repo https://github.com/opensearch-project/OpenSearch.git --body "***Recei
                         createGithubIssue.sh({script=gh issue comment bbb
 ccc --repo https://github.com/opensearch-project/geospatial.git --body "***Received Error***: **Error building geospatial, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component geospatial**.
                       The distribution build for geospatial has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull", returnStdout=true})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details", returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})
                   createBuildFailureGithubIssue.createGithubIssue({repoUrl=https://github.com/opensearch-project/performance-analyzer.git, issueTitle=[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0, issueBody=***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
                       The distribution build for performance-analyzer has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull, label=autocut,v2.0.0})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details, label=autocut,v2.0.0})
                      createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                      createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         createGithubIssue.sh({script=gh issue list --repo https://github.com/opensearch-project/performance-analyzer.git -S "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0 in:title" --label autocut,v2.0.0 --json number --jq '.[0].number', returnStdout=true})
@@ -46,5 +51,6 @@ ccc --repo https://github.com/opensearch-project/geospatial.git --body "***Recei
                         createGithubIssue.println(Creating new issue)
                         createGithubIssue.sh({script=gh issue create --title "[AUTOCUT] Distribution Build Failed for performance-analyzer-2.0.0" --body "***Received Error***: **Error building performance-analyzer, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0ed in the next build. This might have performance impact if it keeps failing. Run the javaToolchains task for more det.yml --component performance-analyzer**.
                       The distribution build for performance-analyzer has failed for version: 2.0.0.
-                      Please see build log at www.example.com/jobs/test/123/consoleFull" --label autocut,v2.0.0 --label "untriaged" --repo https://github.com/opensearch-project/performance-analyzer.git, returnStdout=true})
+                      Please see build log at www.example.com/job/build_url/32/display/redirect.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details" --label autocut,v2.0.0 --label "untriaged" --repo https://github.com/opensearch-project/performance-analyzer.git, returnStdout=true})
                   createBuildFailureGithubIssue.sleep({time=3, unit=SECONDS})

--- a/tests/jenkins/lib-testers/CreateBuildFailureGithubIssueLibTester.groovy
+++ b/tests/jenkins/lib-testers/CreateBuildFailureGithubIssueLibTester.groovy
@@ -36,6 +36,6 @@ class CreateBuildFailureGithubIssueLibTester extends LibFunctionTester{
     void configure(Object helper, Object binding) {
         helper.registerAllowedMethod('withCredentials', [Map])
         helper.registerAllowedMethod('sleep', [Map])
-        binding.setVariable('BUILD_URL', 'www.example.com/jobs/test/123/')
+        binding.setVariable('env', ['RUN_DISPLAY_URL': 'www.example.com/job/build_url/32/display/redirect'])
     }
 }

--- a/vars/createBuildFailureGithubIssue.groovy
+++ b/vars/createBuildFailureGithubIssue.groovy
@@ -43,7 +43,8 @@ void call(Map args = [:]) {
                 compIndex = failedComponents.indexOf(component.name)
                 ghIssueBody = """***Received Error***: **${failureMessages[compIndex]}**.
                       The distribution build for ${component.name} has failed for version: ${currentVersion}.
-                      Please see build log at ${BUILD_URL}consoleFull""".stripIndent()
+                      Please see build log at ${env.RUN_DISPLAY_URL}.
+                      The failed build stage will be marked as unstable(!). Please see ./build.sh step for more details""".stripIndent()
                 createGithubIssue(
                     repoUrl: component.repository,
                     issueTitle: "[AUTOCUT] Distribution Build Failed for ${component.name}-${currentVersion}",


### PR DESCRIPTION
### Description
This change now adds blue ocean view URL to the build failure message and some more instructions on how to track the failure logs.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
