### PR TITLE
Add new script to fetch benchmark test-execution-id for baseline and contender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.7.2'
+String version = '6.8.0'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestGetCompareBenchmarkIds.groovy
+++ b/tests/jenkins/TestGetCompareBenchmarkIds.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import jenkins.tests.BuildPipelineTest
+import org.hamcrest.CoreMatchers
+import org.hamcrest.Matcher
+import org.junit.Before
+import org.junit.Test
+
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.hasItems
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.MatcherAssert.assertTrue
+
+class TestGetCompareBenchmarkIds extends BuildPipelineTest {
+    @Before
+    void setUp() {
+        this.registerLibTester(new GetCompareBenchmarkIdsLibTester(
+                'test-baseline-config',
+                '3.0.0',
+                'big5',
+                '12345'))
+        super.setUp()
+    }
+
+    @Test
+    public void testGetCompareBenchmarkIds_default() {
+        super.testPipeline("tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile")
+    }
+
+    @Test
+    void testCallCurlCommands() {
+        runScript("tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile")
+
+        def curlCommands = getCommandExecutions('sh', 'curl').findAll {
+            shCommand -> shCommand.contains('curl')
+        }
+        assertThat(curlCommands.size(), equalTo(2))
+        def baselineCurlCommand = curlCommands[0]
+        assertThat(baselineCurlCommand, containsString('"user-tags.cluster-config": "test-baseline-config"'))
+        assertThat(baselineCurlCommand, containsString('"workload": "big5"'))
+        assertThat(baselineCurlCommand, containsString('"distribution-version": "3.0.0"'))
+
+        def contenderCurlCommand = curlCommands[1]
+        assertThat(contenderCurlCommand, containsString('"user-tags.pull_request_number": "12345"'))
+    }
+
+    def getCommandExecutions(methodName, command) {
+        def shCommands = helper.callStack.findAll {
+            call ->
+                call.methodName == methodName
+        }.
+                collect {
+                    call ->
+                        callArgsToString(call)
+                }.findAll {
+            shCommand ->
+                shCommand.contains(command)
+        }
+
+        return shCommands
+    }
+}

--- a/tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile
+++ b/tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage('compare-benchmark-test') {
+            steps {
+                script {
+                    getCompareBenchmarkIds(
+                        baselineClusterConfig: "test-baseline-config",
+                        distributionVersion: "3.0.0",
+                        workload: "big5",
+                        pullRequestNumber: "12345"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile.txt
@@ -1,0 +1,82 @@
+   CompareBenchmarkRun_Jenkinsfile.run()
+      CompareBenchmarkRun_Jenkinsfile.pipeline(groovy.lang.Closure)
+         CompareBenchmarkRun_Jenkinsfile.echo(Executing on agent [label:none])
+         CompareBenchmarkRun_Jenkinsfile.stage(compare-benchmark-test, groovy.lang.Closure)
+            CompareBenchmarkRun_Jenkinsfile.script(groovy.lang.Closure)
+               CompareBenchmarkRun_Jenkinsfile.getCompareBenchmarkIds({baselineClusterConfig=test-baseline-config, distributionVersion=3.0.0, workload=big5, pullRequestNumber=12345})
+                  getCompareBenchmarkIds.string({credentialsId=benchmark-metrics-datastore-user, variable=DATASTORE_USER})
+                  getCompareBenchmarkIds.string({credentialsId=benchmark-metrics-datastore-password, variable=DATASTORE_PASSWORD})
+                  getCompareBenchmarkIds.string({credentialsId=benchmark-metrics-datastore-endpoint, variable=DATASTORE_ENDPOINT})
+                  getCompareBenchmarkIds.withCredentials([DATASTORE_USER, DATASTORE_PASSWORD, DATASTORE_ENDPOINT], groovy.lang.Closure)
+                     getCompareBenchmarkIds.sh({script=
+              curl -X POST "https://DATASTORE_ENDPOINT/benchmark-results-*/_search" -ku DATASTORE_USER:DATASTORE_PASSWORD -H 'Content-Type: application/json' -d '{
+              "size": 1,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "user-tags.cluster-config": "test-baseline-config"
+                      }
+                    },
+                    {
+                      "term": {
+                        "workload": "big5"
+                      }
+                    },
+                    {
+                      "term": {
+                        "distribution-version": "3.0.0"
+                      }
+                    },
+                    {
+                      "range": {
+                        "test-execution-timestamp": {
+                          "gte": "now-5d/d",
+                          "lte": "now/d"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "sort": [
+                {
+                  "test-execution-timestamp": {
+                    "order": "desc"
+                  }
+                }
+              ],
+              "_source": ["test-execution-id"]
+            }'
+        , returnStdout=true})
+                     getCompareBenchmarkIds.echo(Latest test-execution-id: test-id)
+                  getCompareBenchmarkIds.string({credentialsId=benchmark-metrics-datastore-user, variable=DATASTORE_USER})
+                  getCompareBenchmarkIds.string({credentialsId=benchmark-metrics-datastore-password, variable=DATASTORE_PASSWORD})
+                  getCompareBenchmarkIds.string({credentialsId=benchmark-metrics-datastore-endpoint, variable=DATASTORE_ENDPOINT})
+                  getCompareBenchmarkIds.withCredentials([DATASTORE_USER, DATASTORE_PASSWORD, DATASTORE_ENDPOINT], groovy.lang.Closure)
+                     getCompareBenchmarkIds.sh({script=
+              curl -X POST "https://DATASTORE_ENDPOINT/benchmark-results-*/_search" -ku DATASTORE_USER:DATASTORE_PASSWORD -H 'Content-Type: application/json' -d '{
+              "size": 1,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "user-tags.pull_request_number": "12345"
+                      }
+                    }
+                  ]
+                }
+              },
+              "sort": [
+                {
+                  "test-execution-timestamp": {
+                    "order": "desc"
+                  }
+                }
+              ],
+              "_source": ["test-execution-id"]
+            }'
+        , returnStdout=true})
+                     getCompareBenchmarkIds.echo(Latest test-execution-id: test-id)

--- a/tests/jenkins/lib-testers/GetCompareBenchmarkIdsLibTester.groovy
+++ b/tests/jenkins/lib-testers/GetCompareBenchmarkIdsLibTester.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class GetCompareBenchmarkIdsLibTester extends LibFunctionTester {
+    private String baselineClusterConfig
+    private String distributionVersion
+    private String workload
+    private String pullRequestNumber
+
+    public GetCompareBenchmarkIdsLibTester(baselineClusterConfig, distributionVersion, workload, pullRequestNumber) {
+        this.baselineClusterConfig = baselineClusterConfig
+        this.distributionVersion = distributionVersion
+        this.workload = workload
+        this.pullRequestNumber = pullRequestNumber
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'getCompareBenchmarkIds'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        if (!this.baselineClusterConfig.isEmpty()) {
+            assertThat(call.args.baselineClusterConfig.first(), notNullValue())
+        }
+        if (!this.distributionVersion.isEmpty()) {
+            assertThat(call.args.distributionVersion.first(), notNullValue())
+        }
+        if (!this.workload.isEmpty()) {
+            assertThat(call.args.workload.first(), notNullValue())
+        }
+        if (!this.pullRequestNumber.isEmpty()) {
+            assertThat(call.args.pullRequestNumber.first(), notNullValue())
+        }
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.pullRequestNumber.first().toString().equals(this.pullRequestNumber)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {
+        helper.registerAllowedMethod("withCredentials", [Map])
+        binding.setVariable('DATASTORE_USER', 'user')
+        binding.setVariable('DATASTORE_PASSWORD', 'password')
+        binding.setVariable('DATASTORE_ENDPOINT', 'endpoint')
+
+        // Mock sh step
+        helper.registerAllowedMethod("sh", [Map.class], { map ->
+            return '{"hits":{"total":{"value":1},"hits":[{"_source":{"test-execution-id":"test-id"}}]}}'
+        })
+        helper.registerAllowedMethod("echo", [String.class], { str -> println str })
+    }
+}

--- a/vars/getCompareBenchmarkIds.groovy
+++ b/vars/getCompareBenchmarkIds.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Library to fetch opensearch-benchmark test-execution-ids for baseline and contender (pull_request) benchmark runs.
+ @param Map args = [:] args A map of the following parameters
+ @param args.baselineClusterConfig <required> - The cluster-config user-tag value attached to metrics published from nightly baseline runs.
+ @param args.distributionVersion <required> - The OpenSearch distribution version.
+ @param args.workload <required> - The workload used for running benchmark.
+ @param args.pullRequestNumber <required> - The pull_request_number user-tag value attached to metrics published from OS pull request runs
+ */
+
+import groovy.json.JsonSlurper
+
+Map<String, String> call(Map args = [:]) {
+    if (isNullOrEmpty(args.baselineClusterConfig.toString()) || isNullOrEmpty(args.distributionVersion.toString()) || isNullOrEmpty(args.workload.toString()) ||
+    isNullOrEmpty(args.pullRequestNumber.toString())) {
+        echo 'Please provide all the required parameters'
+        return null
+    }
+    String baselineId = getBaselineTestExecutionId(args.baselineClusterConfig, args.distributionVersion, args.workload)
+    String contenderId = getContenderTestExecutionId(args.pullRequestNumber)
+    return ['baseline': baselineId, 'contender': contenderId]
+}
+
+String getBaselineTestExecutionId(baselineClusterConfig, distributionVersion, workload) {
+    withCredentials([string(credentialsId: 'benchmark-metrics-datastore-user', variable: 'DATASTORE_USER'),
+                     string(credentialsId: 'benchmark-metrics-datastore-password', variable: 'DATASTORE_PASSWORD'),
+                     string(credentialsId: 'benchmark-metrics-datastore-endpoint', variable: 'DATASTORE_ENDPOINT')]) {
+        def curlCommand = """
+              curl -X POST "https://${DATASTORE_ENDPOINT}/benchmark-results-*/_search" -ku ${DATASTORE_USER}:${DATASTORE_PASSWORD} -H 'Content-Type: application/json' -d '{
+              "size": 1,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "user-tags.cluster-config": \"${baselineClusterConfig}\"
+                      }
+                    },
+                    {
+                      "term": {
+                        "workload": \"${workload}\"
+                      }
+                    },
+                    {
+                      "term": {
+                        "distribution-version": \"${distributionVersion}\"
+                      }
+                    },
+                    {
+                      "range": {
+                        "test-execution-timestamp": {
+                          "gte": "now-5d/d",
+                          "lte": "now/d"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "sort": [
+                {
+                  "test-execution-timestamp": {
+                    "order": "desc"
+                  }
+                }
+              ],
+              "_source": ["test-execution-id"]
+            }'
+        """
+
+        String output = sh(script: curlCommand, returnStdout: true).trim()
+
+        return processQueryOutput(output)
+    }
+}
+
+String getContenderTestExecutionId(pullRequestNumber) {
+    withCredentials([string(credentialsId: 'benchmark-metrics-datastore-user', variable: 'DATASTORE_USER'),
+                     string(credentialsId: 'benchmark-metrics-datastore-password', variable: 'DATASTORE_PASSWORD'),
+                     string(credentialsId: 'benchmark-metrics-datastore-endpoint', variable: 'DATASTORE_ENDPOINT')]) {
+        def curlCommand = """
+              curl -X POST "https://${DATASTORE_ENDPOINT}/benchmark-results-*/_search" -ku ${DATASTORE_USER}:${DATASTORE_PASSWORD} -H 'Content-Type: application/json' -d '{
+              "size": 1,
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "user-tags.pull_request_number": \"${pullRequestNumber}\"
+                      }
+                    }
+                  ]
+                }
+              },
+              "sort": [
+                {
+                  "test-execution-timestamp": {
+                    "order": "desc"
+                  }
+                }
+              ],
+              "_source": ["test-execution-id"]
+            }'
+        """
+
+        String output = sh(script: curlCommand, returnStdout: true).trim()
+        return processQueryOutput(output)
+
+    }
+}
+
+String processQueryOutput(output) {
+    def slurper = new JsonSlurper()
+    def result = slurper.parseText(output)
+
+    if (result.hits.total.value > 0) {
+        String testExecutionId = result.hits.hits[0]._source['test-execution-id']
+        echo "Latest test-execution-id: ${testExecutionId}"
+        return testExecutionId
+    } else {
+        echo "No matching documents found"
+        return null
+    }
+}
+
+boolean isNullOrEmpty(String str) { return (str == null || str.allWhitespace || str.isEmpty()) }


### PR DESCRIPTION
### Description
This PR adds a script to fetch `test-execution-id` for baseline and contender benchmark runs. 
The baseline runs are scheduled to run nightly and have following metadata attached to each metric record, `workload`, `cluster-config` and `distribution-version` and the contender runs have `pull_request_number` metadata attached to its metrics for easy identification. 
The script uses these filters to fetch the latest `test-execution-id` for baseline and contender runs. 
These ids will later be used to run `compare` command of opensearch-benchmark to fetch comparison results. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
