### PR TITLE
Update branch to point to 7.x

### DIFF
--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -33,7 +33,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
-          base: '6.x'
+          base: '7.x'
           committer: opensearch-ci-bot <opensearch-infra@amazon.com>
           author: opensearch-ci-bot <opensearch-infra@amazon.com>
           commit-message: |


### PR DESCRIPTION
### Description
Update branch to point to 7.x as the build.gradle version points to 7.0.0 now

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
