### PR TITLE
Add new fields to integration test and distribution build publish libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.9.0'
+String version = '6.9.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestPublishDistributionBuildResults.groovy
+++ b/tests/jenkins/TestPublishDistributionBuildResults.groovy
@@ -74,6 +74,9 @@ class TestPublishDistributionBuildResults extends BuildPipelineTest {
                     "component_repo": {
                         "type": "keyword"
                     },
+                    "component_repo_url": {
+                        "type": "keyword"
+                    },
                     "component_ref": {
                         "type": "keyword"
                     },
@@ -132,14 +135,15 @@ class TestPublishDistributionBuildResults extends BuildPipelineTest {
     void testGenerateJson() {
         def script = loadScript('vars/publishDistributionBuildResults.groovy')
         def result = script.generateJson(
-            'component1', 'repo1', 'ref1', '1.0', 123,
+            'component1', 'componentRepo', 'https://componentRepoUrl', 'ref1', '1.0', 123,
             'http://example.com/build/123', System.currentTimeMillis(), 'rc1', 1, 'test-category', 'failed'
         )
 
         def parsedResult = new JsonSlurper().parseText(result)
         def expectedJson = [
             component: 'component1',
-            component_repo: 'repo1',
+            component_repo: 'componentRepo',
+            component_repo_url: 'https://componentRepoUrl',
             component_ref: 'ref1',
             version: '1.0',
             distribution_build_number: 123,
@@ -166,7 +170,8 @@ class TestPublishDistributionBuildResults extends BuildPipelineTest {
         // Test valid parameters
         def indexName = "test-index"
         def component = "componentA"
-        def componentRepo = "repoA"
+        def componentRepo = "componentRepo"
+        def componentRepoUrl = "https://componentRepoUrl"
         def componentRef = "refA"
         def version = "1.0.0"
         def distributionBuildNumber = "123"
@@ -177,10 +182,11 @@ class TestPublishDistributionBuildResults extends BuildPipelineTest {
         def componentCategory = "categoryA"
         def status = "success"
 
-        def result = script.generateAndAppendJson(indexName, component, componentRepo, componentRef, version, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, componentCategory, status)
+        def result = script.generateAndAppendJson(component, componentRepo, componentRepoUrl, componentRef, version, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, componentCategory, status)
         def expectedJson = JsonOutput.toJson([
             component: component,
             component_repo: componentRepo,
+            component_repo_url: componentRepoUrl,
             component_ref: componentRef,
             version: version,
             distribution_build_number: distributionBuildNumber,
@@ -193,10 +199,11 @@ class TestPublishDistributionBuildResults extends BuildPipelineTest {
         ])
         assert result == expectedJson
 
-        result = script.generateAndAppendJson(indexName, null, null, null, null, null, null, null, null, null, null, null)
+        result = script.generateAndAppendJson(null, null, null, null, null, null, null, null, null, null, null, null)
         expectedJson = JsonOutput.toJson([
             component: null,
             component_repo: null,
+            component_repo_url: null,
             component_ref: null,
             version: null,
             distribution_build_number: null,

--- a/tests/jenkins/TestPublishIntegTestResults.groovy
+++ b/tests/jenkins/TestPublishIntegTestResults.groovy
@@ -71,6 +71,12 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
                     "component": {
                         "type": "keyword"
                     },
+                    "component_repo": {
+                        "type": "keyword"
+                    },
+                    "component_repo_url": {
+                        "type": "keyword"
+                    },
                     "version": {
                         "type": "keyword"
                     },
@@ -123,7 +129,13 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
                     "with_security_cluster_stdout": {
                         "type": "keyword"
                     },
+                    "with_security_test_stdout": {
+                        "type": "keyword"
+                    },
                     "with_security_cluster_stderr": {
+                        "type": "keyword"
+                    },
+                    "with_security_test_stderr": {
                         "type": "keyword"
                     },
                     "without_security": {
@@ -135,7 +147,13 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
                     "without_security_cluster_stdout": {
                         "type": "keyword"
                     },
+                    "without_security_test_stdout": {
+                        "type": "keyword"
+                    },
                     "without_security_cluster_stderr": {
+                        "type": "keyword"
+                    },
+                    "without_security_test_stderr": {
                         "type": "keyword"
                     }
                 }
@@ -169,16 +187,18 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
     void testGenerateJson() {
         def script = loadScript('vars/publishIntegTestResults.groovy')
         def result = script.generateJson(
-            'component1', '1.0', 123,
+            'component1', 'componentRepo', 'https://componentRepoUrl', '1.0', 123,
             'http://example.com/build/123', 456, 'http://example.com/distribution/456',
             System.currentTimeMillis(), 'rc1', 1, 'linux', 'x64', 'tar', 'test-category',
-            'failed', 'http://example.com/test-report.yml', 'pass', 'yml1', ['stdout1'], ['stderr1'],
-            'fail', 'yml2', ['stdout2'], ['stderr2']
+            'failed', 'http://example.com/test-report.yml', 'pass', 'yml1', ['cluster_stdout1'], ['cluster_stderr1'], ['test_stdout1'], ['test_stderr1'],
+            'fail', 'yml2', ['cluster_stdout2'], ['cluster_stderr2'], ['test_stdout2'], ['test_stderr2']
         )
 
         def parsedResult = new JsonSlurper().parseText(result)
         def expectedJson = [
             component: 'component1',
+            component_repo: 'componentRepo',
+            component_repo_url: 'https://componentRepoUrl',
             version: '1.0',
             integ_test_build_number: 123,
             integ_test_build_url: 'http://example.com/build/123',
@@ -195,12 +215,16 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
             test_report_manifest_yml: 'http://example.com/test-report.yml',
             with_security: 'pass',
             with_security_build_yml: 'yml1',
-            with_security_cluster_stdout: ['stdout1'],
-            with_security_cluster_stderr: ['stderr1'],
+            with_security_cluster_stdout: ['cluster_stdout1'],
+            with_security_cluster_stderr: ['cluster_stderr1'],
+            with_security_test_stdout: ['test_stdout1'],
+            with_security_test_stderr: ['test_stderr1'],
             without_security: 'fail',
             without_security_build_yml: 'yml2',
-            without_security_cluster_stdout: ['stdout2'],
-            without_security_cluster_stderr: ['stderr2']
+            without_security_cluster_stdout: ['cluster_stdout2'],
+            without_security_cluster_stderr: ['cluster_stderr2'],
+            without_security_test_stdout: ['test_stdout2'],
+            without_security_test_stderr: ['test_stderr2']
         ]
 
         // Remove the dynamic field for comparison

--- a/vars/publishDistributionBuildResults.groovy
+++ b/vars/publishDistributionBuildResults.groovy
@@ -41,13 +41,13 @@ void call(Map args = [:]) {
     List<String> passedComponents = extractComponents(passMessages, /(?<=\bSuccessfully built\s).*/, 0)
     inputManifest.components.each { component ->
         if (failedComponents.contains(component.name)) {
-            def jsonData = generateAndAppendJson(indexName, component.name, component.repository, component.ref,
+            def jsonData = generateAndAppendJson(component.name, component.repository.split('/')[-1].replace('.git', ''), component.repository.substring(component.repository.indexOf("github.com")).replace(".git", ""), component.ref,
                                 version, distributionBuildNumber, distributionBuildUrl,
                                 buildStartTime, rc, rcNumber, componentCategory, "failed"
                                 )
             finalJsonDoc += "{\"index\": {\"_index\": \"${indexName}\"}}\n${jsonData}\n"
         } else if (passedComponents.contains(component.name)) {
-            def jsonData = generateAndAppendJson(indexName, component.name, component.repository, component.ref,
+            def jsonData = generateAndAppendJson(component.name, component.repository.split('/')[-1].replace('.git', ''), component.repository.substring(component.repository.indexOf("github.com")).replace(".git", ""), component.ref,
                                 version, distributionBuildNumber, distributionBuildUrl,
                                 buildStartTime, rc, rcNumber, componentCategory, "passed"
                                 )
@@ -80,6 +80,9 @@ void indexFailedTestData(indexName, testRecordsFile) {
                                 "type": "keyword"
                             },
                             "component_repo": {
+                                "type": "keyword"
+                            },
+                           "component_repo_url": {
                                 "type": "keyword"
                             },
                             "component_ref": {
@@ -137,10 +140,11 @@ void indexFailedTestData(indexName, testRecordsFile) {
     }
 }
 
-def generateJson(component, componentRepo, componentRef, version, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, componentCategory, componentResult) {
+def generateJson(component, componentRepo, componentRepoUrl, componentRef, version, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, componentCategory, componentResult) {
     def json = [
         component: component,
         component_repo: componentRepo,
+        component_repo_url: componentRepoUrl,
         component_ref: componentRef,
         version: version,
         distribution_build_number: distributionBuildNumber,
@@ -154,9 +158,9 @@ def generateJson(component, componentRepo, componentRef, version, distributionBu
     return JsonOutput.toJson(json)
 }
 
-def generateAndAppendJson(indexName, component, componentRepo, componentRef, version, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, componentCategory, status) {
+def generateAndAppendJson(component, componentRepo, componentRepoUrl, componentRef, version, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, componentCategory, status) {
     def jsonData = generateJson(
-        component, componentRepo, componentRef, version, 
+        component, componentRepo, componentRepoUrl, componentRef, version, 
         distributionBuildNumber, distributionBuildUrl, buildStartTime, 
         rc, rcNumber, componentCategory, status
     )


### PR DESCRIPTION
### Description
 - Add new `component_repo` and `component_repo_url` fields for both the distribution and integration test publish libs. With these fields all the distribution and integration test documents can be filtered by `component_repo` (or `component_repo_url`). 
 - Since the OSD integration tests has multiple CI groups, filtering by `component_repo` should give the all the CI groups test failures.
 - The new fields `test_stdout` and `test_stderr` for both `with-security` and `without-security` should give users direct downloads links for the stderr and stdout errors. Thanks to @peterzhuamazon coming from https://github.com/opensearch-project/opensearch-build/pull/5001.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/72 and https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
