### PR TITLE
Revert to the `gradle-check` alias logic rather than querying `-*` gradle check indices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jacocoTestReport {
     }
 }
 
-String version = '6.9.1'
+String version = '6.9.2'
 
 task updateVersion {
     doLast {

--- a/src/gradlecheck/OpenSearchMetricsQuery.groovy
+++ b/src/gradlecheck/OpenSearchMetricsQuery.groovy
@@ -26,13 +26,14 @@ class OpenSearchMetricsQuery {
         this.script = script
     }
 
+    // Ensure the alias `gradle-check` is created targeting all the gradle-check-* indices.
     def fetchMetrics(String query) {
         def response = script.sh(
             script: """
             set -e
             set +x
             MONTH_YEAR=\$(date +"%m-%Y")
-            curl -s -XGET "${metricsUrl}/gradle-check-*/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "${awsAccessKey}:${awsSecretKey}" -H "x-amz-security-token:${awsSessionToken}" -H 'Content-Type: application/json' -d "${query}" | jq '.'
+            curl -s -XGET "${metricsUrl}/gradle-check/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "${awsAccessKey}:${awsSecretKey}" -H "x-amz-security-token:${awsSessionToken}" -H 'Content-Type: application/json' -d "${query}" | jq '.'
         """,
                 returnStdout: true
         ).trim()

--- a/vars/publishGradleCheckTestResults.groovy
+++ b/vars/publishGradleCheckTestResults.groovy
@@ -164,6 +164,9 @@ void indexFailedTestData() {
                                 "type": "keyword"
                             }
                         }
+                    },
+                    "aliases": {
+                        "gradle-check": {}
                     }
                 }'
                 echo "INDEX NAME IS \$INDEX_NAME"


### PR DESCRIPTION
### Description
The curl with `-*` is converted to `%2A`. Hence updated the logic to look for the `gradle-check` alias and the new index are created with  `gradle-check`  alias.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/493

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
