### PR TITLE
Update the publish gradle check library mapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.4.7'
+String version = '6.4.8'
 
 task updateVersion {
     doLast {

--- a/vars/publishGradleCheckTestResults.groovy
+++ b/vars/publishGradleCheckTestResults.groovy
@@ -99,7 +99,7 @@ void indexFailedTestData() {
                               "pull_request_owner": { "type": "keyword" },
                               "invoke_type": { "type": "keyword" },
                               "pull_request_title": { "type": "text" },
-                              "git_reference": { "type": "text" },
+                              "git_reference": { "type": "keyword" },
                               "test_class": { "type": "keyword" },
                               "test_name": { "type": "keyword" },
                               "test_status": { "type": "keyword" },


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/OpenSearch/issues/11217#issuecomment-2118322724. The initial PR with the change https://github.com/opensearch-project/opensearch-build-libraries/pull/427. This PR update the mapping type of `git_reference` with `keyword`.

### Issues Resolved
Part of: https://github.com/opensearch-project/OpenSearch/issues/3713

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
