### PR TITLE
Gradle agent `Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host` error `[[: not found` 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '7.3.1'
+String version = '7.3.2'
 
 task updateVersion {
     doLast {

--- a/vars/publishGradleCheckTestResults.groovy
+++ b/vars/publishGradleCheckTestResults.groovy
@@ -173,7 +173,7 @@ void indexFailedTestData() {
                 else
                     echo "Index does not exist. Creating..."
                     create_index_response=\$(curl -s -XPUT "${METRICS_HOST_URL}/\${INDEX_NAME}" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"${awsAccessKey}:${awsSecretKey}\" -H \"x-amz-security-token:${awsSessionToken}\" -H 'Content-Type: application/json' -d "\${INDEX_MAPPING}")
-                    if [[ \$create_index_response == *'"acknowledged":true'* ]]; then
+                    if echo "\$create_index_response" | grep -q '"acknowledged":true'; then
                         echo "Index created successfully."
                         echo "Updating alias..."
                         update_alias_response=\$(curl -s -XPOST "${METRICS_HOST_URL}/_aliases" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"${awsAccessKey}:${awsSecretKey}\" -H \"x-amz-security-token:${awsSessionToken}\" -H "Content-Type: application/json" -d '{
@@ -186,7 +186,7 @@ void indexFailedTestData() {
                                 }
                             ]
                         }')
-                        if [[ \$update_alias_response == *'"acknowledged":true'* ]]; then
+                        if echo "\$update_alias_response" | grep -q '"acknowledged":true'; then
                             echo "Alias updated successfully."
                         else
                             echo "Failed to update alias. Error message: \$update_alias_response"


### PR DESCRIPTION
### Description
Gradle agent `Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host` error `[[: not found`, related failed build https://build.ci.opensearch.org/job/gradle-check/50312/console. This change is not required to other libraries as the existing logic continues to work on the agents https://build.ci.opensearch.org/job/integ-test/8911/console. Issue seen only with `Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host`.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build-libraries/issues/493 and https://github.com/opensearch-project/opensearch-metrics/issues/51.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
