### PR TITLE
Add method to get component names from test manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ out.txt
 .classpath
 bin/*
 
-
+logback.log

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.0.0'
+String version = '6.1.0'
 
 task updateVersion {
     doLast {

--- a/src/jenkins/BuildManifest.groovy
+++ b/src/jenkins/BuildManifest.groovy
@@ -6,11 +6,12 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-
 package jenkins
 
 class BuildManifest implements Serializable {
+
     class Build implements Serializable {
+
         String id
         String name
         String version
@@ -57,6 +58,7 @@ class BuildManifest implements Serializable {
                     this.architecture,
             ].join('-') + '.' + getExtension()
         }
+
     }
 
     class Components extends HashMap<String, Component> {
@@ -67,9 +69,11 @@ class BuildManifest implements Serializable {
                 this[component.name] = component
             }
         }
+
     }
 
     class Component implements Serializable {
+
         String name
         String version
         String ref
@@ -103,25 +107,25 @@ class BuildManifest implements Serializable {
                 buildNumber,
                 this.build.platform,
                 this.build.architecture
-        ].join("/")
+        ].join('/')
     }
 
     public String getArtifactRoot(String jobName, String buildNumber) {
         return [
                 this.getArtifactRootWithoutDistribution(jobName, buildNumber),
                 this.build.distribution
-        ].join("/")
+        ].join('/')
     }
-    
+
     public String getIndexFileRoot(String jobName) {
         return [
                 jobName,
                 this.build.version,
-                "index",
+                'index',
                 this.build.platform,
                 this.build.architecture,
                 this.build.distribution
-        ].join("/")
+        ].join('/')
     }
 
     public String getArtifactRootUrlWithoutDistribution(String publicArtifactUrl = 'https://ci.opensearch.org/ci/dbc', String jobName, String buildNumber) {
@@ -144,7 +148,7 @@ class BuildManifest implements Serializable {
             'builds',
             this.build.getFilename(),
             'manifest.yml'
-        ].join("/")
+        ].join('/')
     }
 
     public String getBundleManifestUrl(String publicArtifactUrl = 'https://ci.opensearch.org/ci/dbc', String jobName, String buildNumber) {
@@ -153,7 +157,7 @@ class BuildManifest implements Serializable {
             'dist',
             this.build.getFilename(),
             'manifest.yml'
-        ].join("/")
+        ].join('/')
     }
 
     public String getArtifactUrl(String publicArtifactUrl = 'https://ci.opensearch.org/ci/dbc', String jobName, String buildNumber) {
@@ -162,7 +166,7 @@ class BuildManifest implements Serializable {
             'dist',
             this.build.getFilename(),
             this.build.getFilenameWithExtension()
-        ].join("/")
+        ].join('/')
     }
 
     public String getArtifactArchitecture() {
@@ -182,7 +186,7 @@ class BuildManifest implements Serializable {
     }
 
     public String getMinArtifact() {
-        components.get(build.name.replace(' ','-'))?.artifacts?.get("dist")?.first()
+        components.get(build.name.replace(' ', '-'))?.artifacts?.get('dist')?.first()
     }
 
     public String getCommitId (String name) {
@@ -191,11 +195,12 @@ class BuildManifest implements Serializable {
 
     public ArrayList getNames() {
         def componentsName = []
-        this.components.each{key, value -> componentsName.add(key)}
+        this.components.each { key, value -> componentsName.add(key) }
         return componentsName
     }
 
     public String getRepo(String name) {
         return this.components.get(name).repository
     }
+
 }

--- a/src/jenkins/TestManifest.groovy
+++ b/src/jenkins/TestManifest.groovy
@@ -10,8 +10,10 @@
 package jenkins
 
 class TestManifest {
+
     class Ci implements Serializable {
         class Image implements Serializable {
+
             String name
             String args
 
@@ -19,6 +21,7 @@ class TestManifest {
                 this.name = data.name
                 this.args = data.args
             }
+
         }
 
         Image image
@@ -26,14 +29,45 @@ class TestManifest {
         Ci(Map data) {
             this.image = new TestManifest.Ci.Image(data.image)
         }
+
+    }
+
+    class Components extends HashMap<String, Component> {
+
+        Components(ArrayList data) {
+            data.each { item ->
+                Component component = new Component(item)
+                this[component.name] = component
+            }
+        }
+
+    }
+
+    class Component implements Serializable {
+
+        String name
+
+        Component(Map data) {
+            this.name = data.name
+        }
+
     }
 
     String name
 
     Ci ci
+    Components components
 
     TestManifest(Map data) {
         this.name = data.name
         this.ci = data.ci ? new TestManifest.Ci(data.ci) : null
+        this.components = data.components ? new TestManifest.Components(data.components) : null
     }
+
+    public ArrayList getComponentNames() {
+        def componentsName = []
+        this.components.each { key, value -> componentsName.add(key) }
+        return componentsName
+    }
+
 }


### PR DESCRIPTION
### Description
Add getComponentNames method from test Manifest

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3461

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
