### PR TITLE
Update the `component_build_result` field for `Not Available` scenario.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.7.1'
+String version = '6.7.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishIntegTestResults.groovy
+++ b/tests/jenkins/TestPublishIntegTestResults.groovy
@@ -209,6 +209,52 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
     }
 
     @Test
+    void testComponentResultWithSecurityFail() {
+        def withSecurity = 'fail'
+        def withoutSecurity = 'pass'
+        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail' || withSecurity == 'Not Available' || withoutSecurity == 'Not Available') ? 'failed' : 'passed'
+        
+        assert componentResult == 'failed'
+    }
+
+    @Test
+    void testComponentResultWithoutSecurityFail() {
+        def withSecurity = 'pass'
+        def withoutSecurity = 'fail'
+        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail' || withSecurity == 'Not Available' || withoutSecurity == 'Not Available') ? 'failed' : 'passed'
+        
+        assert componentResult == 'failed'
+    }
+
+    @Test
+    void testComponentResultWithSecurityNotAvailable() {
+        def withSecurity = 'Not Available'
+        def withoutSecurity = 'pass'
+        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail' || withSecurity == 'Not Available' || withoutSecurity == 'Not Available') ? 'failed' : 'passed'
+        
+        assert componentResult == 'failed'
+    }
+
+    @Test
+    void testComponentResultWithoutSecurityNotAvailable() {
+        def withSecurity = 'pass'
+        def withoutSecurity = 'Not Available'
+        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail' || withSecurity == 'Not Available' || withoutSecurity == 'Not Available') ? 'failed' : 'passed'
+        
+        assert componentResult == 'failed'
+    }
+
+    @Test
+    void testComponentResultBothPass() {
+        def withSecurity = 'pass'
+        def withoutSecurity = 'pass'
+        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail' || withSecurity == 'Not Available' || withoutSecurity == 'Not Available') ? 'failed' : 'passed'
+        
+        assert componentResult == 'passed'
+    }
+
+
+    @Test
     void testCallWithMissingArgs() {
         def script = loadScript('vars/publishIntegTestResults.groovy')
         def args = [

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -64,7 +64,7 @@ void call(Map args = [:]) {
         def componentCategory = manifest.name
         def withSecurity = component.configs.find { it.name == 'with-security' }?.status?.toLowerCase() ?: 'unknown'
         def withoutSecurity = component.configs.find { it.name == 'without-security' }?.status?.toLowerCase() ?: 'unknown'
-        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail') ? 'failed' : 'passed'
+        def componentResult = (withSecurity == 'fail' || withoutSecurity == 'fail' || withSecurity == 'Not Available' || withoutSecurity == 'Not Available') ? 'failed' : 'passed'
         def withSecurityYml = component.configs.find { it.name == 'with-security' }?.yml ?: ''
         def withSecurityStdout = component.configs.find { it.name == 'with-security' }?.cluster_stdout ?: []
         def withSecurityStderr = component.configs.find { it.name == 'with-security' }?.cluster_stderr ?: []


### PR DESCRIPTION
### Description
In the following scenario treat the `Not Available` as failure, this PR will update the `component_build_result` to `failed` when the status is `Not Available`.
```
components:
  - name: OpenSearch-Dashboards
    command: ./test.sh integ-test manifests/2.16.0/opensearch-dashboards-2.16.0-test.yml
      --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.16.0/10128/linux/arm64/rpm
      opensearch-dashboards=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm
      --component OpenSearch-Dashboards
    configs:
      - name: with-security
        status: Not Available
        yml: URL not available
        cluster_stdout:
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/with-security/local-cluster-logs/id-0/stdout.txt
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/with-security/local-cluster-logs/id-1/stdout.txt
        cluster_stderr:
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/with-security/local-cluster-logs/id-0/stderr.txt
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/with-security/local-cluster-logs/id-1/stderr.txt
      - name: without-security
        status: Not Available
        yml: URL not available
        cluster_stdout:
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/without-security/local-cluster-logs/id-2/stdout.txt
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/without-security/local-cluster-logs/id-3/stdout.txt
        cluster_stderr:
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/without-security/local-cluster-logs/id-2/stderr.txt
          - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7849/linux/arm64/rpm/test-results/6123/integ-test/OpenSearch-Dashboards/without-security/local-cluster-logs/id-3/stderr.txt
```

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/56 and https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
