### PR TITLE
Adapt RubyGems publish action to path changes

### DIFF
--- a/tests/jenkins/TestPublishToRubyGems.groovy
+++ b/tests/jenkins/TestPublishToRubyGems.groovy
@@ -28,7 +28,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         assertThat(curlCommands, hasItem(
             "cd /tmp/workspace/dist && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()
         ))
-        assertThat(gemCommands, hasItem("#!/bin/bash\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P MediumSecurity\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
+        assertThat(gemCommands, hasItem("#!/bin/bash\n        gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem\n        source ~/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version\n        cd /tmp/workspace/dist && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P MediumSecurity\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 
     @Test
@@ -40,7 +40,7 @@ class TestPublishToRubyGems extends BuildPipelineTest {
         def gemCommands = getCommands('sh', 'gem')
         assertThat(curlCommands, hasItem(
             "cd /tmp/workspace/test && curl --fail --data-binary @`ls *.gem` -H 'Authorization:API_KEY' -H 'Content-Type: application/octet-stream' https://rubygems.org/api/v1/gems".toString()))
-        assertThat(gemCommands, hasItem("#!/bin/bash\n        gem cert --add /tmp/workspace/certificate/path\n        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use jruby-9.3.0.0 && ruby --version\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P MediumSecurity\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
+        assertThat(gemCommands, hasItem("#!/bin/bash\n        gem cert --add /tmp/workspace/certificate/path\n        source ~/.rvm/scripts/rvm && rvm use jruby-9.3.0.0 && ruby --version\n        cd /tmp/workspace/test && gemNameWithVersion=\$(ls *.gem)\n        gem install \$gemNameWithVersion\n        gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P MediumSecurity\n        gem uninstall \$gemName\n        gem install \$gemNameWithVersion -P HighSecurity\n    "))
     }
 
     def getCommands(method, text) {

--- a/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGemWithArgs_Jenkinsfile.txt
@@ -6,7 +6,7 @@
                PublishToRubyGemWithArgs_Jenkinsfile.publishToRubyGems({apiKeyCredentialId=ruby-api-key, gemsDir=test, publicCertPath=certificate/path, rubyVersion=jruby-9.3.0.0})
                   publishToRubyGems.sh(#!/bin/bash
         gem cert --add /tmp/workspace/certificate/path
-        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use jruby-9.3.0.0 && ruby --version
+        source ~/.rvm/scripts/rvm && rvm use jruby-9.3.0.0 && ruby --version
         cd /tmp/workspace/test && gemNameWithVersion=$(ls *.gem)
         gem install $gemNameWithVersion
         gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem$)//g')

--- a/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToRubyGems_JenkinsFile.txt
@@ -6,7 +6,7 @@
                PublishToRubyGems_JenkinsFile.publishToRubyGems({apiKeyCredentialId=ruby-api-key})
                   publishToRubyGems.sh(#!/bin/bash
         gem cert --add /tmp/workspace/certs/opensearch-rubygems.pem
-        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version
+        source ~/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version
         cd /tmp/workspace/dist && gemNameWithVersion=$(ls *.gem)
         gem install $gemNameWithVersion
         gemName=$(echo $gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem$)//g')

--- a/vars/publishToRubyGems.groovy
+++ b/vars/publishToRubyGems.groovy
@@ -24,7 +24,7 @@ void call(Map args = [:]) {
 
     sh """#!/bin/bash
         gem cert --add ${certPath}
-        source /usr/share/opensearch/.rvm/scripts/rvm && rvm use ${rubyVersion} && ruby --version
+        source ~/.rvm/scripts/rvm && rvm use ${rubyVersion} && ruby --version
         cd ${releaseArtifactsDir} && gemNameWithVersion=\$(ls *.gem)
         gem install \$gemNameWithVersion
         gemName=\$(echo \$gemNameWithVersion | sed -E 's/(-[0-9.]+-*[a-z]*.gem\$)//g')


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/opensearch-build/commit/01613af16774cfe39bf41ab23bf2fdf27a78b95f the docker user got changed. As such the users home folder location got changed as well, which didn't get reflected in the rubygems publish action.

This can be seen in the latest publish attempt of `opensearch-ruby`: https://build.ci.opensearch.org/blue/organizations/jenkins/opensearch-ruby-gems-release/detail/opensearch-ruby-gems-release/31/pipeline/

> script.sh: line 3: /usr/share/opensearch/.rvm/scripts/rvm: No such file or directory

In order for a ruby version to be selected the path to rvm must be updated. This PR does that by simply using `~`, unblocking a new release of `opensearch-ruby`.

Old output:

```sh
[ci-runner@b51ea2c5f5d2 ~]$ source /usr/share/opensearch/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version
bash: /usr/share/opensearch/.rvm/scripts/rvm: No such file or directory
```

New output:

```sh
[ci-runner@b51ea2c5f5d2 ~]$ source ~/.rvm/scripts/rvm && rvm use 2.6.0 && ruby --version
Using /home/ci-runner/.rvm/gems/ruby-2.6.0
ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-linux]
```

### Issues Resolved
Closes #410

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
