### PR TITLE
Update the search URL to `gradle-check-*` 

### DIFF
--- a/src/gradlecheck/OpenSearchMetricsQuery.groovy
+++ b/src/gradlecheck/OpenSearchMetricsQuery.groovy
@@ -26,14 +26,13 @@ class OpenSearchMetricsQuery {
         this.script = script
     }
 
-    // Ensure the alias `gradle-check` is created targeting all the gradle-check-* indices.
     def fetchMetrics(String query) {
         def response = script.sh(
             script: """
             set -e
             set +x
             MONTH_YEAR=\$(date +"%m-%Y")
-            curl -s -XGET "${metricsUrl}/gradle-check/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "${awsAccessKey}:${awsSecretKey}" -H "x-amz-security-token:${awsSessionToken}" -H 'Content-Type: application/json' -d "${query}" | jq '.'
+            curl -s -XGET "${metricsUrl}/gradle-check-*/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "${awsAccessKey}:${awsSecretKey}" -H "x-amz-security-token:${awsSessionToken}" -H 'Content-Type: application/json' -d "${query}" | jq '.'
         """,
                 returnStdout: true
         ).trim()


### PR DESCRIPTION
### Description
Update the search URL to `gradle-check-*` , using `gradle-check-*`  we dont need to manage any alias as `gradle-check`.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/493

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
