### PR TITLE
Create GH label if one is missing while creating GH issues

### DIFF
--- a/tests/jenkins/TestCreateGithubIssue.groovy
+++ b/tests/jenkins/TestCreateGithubIssue.groovy
@@ -65,7 +65,7 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --json number --jq '.[0].number'""") { script ->
             return [stdout: "", exitValue: 0]
         }
-        super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
+        runScript('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
         assertThat(getCommands('println', ''), hasItem("Creating new issue"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue create --title \"Test GH issue title\" --body \"Test GH issue body\" --label \"label101\" --label \"untriaged\" --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
     }
@@ -90,7 +90,7 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         helper.addShMock("""gh label list --repo https://github.com/opensearch-project/opensearch-build -S "label101" --json name --jq '.[0].name'""") { script ->
             return [stdout: "no labels in opensearch-project/opensearch-build matched your search", exitValue: 0]
         }
-        super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
+        runScript('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
         assertThat(getCommands('println', ''), hasItem("Creating new issue"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh label create label101 --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue create --title \"Test GH issue title\" --body \"Test GH issue body\" --label \"label101\" --label \"untriaged\" --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
@@ -113,7 +113,7 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --json number --jq '.[0].number'""") { script ->
             return [stdout: "22", exitValue: 0]
         }
-        super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
+        runScript('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
         assertThat(getCommands('println', ''), hasItem("Re-opening a recently closed issue and commenting on it"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue reopen --repo https://github.com/opensearch-project/opensearch-build 22, returnStdout=true}"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment 22 --repo https://github.com/opensearch-project/opensearch-build --body \"Test GH issue body\", returnStdout=true}"))
@@ -128,7 +128,7 @@ class TestCreateGithubIssue extends BuildPipelineTest {
                 "label101",
                 "5"
         ))
-        super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
+        runScript('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
         assertThat(getCommands('sh', 'script'), hasItem("{script=date -d \"5 days ago\" +'%Y-%m-%d', returnStdout=true}"))
     }
 

--- a/tests/jenkins/TestCreateGithubIssue.groovy
+++ b/tests/jenkins/TestCreateGithubIssue.groovy
@@ -47,7 +47,8 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         assertThat(getCommands('println', ''), hasItem("Issue already exists, adding a comment"))
         assertThat(getCommands('sh', 'script'), hasItem("""{script=gh issue comment bbb\nccc --repo https://github.com/opensearch-project/opensearch-build --body \"Test GH issue body\", returnStdout=true}"""))
     }
-
+    
+    @Test
     void testCreateGithubIssueCreate() {
         this.registerLibTester(new CreateGithubIssueLibTester(
                 "https://github.com/opensearch-project/opensearch-build",
@@ -58,10 +59,10 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         helper.addShMock("date -d \"5 days ago\" +'%Y-%m-%d'") { script ->
             return [stdout: "2023-10-24", exitValue: 0]
         }
-        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title" --label label101 --json number --jq '.[0].number'""") { script ->
+        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title" --json number --jq '.[0].number'""") { script ->
             return [stdout: "", exitValue: 0]
         }
-        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --label label101 --json number --jq '.[0].number'""") { script ->
+        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --json number --jq '.[0].number'""") { script ->
             return [stdout: "", exitValue: 0]
         }
         super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
@@ -69,31 +70,33 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue create --title \"Test GH issue title\" --body \"Test GH issue body\" --label \"label101\" --label \"untriaged\" --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
     }
 
+    @Test
     void testCreateGithubIssueCreateWithMissingLabel() {
         this.registerLibTester(new CreateGithubIssueLibTester(
                 "https://github.com/opensearch-project/opensearch-build",
                 "Test GH issue title",
                 "Test GH issue body",
-                "label101,missedOne"
+                "label101"
         ))
         helper.addShMock("date -d \"5 days ago\" +'%Y-%m-%d'") { script ->
             return [stdout: "2023-10-24", exitValue: 0]
         }
-        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title" --label label101 --json number --jq '.[0].number'""") { script ->
+        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title" --json number --jq '.[0].number'""") { script ->
             return [stdout: "", exitValue: 0]
         }
-        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --label label101 --json number --jq '.[0].number'""") { script ->
+        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --json number --jq '.[0].number'""") { script ->
             return [stdout: "", exitValue: 0]
         }
-        helper.addShMock("""gh label list --repo https://github.com/opensearch-project/opensearch-build -S "missedOne" --json name --jq '.[0].name'""") { script ->
+        helper.addShMock("""gh label list --repo https://github.com/opensearch-project/opensearch-build -S "label101" --json name --jq '.[0].name'""") { script ->
             return [stdout: "no labels in opensearch-project/opensearch-build matched your search", exitValue: 0]
         }
         super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
         assertThat(getCommands('println', ''), hasItem("Creating new issue"))
-        assertThat(getCommands('sh', 'script'), hasItem("{script=gh label create missedOne --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
+        assertThat(getCommands('sh', 'script'), hasItem("{script=gh label create label101 --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue create --title \"Test GH issue title\" --body \"Test GH issue body\" --label \"label101\" --label \"untriaged\" --repo https://github.com/opensearch-project/opensearch-build, returnStdout=true}"))
     }
 
+    @Test
     void testCreateGithubIssueReOpen() {
         this.registerLibTester(new CreateGithubIssueLibTester(
                 "https://github.com/opensearch-project/opensearch-build",
@@ -104,18 +107,19 @@ class TestCreateGithubIssue extends BuildPipelineTest {
         helper.addShMock("date -d \"5 days ago\" +'%Y-%m-%d'") { script ->
             return [stdout: "2023-10-24", exitValue: 0]
         }
-        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title" --label label101 --json number --jq '.[0].number'""") { script ->
+        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title" --json number --jq '.[0].number'""") { script ->
             return [stdout: "", exitValue: 0]
         }
-        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --label label101 --json number --jq '.[0].number'""") { script ->
+        helper.addShMock("""gh issue list --repo https://github.com/opensearch-project/opensearch-build -S "Test GH issue title in:title is:closed closed:>=2023-10-24" --json number --jq '.[0].number'""") { script ->
             return [stdout: "22", exitValue: 0]
         }
         super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
         assertThat(getCommands('println', ''), hasItem("Re-opening a recently closed issue and commenting on it"))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue reopen --repo https://github.com/opensearch-project/opensearch-build 22, returnStdout=true}"))
-        assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment 22 --repo https://github.com/opensearch-project/opensearch-build  --body \"Test GH issue body\", returnStdout=true}"))
+        assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment 22 --repo https://github.com/opensearch-project/opensearch-build --body \"Test GH issue body\", returnStdout=true}"))
     }
 
+    @Test
     void testCreateGithubIssueReOpenWithDays() {
         this.registerLibTester(new CreateGithubIssueLibTester(
                 "https://github.com/opensearch-project/opensearch-build",
@@ -125,7 +129,7 @@ class TestCreateGithubIssue extends BuildPipelineTest {
                 "5"
         ))
         super.testPipeline('tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile')
-        assertThat(getCommands('sh', 'script'), hasItem("""{script=date -d "5 days ago" +'%Y-%m-%d'}"""))
+        assertThat(getCommands('sh', 'script'), hasItem("{script=date -d \"5 days ago\" +'%Y-%m-%d', returnStdout=true}"))
     }
 
     @Test

--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -76,6 +76,19 @@ void call(Map args = [:]) {
             }
             else {
                 println("Creating new issue")
+                def labelName = sh(
+                        script: "gh label list --repo ${args.repoUrl} -S ${i} --json name --jq '.[0].name'",
+                        returnStdout: true
+                    ).trim()
+                if (labelName.equals(i.trim())) {
+                    println("Label ${i} already exists. Skipping label creation")
+                } else {
+                    println("${i} label is missing. Creating the missing label")
+                    sh(
+                        script: "gh label create ${i} --repo ${args.repoUrl}",
+                        returnStdout: true
+                    )
+                }
                 sh(
                     script: "gh issue create --title \"${args.issueTitle}\" ${bodyOption} --label \"${label}\" --label \"untriaged\" --repo ${args.repoUrl}",
                     returnStdout: true

--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -76,18 +76,21 @@ void call(Map args = [:]) {
             }
             else {
                 println("Creating new issue")
-                def labelName = sh(
-                        script: "gh label list --repo ${args.repoUrl} -S ${i} --json name --jq '.[0].name'",
-                        returnStdout: true
-                    ).trim()
-                if (labelName.equals(i.trim())) {
-                    println("Label ${i} already exists. Skipping label creation")
-                } else {
-                    println("${i} label is missing. Creating the missing label")
-                    sh(
-                        script: "gh label create ${i} --repo ${args.repoUrl}",
-                        returnStdout: true
-                    )
+                List<String> allLabels = Arrays.asList(label.split(','))
+                allLabels.each { i ->
+                    def labelName = sh(
+                            script: "gh label list --repo ${args.repoUrl} -S ${i} --json name --jq '.[0].name'",
+                            returnStdout: true
+                        ).trim()
+                    if (labelName.equals(i.trim())) {
+                        println("Label ${i} already exists. Skipping label creation")
+                    } else {
+                        println("${i} label is missing. Creating the missing label")
+                        sh(
+                            script: "gh label create ${i} --repo ${args.repoUrl}",
+                            returnStdout: true
+                        )
+                    }
                 }
                 sh(
                     script: "gh issue create --title \"${args.issueTitle}\" ${bodyOption} --label \"${label}\" --label \"untriaged\" --repo ${args.repoUrl}",


### PR DESCRIPTION
### Description
Create GH label if one is missing while creating GH issues. Also fixes the test cases where `@Test` annotation was missing hence the tests never ran. 

### Issues Resolved
closes #530 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
