### PR TITLE
Use HOME var instead of tilde to be more comparible with Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '7.2.0'
+String version = '7.2.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestRetrievePreviousBuild.groovy
+++ b/tests/jenkins/TestRetrievePreviousBuild.groovy
@@ -34,7 +34,7 @@ class TestRetrievePreviousBuild extends BuildPipelineTest {
         super.testPipeline('tests/jenkins/jobs/RetrievePreviousBuild_Jenkinsfile')
         def shCommands = getCommands('sh', 'mkdir')
         assertThat(shCommands, hasItems('rm -rf tar && mkdir -p tar && mv -v /tmp/workspace/download/dummy_job/2.12.0/123/linux/x64/tar/* /tmp/workspace/tar'))
-        assertThat(shCommands, hasItems('mkdir -p ~/.m2/repository/org/ && cp -r tar/builds/opensearch/maven/org/opensearch/ ~/.m2/repository/org/'))
+        assertThat(shCommands, hasItems('mkdir -p $HOME/.m2/repository/org/ && cp -r tar/builds/opensearch/maven/org/opensearch/ $HOME/.m2/repository/org/'))
 
         assertThat(shCommands, hasItems('rm -rf zip && mkdir -p zip && mv -v /tmp/workspace/download/dummy_job/2.12.0/1234/windows/x64/zip/* /tmp/workspace/zip'))
         assertThat(shCommands, not(hasItems('mkdir -p ~/.m2/repository/org/ && cp -r zip/builds/opensearch/maven/org/opensearch/ ~/.m2/repository/org/')))

--- a/tests/jenkins/jobs/BuildShManifestIncremental_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/BuildShManifestIncremental_Jenkinsfile.txt
@@ -31,5 +31,5 @@ ccc/linux/x64/tar/, force=true})
                      retrievePreviousBuild.sh(rm -rf tar && mkdir -p tar && mv -v /tmp/workspace/download/dummy-build-job/2.12.0/bbb
 ccc/linux/x64/tar/* /tmp/workspace/tar)
                      retrievePreviousBuild.echo(Setting up Maven Local for OpenSearch build.)
-                     retrievePreviousBuild.sh(mkdir -p ~/.m2/repository/org/ && cp -r tar/builds/opensearch/maven/org/opensearch/ ~/.m2/repository/org/)
+                     retrievePreviousBuild.sh(mkdir -p $HOME/.m2/repository/org/ && cp -r tar/builds/opensearch/maven/org/opensearch/ $HOME/.m2/repository/org/)
                   buildManifest.sh(./build.sh tests/data/opensearch-input-2.12.0.yml -d tar -p linux -a x64 --incremental)

--- a/tests/jenkins/jobs/RetrievePreviousBuild_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RetrievePreviousBuild_Jenkinsfile.txt
@@ -17,7 +17,7 @@
                               downloadFromS3.s3Download({file=/tmp/workspace/download, bucket=ARTIFACT_BUCKET_NAME, path=dummy_job/2.12.0/123/linux/x64/tar/, force=true})
                   retrievePreviousBuild.sh(rm -rf tar && mkdir -p tar && mv -v /tmp/workspace/download/dummy_job/2.12.0/123/linux/x64/tar/* /tmp/workspace/tar)
                   retrievePreviousBuild.echo(Setting up Maven Local for OpenSearch build.)
-                  retrievePreviousBuild.sh(mkdir -p ~/.m2/repository/org/ && cp -r tar/builds/opensearch/maven/org/opensearch/ ~/.m2/repository/org/)
+                  retrievePreviousBuild.sh(mkdir -p $HOME/.m2/repository/org/ && cp -r tar/builds/opensearch/maven/org/opensearch/ $HOME/.m2/repository/org/)
                RetrievePreviousBuild_Jenkinsfile.retrievePreviousBuild({inputManifest=tests/data/opensearch-dashboards-input-2.12.0.yml, distribution=zip, architecture=x64, platform=windows, distributionBuildNumber=1234})
                   retrievePreviousBuild.legacySCM(groovy.lang.Closure)
                   retrievePreviousBuild.library({identifier=jenkins@main, retriever=null})

--- a/vars/retrievePreviousBuild.groovy
+++ b/vars/retrievePreviousBuild.groovy
@@ -43,7 +43,7 @@ void call(Map args = [:]) {
     sh("rm -rf ${distribution} && mkdir -p ${distribution} && mv -v ${prefixPath}/${artifactPath}/* ${WORKSPACE}/${distribution}")
     if (inputManifestObj.build.getFilename().equals("opensearch")) {
         echo("Setting up Maven Local for OpenSearch build.")
-        sh("mkdir -p ~/.m2/repository/org/ && cp -r ${distribution}/builds/opensearch/maven/org/opensearch/ ~/.m2/repository/org/")
+        sh("mkdir -p \$HOME/.m2/repository/org/ && cp -r ${distribution}/builds/opensearch/maven/org/opensearch/ \$HOME/.m2/repository/org/")
     }
 
 }


### PR DESCRIPTION
### Description
Use HOME var instead of tilde to be more comparible with Windows

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5004

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
