### PR TITLE
Update the URL for latest index.json in retrievePreviousBuild library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.1.0'
+String version = '6.1.1'
 
 task updateVersion {
     doLast {

--- a/vars/retrievePreviousBuild.groovy
+++ b/vars/retrievePreviousBuild.groovy
@@ -31,10 +31,9 @@ void call(Map args = [:]) {
 
     if (previousBuildId.equalsIgnoreCase("latest")) {
         DISTRIBUTION_BUILD_NUMBER = sh(
-                script:  "curl -sL https://ci.opensearch.org/ci/dbc/${DISTRIBUTION_JOB_NAME}/${version}/index.json | jq -r \".latest\"",
+                script:  "curl -sL https://ci.opensearch.org/ci/dbc/${DISTRIBUTION_JOB_NAME}/${version}/index/${DISTRIBUTION_PLATFORM}/${DISTRIBUTION_ARCHITECTURE}/${distribution}/index.json | jq -r \".latest\"",
                 returnStdout: true
         ).trim()
-        //Once we have new index.json, URL will be changed to: https://ci.opensearch.org/ci/dbc/${DISTRIBUTION_JOB_NAME}/${version}/index/${platform}/${architecture}/${distribution}/index.json
     } else {
         DISTRIBUTION_BUILD_NUMBER = previousBuildId
     }


### PR DESCRIPTION
### Description
Update the URL for latest index.json since we have a new uploading path for the `index.json`.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
