### PR TITLE
Create autocut issues without `untriaged` label

### DIFF
--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -76,8 +76,9 @@ void call(Map args = [:]) {
             }
             else {
                 println("Creating new issue")
+                def untriagedLabel = label != "autocut" ? "--label \"untriaged\"" : ""
                 sh(
-                    script: "gh issue create --title \"${args.issueTitle}\" ${bodyOption} --label \"${label}\" --label \"untriaged\" --repo ${args.repoUrl}",
+                    script: "gh issue create --title \"${args.issueTitle}\" ${bodyOption} --label \"${label}\" ${untriagedLabel} --repo ${args.repoUrl}",
                     returnStdout: true
                 )
             }


### PR DESCRIPTION
### Description
the label is not required, this issue type is noisy in triage meeting

### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-build-libraries/issues/498

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
