### PR TITLE
Add tagging feature to npm publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.8.4'
+String version = '6.9.0'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishToNpm.groovy
+++ b/tests/jenkins/TestPublishToNpm.groovy
@@ -29,7 +29,7 @@ class TestPublishToNpm extends BuildPipelineTest {
         this.registerLibTester(new PublishToNpmLibTester('artifact', '/tmp/workspace/example.tgz'))
         super.testPipeline('tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile')
         assertThat(getShellCommands('npm'), hasItem(
-            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public\n        '
+            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public --tag latest\n        '
         ))
         assertThat(getShellCommands('nvmrc'), hasItem('rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc'))
     }
@@ -39,7 +39,7 @@ class TestPublishToNpm extends BuildPipelineTest {
         this.registerLibTester(new PublishToNpmLibTester('github'))
         super.testPipeline('tests/jenkins/jobs/PublishToNpm_Jenkinsfile')
         assertThat(getShellCommands('npm'), hasItem(
-            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish  --dry-run && npm publish  --access public\n        '
+            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish  --dry-run && npm publish  --access public --tag beta\n        '
         ))
         assertThat(getShellCommands('nvmrc'), hasItem('rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc'))
     }

--- a/tests/jenkins/TestPublishToNpm.groovy
+++ b/tests/jenkins/TestPublishToNpm.groovy
@@ -29,7 +29,7 @@ class TestPublishToNpm extends BuildPipelineTest {
         this.registerLibTester(new PublishToNpmLibTester('artifact', '/tmp/workspace/example.tgz'))
         super.testPipeline('tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile')
         assertThat(getShellCommands('npm'), hasItem(
-            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public --tag latest\n        '
+            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public --tag beta\n        '
         ))
         assertThat(getShellCommands('nvmrc'), hasItem('rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc'))
     }
@@ -39,7 +39,7 @@ class TestPublishToNpm extends BuildPipelineTest {
         this.registerLibTester(new PublishToNpmLibTester('github'))
         super.testPipeline('tests/jenkins/jobs/PublishToNpm_Jenkinsfile')
         assertThat(getShellCommands('npm'), hasItem(
-            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish  --dry-run && npm publish  --access public --tag beta\n        '
+            '\n            npm set registry \"https://registry.npmjs.org\"\n            npm set //registry.npmjs.org/:_authToken NPM_TOKEN\n            npm publish  --dry-run && npm publish  --access public --tag latest\n        '
         ))
         assertThat(getShellCommands('nvmrc'), hasItem('rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc'))
     }

--- a/tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile
+++ b/tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile
@@ -9,7 +9,7 @@
 
 pipeline {
     environment {
-        tag = '2.0.0'
+        tag = '2.0.0-beta.1'
         repository = 'https://github.com/opensearch-project/opensearch-ci'
     }
     agent none

--- a/tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile.txt
@@ -9,6 +9,6 @@
                      publishToNpm.sh(
             npm set registry "https://registry.npmjs.org"
             npm set //registry.npmjs.org/:_authToken NPM_TOKEN
-            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public
+            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public --tag latest
         )
                   publishToNpm.sh(rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc)

--- a/tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile.txt
+++ b/tests/jenkins/jobs/PublishToNpmUsingTarball_JenkinsFile.txt
@@ -9,6 +9,6 @@
                      publishToNpm.sh(
             npm set registry "https://registry.npmjs.org"
             npm set //registry.npmjs.org/:_authToken NPM_TOKEN
-            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public --tag latest
+            npm publish /tmp/workspace/example.tgz --dry-run && npm publish /tmp/workspace/example.tgz --access public --tag beta
         )
                   publishToNpm.sh(rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc)

--- a/tests/jenkins/jobs/PublishToNpm_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToNpm_Jenkinsfile
@@ -18,7 +18,8 @@ pipeline {
             steps {
                 script {
                     publishToNpm(
-                        publicationType: 'github'
+                        publicationType: 'github',
+                        tag: 'beta'
                     )
                 }
             }

--- a/tests/jenkins/jobs/PublishToNpm_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishToNpm_Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
                 script {
                     publishToNpm(
                         publicationType: 'github',
-                        tag: 'beta'
                     )
                 }
             }

--- a/tests/jenkins/jobs/PublishToNpm_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToNpm_Jenkinsfile.txt
@@ -3,13 +3,13 @@
          PublishToNpm_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToNpm_Jenkinsfile.stage(publishToNpm, groovy.lang.Closure)
             PublishToNpm_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToNpm_Jenkinsfile.publishToNpm({publicationType=github})
+               PublishToNpm_Jenkinsfile.publishToNpm({publicationType=github, tag=beta})
                   publishToNpm.checkout({$class=GitSCM, branches=[{name=2.0.0}], userRemoteConfigs=[{url=https://github.com/opensearch-project/opensearch-ci}]})
                   publishToNpm.string({credentialsId=jenkins-opensearch-publish-to-npm-token, variable=NPM_TOKEN})
                   publishToNpm.withCredentials([NPM_TOKEN], groovy.lang.Closure)
                      publishToNpm.sh(
             npm set registry "https://registry.npmjs.org"
             npm set //registry.npmjs.org/:_authToken NPM_TOKEN
-            npm publish  --dry-run && npm publish  --access public
+            npm publish  --dry-run && npm publish  --access public --tag beta
         )
                   publishToNpm.sh(rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc)

--- a/tests/jenkins/jobs/PublishToNpm_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToNpm_Jenkinsfile.txt
@@ -3,13 +3,13 @@
          PublishToNpm_Jenkinsfile.echo(Executing on agent [label:none])
          PublishToNpm_Jenkinsfile.stage(publishToNpm, groovy.lang.Closure)
             PublishToNpm_Jenkinsfile.script(groovy.lang.Closure)
-               PublishToNpm_Jenkinsfile.publishToNpm({publicationType=github, tag=beta})
+               PublishToNpm_Jenkinsfile.publishToNpm({publicationType=github})
                   publishToNpm.checkout({$class=GitSCM, branches=[{name=2.0.0}], userRemoteConfigs=[{url=https://github.com/opensearch-project/opensearch-ci}]})
                   publishToNpm.string({credentialsId=jenkins-opensearch-publish-to-npm-token, variable=NPM_TOKEN})
                   publishToNpm.withCredentials([NPM_TOKEN], groovy.lang.Closure)
                      publishToNpm.sh(
             npm set registry "https://registry.npmjs.org"
             npm set //registry.npmjs.org/:_authToken NPM_TOKEN
-            npm publish  --dry-run && npm publish  --access public --tag beta
+            npm publish  --dry-run && npm publish  --access public --tag latest
         )
                   publishToNpm.sh(rm -rf /tmp/workspace/.nvmrc && rm -rf ~/.nvmrc)

--- a/vars/publishToNpm.groovy
+++ b/vars/publishToNpm.groovy
@@ -11,10 +11,12 @@
 @param Map args = [:] args A map of the following parameters
 @param args.publicationType <required> - github (will clone the repository at triggered tag and url and publish), artifact (Needs artifactPath arg to the URL or local artifact that needs to be published)
 @param args.artifactPath <required with publicationType: artifact > - URL or local Path to the artifact that needs to be publish to NPM.See supported artifacts https://docs.npmjs.com/cli/v9/commands/npm-publish?v=true#description for more details.
+@ param args.tag <optional> - Tag to publish the package with. Defaults to latest. See https://docs.npmjs.com/cli/v9/commands/npm-publish#tag for more details.
 */
 void call(Map args = [:]) {
-    parameterCheck(args.publicationType, args.artifactPath)
+    parameterCheck(args.publicationType, args.artifactPath, args.tag)
     artifactPath = args.artifactPath ?: ''
+    tag = args.tag ?: 'latest'
     if (args.publicationType == 'github') {
         checkout([$class: 'GitSCM', branches: [[name: "${env.tag}" ]], userRemoteConfigs: [[url: "${env.repository}" ]]])
     }
@@ -23,14 +25,14 @@ void call(Map args = [:]) {
         sh """
             npm set registry "https://registry.npmjs.org"
             npm set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-            npm publish ${artifactPath} --dry-run && npm publish ${artifactPath} --access public
+            npm publish ${artifactPath} --dry-run && npm publish ${artifactPath} --access public --tag ${tag}
         """
     }
     println('Cleaning up')
     sh """rm -rf ${WORKSPACE}/.nvmrc && rm -rf ~/.nvmrc"""
 }
 
-void parameterCheck(String publicationType, String artifactPath) {
+void parameterCheck(String publicationType, String artifactPath, String tag) {
     allowedPublicationType = ['github', 'artifact']
     if (!allowedPublicationType.contains(publicationType)) {
         currentBuild.result = 'ABORTED'
@@ -43,5 +45,8 @@ void parameterCheck(String publicationType, String artifactPath) {
     if (publicationType == 'github' && artifactPath) {
         currentBuild.result = 'ABORTED'
         error('publicationType: github does take any argument with it.')
+    }
+    if (!tag) {
+        println('Tag argument not provided. Default tag of latest will be used')
     }
 }

--- a/vars/publishToNpm.groovy
+++ b/vars/publishToNpm.groovy
@@ -11,7 +11,6 @@
 @param Map args = [:] args A map of the following parameters
 @param args.publicationType <required> - github (will clone the repository at triggered tag and url and publish), artifact (Needs artifactPath arg to the URL or local artifact that needs to be published)
 @param args.artifactPath <required with publicationType: artifact > - URL or local Path to the artifact that needs to be publish to NPM.See supported artifacts https://docs.npmjs.com/cli/v9/commands/npm-publish?v=true#description for more details.
-@ param args.tag <optional> - Tag to publish the package with. Defaults to latest. See https://docs.npmjs.com/cli/v9/commands/npm-publish#tag for more details.
 */
 void call(Map args = [:]) {
     parameterCheck(args.publicationType, args.artifactPath)
@@ -49,9 +48,8 @@ void parameterCheck(String publicationType, String artifactPath) {
 }
 
 String getNpmTag(String githubTag) {
-    println(githubTag)
     def matcher = githubTag =~ /-(\w+)\./
     def npmTag = matcher ? matcher[0][1] : 'latest'
-    println(npmTag)
+    println("Tagging the release as '${npmTag}'")
     return npmTag
 }


### PR DESCRIPTION
### Description
Add tagging feature to npm publishing. Synced up with @nhtruong offline and confirmed the version syntax for npmjs. Will be parsing the GH tag pushed for tagging the release. Defaults to latest. 


### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build-libraries/issues/206

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
