### PR TITLE
Update gradle publish library to handle `invokeType`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.4.5'
+String version = '6.4.6'
 
 task updateVersion {
     doLast {


### PR DESCRIPTION
### Description
Coming from a failed gradle check job https://build.ci.opensearch.org/job/gradle-check/38585/console with error `No such property: pr_number for class: groovy.lang.Binding` because this job was invoked by `parameterizedCron`. 

Update gradle publish library to handle the `invokeType` so that the failed jobs can be filtered by `invokeType`.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
