### PR TITLE
Update getIndexFileRoot path in BuildManifest

### DIFF
--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -33,7 +33,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
-          base: '5.x'
+          base: '6.x'
           committer: opensearch-ci-bot <opensearch-infra@amazon.com>
           author: opensearch-ci-bot <opensearch-infra@amazon.com>
           commit-message: |

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestReport {
     }
 }
 
-String version = '5.12.0'
+String version = '6.0.0'
 
 task updateVersion {
     doLast {

--- a/src/jenkins/BuildManifest.groovy
+++ b/src/jenkins/BuildManifest.groovy
@@ -116,7 +116,11 @@ class BuildManifest implements Serializable {
     public String getIndexFileRoot(String jobName) {
         return [
                 jobName,
-                this.build.version
+                this.build.version,
+                "index",
+                this.build.platform,
+                this.build.architecture,
+                this.build.distribution
         ].join("/")
     }
 

--- a/tests/jenkins/jobs/BuildManifest_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/BuildManifest_Jenkinsfile.txt
@@ -28,7 +28,7 @@
                BuildManifest.getMinArtifact()
                BuildManifest_Jenkinsfile.echo(dist/opensearch-min-1.1.0-linux-x64.tar.gz)
                BuildManifest.getIndexFileRoot(distribution-build-opensearch)
-               BuildManifest_Jenkinsfile.echo(distribution-build-opensearch/1.1.0)
+               BuildManifest_Jenkinsfile.echo(distribution-build-opensearch/1.1.0/index/linux/x64/tar)
                BuildManifest.getCommitId(OpenSearch)
                BuildManifest_Jenkinsfile.echo(b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583)
                BuildManifest.getRepo(OpenSearch)


### PR DESCRIPTION
### Description
Return the new index.json file path w.r.t platform, architecture and distribution types.
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4165
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
