### PR TITLE
Add mavenCentral to the list of repositories in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     maven { url 'https://repo.jenkins-ci.org/releases/' }
     maven { url 'https://mvnrepository.com/artifact/' }
     mavenLocal()


### PR DESCRIPTION
### Description
Fix to failing groovy tests due to missing plugin dependecies in the targeted repository.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4297

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
