### PR TITLE
Ensure macos using gsed to avoid sha512 value substitution issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.6.0'
+String version = '6.6.1'
 
 task updateVersion {
     doLast {

--- a/vars/uploadMinSnapshotsToS3.groovy
+++ b/vars/uploadMinSnapshotsToS3.groovy
@@ -52,11 +52,16 @@ void call(Map args = [:]) {
 
     echo("Start copying files: version-${version} architecture-${architecture} platform-${platform} buildid-${id} distribution-${distribution} extension-${extension}")
 
+    String sedCmd = "sed"
+    if (platform == "darwin") {
+        sedCmd = "gsed"
+    }
+
     sh """
         cp -v ${srcDir}/${baseName}.${extension} ${srcDir}/${baseName}-latest.${extension}
         cp -v ${srcDir}/${baseName}.${extension}.sha512 ${srcDir}/${baseName}-latest.${extension}.sha512
         cp -v ${srcDir}/../manifest.yml ${srcDir}/${baseName}-latest.${extension}.build-manifest.yml
-        sed -i "s/.${extension}/-latest.${extension}/g" ${srcDir}/${baseName}-latest.${extension}.sha512
+        ${sedCmd} -i "s/.${extension}/-latest.${extension}/g" ${srcDir}/${baseName}-latest.${extension}.sha512
     """
     withCredentials([
         string(credentialsId: 'jenkins-artifact-promotion-role', variable: 'ARTIFACT_PROMOTION_ROLE_NAME'),


### PR DESCRIPTION
### Description
Ensure macos using gsed to avoid sha512 value substitution issues

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4670

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
