### PR TITLE
Adding @Divyaasm and @zelinh as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @peterzhuamazon @prudhvigodithi @gaiksaya @rishabh6788
+*   @peterzhuamazon @prudhvigodithi @gaiksaya @rishabh6788 @Divyaasm @zelinh
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya)             | Amazon      |
 | Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon      |
 | Rishabh Singh   | [rishabh6788](https://github.com/rishabh6788)       | Amazon      |
+| Divya Madala    | [Divyaasm](https://github.com/Divyaasm)             | Amazon      |
+| Zelin Hao       | [zelinh](https://github.com/zelinh)                 | Amazon      |


### PR DESCRIPTION
### Description
Adding @Divyaasm and @zelinh as maintainers

Divyaasm contributions:
https://github.com/opensearch-project/opensearch-build-libraries/pulls?q=is%3Apr+is%3Amerged+author%3ADivyaasm

zelinh contributions: 
https://github.com/opensearch-project/opensearch-build-libraries/pulls?q=is%3Apr+is%3Amerged+author%3Azelinh+

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
