### PR TITLE
Debug the lib

### DIFF
--- a/tests/jenkins/TestPublishIntegTestResults.groovy
+++ b/tests/jenkins/TestPublishIntegTestResults.groovy
@@ -475,8 +475,8 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
                 distribution: 'tar',
                 component_category: 'test_category',
                 test_type: 'test_type',
-                test_class: 'Not Available',
-                test_name: 'Not Available'
+                test_class: 'Result Not Available',
+                test_name: 'Result Not Available'
             ]
         ]
         def parsedResult = result.trim().split('\n').collect { new JsonSlurper().parseText(it) }
@@ -486,6 +486,45 @@ class TestPublishIntegTestResults extends BuildPipelineTest {
         assert parsedResult == expectedJson
     }
 
+    @Test
+    void testProcessFailedTestsWithTestResultFilesListNotAvailable() {
+        def script = loadScript('vars/publishIntegTestResults.groovy')
+        def result = script.processFailedTests(['Test Result Files List Not Available'], 'component1', 'componentRepo', 
+            'https://componentRepoUrl', '1.0', 123, 'http://example.com/build/123', 456, 
+            'http://example.com/distribution/456', System.currentTimeMillis(), 'rc1', 1, 
+            'linux', 'x64', 'tar', 'test_category', 'test_type', 'test_failures_index')
+        def expectedJson = [
+            [
+                index: [
+                    _index: 'test_failures_index'
+                ]
+            ],
+            [
+                component: 'component1',
+                component_repo: 'componentRepo',
+                component_repo_url: 'https://componentRepoUrl',
+                version: '1.0',
+                integ_test_build_number: 123,
+                integ_test_build_url: 'http://example.com/build/123',
+                distribution_build_number: 456,
+                distribution_build_url: 'http://example.com/distribution/456',
+                rc: 'rc1',
+                rc_number: 1,
+                platform: 'linux',
+                architecture: 'x64',
+                distribution: 'tar',
+                component_category: 'test_category',
+                test_type: 'test_type',
+                test_class: 'Report Not Available',
+                test_name: 'Report Not Available'
+            ]
+        ]
+        def parsedResult = result.trim().split('\n').collect { new JsonSlurper().parseText(it) }
+        parsedResult.each { json ->
+            json.remove('build_start_time')
+        }
+        assert parsedResult == expectedJson
+    }
 
 
     @Test

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -108,7 +108,13 @@ def processFailedTests(failedTests, componentName, componentRepo, componentRepoU
         case failedTests.contains("Test Result Not Available"):
             def testResultJsonContent = generateFailedTestJson(componentName, componentRepo, componentRepoUrl, version, integTestBuildNumber, 
                 integTestBuildUrl, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, 
-                platform, architecture, distribution, componentCategory, securityType, "Not Available", "Not Available")
+                platform, architecture, distribution, componentCategory, securityType, "Result Not Available", "Result Not Available")
+            finalFailedTestsJsonDoc += "{\"index\": {\"_index\": \"${testFailuresindexName}\"}}\n${testResultJsonContent}\n"
+            break
+        case failedTests.contains("Test Result Files List Not Available"):
+            def testResultJsonContent = generateFailedTestJson(componentName, componentRepo, componentRepoUrl, version, integTestBuildNumber, 
+                integTestBuildUrl, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber, 
+                platform, architecture, distribution, componentCategory, securityType, "Report Not Available", "Report Not Available")
             finalFailedTestsJsonDoc += "{\"index\": {\"_index\": \"${testFailuresindexName}\"}}\n${testResultJsonContent}\n"
             break
         case failedTests.contains("No Failed Test"):


### PR DESCRIPTION
### Description
Handle `publishIntegTestResults` lib when test reports are not available 

### Issues Resolved
Coming from https://github.com/opensearch-project/opensearch-metrics/issues/68 (part of https://github.com/opensearch-project/opensearch-metrics/issues/51). Resolves https://github.com/opensearch-project/opensearch-build-libraries/issues/546.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
