### PR TITLE
Bug fixes in `publishDistributionBuildResults` and `publishIntegTestResults`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.7.0'
+String version = '6.7.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishDistributionBuildResults.groovy
+++ b/tests/jenkins/TestPublishDistributionBuildResults.groovy
@@ -209,4 +209,43 @@ class TestPublishDistributionBuildResults extends BuildPipelineTest {
         ])
         assert result == expectedJson
     }
+
+    @Test
+    void testExtractComponentsForFailureMessages() {
+        List<String> failureMessages = [
+            "Error building componentA, caused by ...",
+            "Error building componentB due to ...",
+            "Error building componentA because ..."
+        ]
+        List<String> expectedComponents = ["componentA", "componentB"]
+        def script = loadScript('vars/publishDistributionBuildResults.groovy')
+        List<String> result = script.extractComponents(failureMessages, /(?<=\bError building\s).*/, 0)
+        assert result == expectedComponents
+    }
+
+    @Test
+    void testExtractComponentsForPassMessages() {
+        List<String> passMessages = [
+            "Successfully built componentA",
+            "Successfully built componentB",
+            "Successfully built componentC"
+        ]
+        List<String> expectedComponents = ["componentA", "componentB", "componentC"]
+        def script = loadScript('vars/publishDistributionBuildResults.groovy')
+        List<String> result = script.extractComponents(passMessages, /(?<=\bSuccessfully built\s).*/, 0)
+        assert result == expectedComponents
+    }
+
+    @Test
+    void testExtractComponentsWithDuplicates() {
+        List<String> messages = [
+            "Successfully built componentA",
+            "Successfully built componentA",
+            "Successfully built componentB"
+        ]
+        List<String> expectedComponents = ["componentA", "componentB"]
+        def script = loadScript('vars/publishDistributionBuildResults.groovy')
+        List<String> result = script.extractComponents(messages, /(?<=\bSuccessfully built\s).*/, 0)
+        assert result == expectedComponents
+    }
 }

--- a/tests/jenkins/TestPublishIntegTestResults.groovy
+++ b/tests/jenkins/TestPublishIntegTestResults.groovy
@@ -208,6 +208,48 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
         assert parsedResult == expectedJson
     }
 
+    @Test
+    void testCallWithMissingArgs() {
+        def script = loadScript('vars/publishIntegTestResults.groovy')
+        def args = [
+            version: "1.0",
+            distributionBuildNumber: null, // Missing required argument
+            distributionBuildUrl: "http://example.com/distribution/456",
+            rc: "rc1",
+            rcNumber: "1",
+            platform: "linux",
+            architecture: "x64",
+            distribution: "tar",
+            testReportManifestYml: "path/to/testReportManifest.yml",
+            jobName: "test-job"
+        ]
+
+        def result = script.call(args)
+        
+        assert result == null
+    }
+
+    @Test
+    void testCallWithEmptyArgs() {
+        def script = loadScript('vars/publishIntegTestResults.groovy')
+        def args = [
+            version: "1.0",
+            distributionBuildNumber: "", // Empty required argument
+            distributionBuildUrl: "http://example.com/distribution/456",
+            rc: "rc1",
+            rcNumber: "1",
+            platform: "linux",
+            architecture: "x64",
+            distribution: "tar",
+            testReportManifestYml: "path/to/testReportManifest.yml",
+            jobName: "test-job"
+        ]
+
+        def result = script.call(args)
+        
+        assert result == null
+    }
+
     def normalizeString(String str) {
         return str.replaceAll(/\s+/, " ").trim()
     }

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -19,6 +19,7 @@
  * @param args.architecture <required> - The architecture of the integration test build.
  * @param args.distribution <required> - The distribution of the integration test build.
  * @param args.testReportManifestYml <required> - The generated test report YAML file using test report workflow.
+ * @param args.jobName <required> - The integ test job name, used in `testReportManifestYmlUrl`.
  */
 
 import groovy.json.JsonOutput
@@ -34,10 +35,9 @@ void call(Map args = [:]) {
     }
     if (isNullOrEmpty(args.version) || isNullOrEmpty(args.distributionBuildNumber) || isNullOrEmpty(args.distributionBuildUrl) || 
         isNullOrEmpty(args.rcNumber) || isNullOrEmpty(args.rc) || isNullOrEmpty(args.platform) || 
-        isNullOrEmpty(args.architecture) || isNullOrEmpty(args.distribution) || isNullOrEmpty(args.testReportManifestYml)) {
+        isNullOrEmpty(args.architecture) || isNullOrEmpty(args.distribution) || isNullOrEmpty(args.testReportManifestYml) || isNullOrEmpty(args.jobName)) {
         return null
     }
-
 
     def version = args.version.toString()
     def integTestBuildNumber = currentBuild.number
@@ -53,7 +53,8 @@ void call(Map args = [:]) {
     def architecture = args.architecture
     def distribution = args.distribution
     def testReportManifestYml = args.testReportManifestYml
-    def testReportManifestYmlUrl = "https://ci.opensearch.org/ci/dbc/integ-test/${version}/${distributionBuildNumber}/${platform}/${architecture}/${distribution}/test-results/${integTestBuildNumber}/integ-test/test-report.yml"
+    def jobName = args.jobName
+    def testReportManifestYmlUrl = "https://ci.opensearch.org/ci/dbc/${jobName}/${version}/${distributionBuildNumber}/${platform}/${architecture}/${distribution}/test-results/${integTestBuildNumber}/integ-test/test-report.yml"
     def manifestFile = readFile testReportManifestYml
     def manifest = readYaml text: manifestFile
     def indexName = "opensearch-integration-test-results-${formattedDate}"


### PR DESCRIPTION
### Description
Coming from initial PR https://github.com/opensearch-project/opensearch-build-libraries/pull/459:
- Better extract the failed components using from `publishDistributionBuildResults` using `extractComponents`.

- Fix the `testReportManifestYmlUrl` which is different for OS and OSD., example the change is to use `integ-test` for OS and `integ-test-opensearch-dashboards` for OSD. We should fix here as well https://github.com/opensearch-project/opensearch-build/blob/main/jenkins/opensearch-dashboards/integ-test.jenkinsfile#L362

OS: https://ci.opensearch.org/ci/dbc/integ-test/2.16.0/10113/linux/x64/tar/test-results/8411/integ-test/test-report.yml

OSD: https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7834/linux/x64/deb/test-results/6074/integ-test/test-report.yml 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/56 and https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
