### PR TITLE
Fix grep bug in publishGradleCheckTestResults script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.4.1'
+String version = '6.4.2'
 
 task updateVersion {
     doLast {

--- a/vars/publishGradleCheckTestResults.groovy
+++ b/vars/publishGradleCheckTestResults.groovy
@@ -107,7 +107,7 @@ void indexFailedTestData() {
                         }
                 }'
                 echo "INDEX NAME IS \$INDEX_NAME"
-                curl -I "${METRICS_HOST_URL}/\$INDEX_NAME" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"${awsAccessKey}:${awsSecretKey}\" -H \"x-amz-security-token:${awsSessionToken}\" | grep -E 'HTTP\\/[0-9]+(\\.[0-9]+)? [0-9]+'
+                curl -I "${METRICS_HOST_URL}/\$INDEX_NAME" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"${awsAccessKey}:${awsSecretKey}\" -H \"x-amz-security-token:${awsSessionToken}\" | grep -E "HTTP\\/[0-9]+(\\.[0-9]+)? 200"
                 if [ \$? -eq 0 ]; then
                     echo "Index already exists. Indexing Results"
                 else


### PR DESCRIPTION
### Description
Fix bug related to grep expression in the script. Currently it will match all HTTP status codes including 404 which is not correct. 
It only needs to match 200 status to check if an index already exists. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
