### PR TITLE
Add library to comment RC details on GH release issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.1.1'
+String version = '8.2.0'
 
 task updateVersion {
     doLast {

--- a/resources/release/rc-details-template.md
+++ b/resources/release/rc-details-template.md
@@ -1,0 +1,130 @@
+## See OpenSearch RC ${OPENSEARCH_RC_NUMBER} and OpenSearch-Dashboards RC ${OPENSEARCH_DASHBOARDS_RC_NUMBER} details
+<details><summary>OpenSearch ${OPENSEARCH_RC_NUMBER} and OpenSearch-Dashboards ${OPENSEARCH_DASHBOARDS_RC_NUMBER} details</summary>
+<p>
+ ## OpenSearch ${OPENSEARCH_RC_BUILD_NUMBER} and OpenSearch-Dashboards ${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER} is ready for your test.
+
+OpenSearch - [Build ${OPENSEARCH_RC_BUILD_NUMBER}](https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch/detail/distribution-build-opensearch/${OPENSEARCH_RC_BUILD_NUMBER}/pipeline)
+OpenSearch Dashboards - [Build ${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}](https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch-dashboards/detail/distribution-build-opensearch-dashboards/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/pipeline)
+
+- Use the following Docker-Compose to setup a cluster
+  <details><summary>docker-compose.yml</summary>
+  <p>
+    <pre>
+    <code>
+  version: '3'
+  services:
+    opensearch-node1:
+      image: opensearchstaging/opensearch:${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER}
+      container_name: opensearch-node1
+      environment:
+        - cluster.name=opensearch-cluster
+        - node.name=opensearch-node1
+        - discovery.seed_hosts=opensearch-node1,opensearch-node2
+        - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+        - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+          hard: 65536
+      volumes:
+        - opensearch-data1:/usr/share/opensearch/data
+      ports:
+        - 9200:9200
+        - 9600:9600 # required for Performance Analyzer
+      networks:
+        - opensearch-net
+    opensearch-node2:
+      image: opensearchstaging/opensearch:${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER}
+      container_name: opensearch-node2
+      environment:
+        - cluster.name=opensearch-cluster
+        - node.name=opensearch-node2
+        - discovery.seed_hosts=opensearch-node1,opensearch-node2
+        - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+        - bootstrap.memory_lock=true
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536
+          hard: 65536
+      volumes:
+        - opensearch-data2:/usr/share/opensearch/data
+      networks:
+        - opensearch-net
+    opensearch-dashboards:
+      image: opensearchstaging/opensearch-dashboards:${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}
+      container_name: opensearch-dashboards
+      ports:
+        - 5601:5601
+      expose:
+        - "5601"
+      environment:
+        OPENSEARCH_HOSTS: '["https://opensearch-node1:9200","https://opensearch-node2:9200"]'
+      networks:
+        - opensearch-net
+  volumes:
+    opensearch-data1:
+    opensearch-data2:
+
+  networks:
+  opensearch-net:
+  </code>
+  </pre>
+
+  </p>
+  </details>
+
+    + Download the above docker-compose.yml on your machine.
+    + Get latest image versions `docker-compose pull`.
+    + Start the cluster `docker-compose up`.
+
+- [OpenSearch docker ${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER}](https://hub.docker.com/r/opensearchstaging/opensearch/tags?page=1&name=${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER})
+    + Start without security
+        - Docker command `docker pull opensearchstaging/opensearch:${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER} && docker run -it -p 9200:9200 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" opensearchstaging/opensearch:${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER}`
+        - Connect command `curl http://localhost:9200/`
+    + Start with security
+        - Docker command
+      ```
+      docker pull opensearchstaging/opensearch:${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER} && docker run -it -p 9200:9200 -e "discovery.type=single-node" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" opensearchstaging/opensearch:${VERSION}.${OPENSEARCH_RC_BUILD_NUMBER}
+      ```
+        - Connect command `curl --insecure 'https://admin:myStrongPassword123!@localhost:9200/'`
+- [OpenSearch-Dashboards docker ${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}](https://hub.docker.com/r/opensearchstaging/opensearch-dashboards/tags?page=1&name=${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER})
+    + Start without security
+        - Docker command `docker pull opensearchstaging/opensearch-dashboards:${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER} && docker run -it --network="host" -e "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" opensearchstaging/opensearch-dashboards:${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}`
+        - URL `http://localhost:5601/`
+    + Start with security
+        - Docker command `docker pull opensearchstaging/opensearch-dashboards:${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER} && docker run -it --network="host" opensearchstaging/opensearch-dashboards:${VERSION}.${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}`
+        - URL `http://localhost:5601/`
+
+- Use TARs to deploy OpenSearch Manually
+    + OpenSearch - Build ${OPENSEARCH_RC_BUILD_NUMBER} (Note: Windows version does not have performance analyzer plugin)
+        * arm64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/arm64/tar/dist/opensearch/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/arm64/tar/dist/opensearch/opensearch-${VERSION}-linux-arm64.tar.gz)] [[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/arm64/rpm/dist/opensearch/opensearch-${VERSION}-linux-arm64.rpm)][[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/arm64/deb/dist/opensearch/opensearch-${VERSION}-linux-arm64.deb)]
+        * x64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/x64/tar/dist/opensearch/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/x64/tar/dist/opensearch/opensearch-${VERSION}-linux-x64.tar.gz)] [[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/x64/rpm/dist/opensearch/opensearch-${VERSION}-linux-x64.rpm)] [[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/linux/x64/deb/dist/opensearch/opensearch-${VERSION}-linux-x64.deb)] [[windows](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${VERSION}/${OPENSEARCH_RC_BUILD_NUMBER}/windows/x64/zip/dist/opensearch/opensearch-${VERSION}-windows-x64.zip)]
+
+
++ OpenSearch Dashboards - Build ${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}
+    * arm64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/arm64/tar/dist/opensearch-dashboards/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/arm64/tar/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-linux-arm64.tar.gz)][[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/arm64/rpm/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-linux-arm64.rpm)][[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/arm64/deb/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-linux-arm64.deb)]
+    * x64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/x64/tar/dist/opensearch-dashboards/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-linux-x64.tar.gz)][[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/x64/rpm/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-linux-x64.rpm)] [[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/linux/x64/deb/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-linux-x64.deb)] [[windows](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${VERSION}/${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}/windows/x64/zip/dist/opensearch-dashboards/opensearch-dashboards-${VERSION}-windows-x64.zip)]
+
+
+_Check how to install [opensearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/) and [dashboards](https://opensearch.org/docs/latest/install-and-configure/install-dashboards/index/) on different platforms_
+
+## Integration Test Results
+
+- Use the https://metrics.opensearch.org/_dashboards/goto/9ed74dd90eb31c7b83f3542e43328088?security_tenant=global.
+
+- Filter by the `distribution_build_number`. Use **${OPENSEARCH_RC_BUILD_NUMBER}** for OpenSearch and **${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}** for OpenSearch Dashboards.
+  Example when filtered with **${OPENSEARCH_RC_BUILD_NUMBER}** we can see all the passed/failed OpenSearch components. Check the metrics [here](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/21aad140-49f6-11ef-bbdd-39a9b324a5aa?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now%2Fw,to:now%2Fw))&_a=(description:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',filters:!(('\$state':(store:appState),meta:(alias:!n,controlledBy:'1721852613904',disabled:!f,index:'16f55f10-4977-11ef-8565-15a1562cd0a0',key:version,negate:!f,params:(query:'${VERSION}'),type:phrase),query:(match_phrase:(version:'${VERSION}'))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'23eb6520-4977-11ef-bbdd-39a9b324a5aa',key:distribution_build_number,negate:!f,params:!('${OPENSEARCH_RC_BUILD_NUMBER}','%20${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}'),type:phrases,value:'${OPENSEARCH_RC_BUILD_NUMBER},%20%20${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}'),query:(bool:(minimum_should_match:1,should:!((match_phrase:(distribution_build_number:'${OPENSEARCH_RC_BUILD_NUMBER}')),(match_phrase:(distribution_build_number:'%20${OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER}')))))),('\$state':(store:appState),meta:(alias:!n,controlledBy:'1722482131538',disabled:!f,index:'16f55f10-4977-11ef-8565-15a1562cd0a0',key:rc_number,negate:!f,params:(query:4),type:phrase),query:(match_phrase:(rc_number:4)))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',viewMode:view)).
+
+- Find the list of the created **AUTOCUT** issues here https://github.com/issues?page=1&q=is%3Aopen+is%3Aissue+user%3Aopensearch-project+label%3Av${VERSION}+label%3Aautocut+%5BAUTOCUT%5D+in%3Atitle.
+
+Thank you
+</p>
+</details>

--- a/src/jenkins/ReleaseCandidateStatus.groovy
+++ b/src/jenkins/ReleaseCandidateStatus.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+import groovy.json.JsonOutput
+import utils.OpenSearchMetricsQuery
+
+class ReleaseCandidateStatus {
+    String metricsUrl
+    String awsAccessKey
+    String awsSecretKey
+    String awsSessionToken
+    String indexName
+    String version
+    def script
+    OpenSearchMetricsQuery openSearchMetricsQuery
+
+    ReleaseCandidateStatus(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String indexName, String version, def script) {
+        this.metricsUrl = metricsUrl
+        this.awsAccessKey = awsAccessKey
+        this.awsSecretKey = awsSecretKey
+        this.awsSessionToken = awsSessionToken
+        this.indexName = indexName
+        this.version = version
+        this.script = script
+        this.openSearchMetricsQuery = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script)
+    }
+
+    def getRcDistributionNumberQuery(Integer rcNumber = null, String componentName) {
+        def queryMap = [
+                _source: "distribution_build_number",
+                sort: [
+                    [
+                        distribution_build_number: [
+                            order: "desc"
+                        ],
+                        rc_number: [
+                            order: "desc"
+                        ]
+                    ]
+                ],
+                size: 1,
+                query: [
+                    bool: [
+                        filter: [
+                            [
+                                match_phrase: [
+                                    component: "${componentName}"
+                                ]
+                            ],
+                            [
+                                match_phrase: [
+                                    rc: "true"
+                                ]
+                            ],
+                            [
+                                match_phrase: [
+                                    version: "${this.version}"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+
+        if (rcNumber != null) {
+            queryMap = [
+                _source: "distribution_build_number",
+                sort: [
+                    [
+                        distribution_build_number: [
+                            order: "desc"
+                        ]
+                    ]
+                ],
+                size: 1,
+                query: [
+                    bool: [
+                        filter: [
+                            [
+                                match_phrase: [
+                                    component: "${componentName}"
+                                ]
+                            ],
+                            [
+                                match_phrase: [
+                                    rc: "true"
+                                ]
+                            ],
+                            [
+                                match_phrase: [
+                                    version: "${this.version}"
+                                ]
+                            ],
+                            [
+                                match_phrase: [
+                                    rc_number: "${rcNumber}"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        }
+
+        def query = JsonOutput.toJson(queryMap)
+        return query.replace('"', '\\"')
+    }
+
+    def getLatestRcNumberQuery(String componentName){
+        def queryMap = [
+                _source: "rc_number",
+                sort: [
+                        [
+                                distribution_build_number: [
+                                        order: "desc"
+                                ],
+                                rc_number: [
+                                        order: "desc"
+                                ]
+                        ]
+                ],
+                size: 1,
+                query: [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        component: "${componentName}"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        rc: "true"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        version: "${this.version}"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ]
+        ]
+        def query = JsonOutput.toJson(queryMap)
+        return query.replace('"', '\\"')
+    }
+
+    def getRcDistributionNumber(Integer rcNumber = null, String componentName) {
+         def jsonResponse = this.openSearchMetricsQuery.fetchMetrics(getRcDistributionNumberQuery(rcNumber, componentName))
+         def rcDistributionNumber = jsonResponse.hits.hits[0]._source.distribution_build_number
+         return rcDistributionNumber
+    }
+
+    def getLatestRcNumber(String componentName) {
+        def jsonResponse = this.openSearchMetricsQuery.fetchMetrics(getLatestRcNumberQuery(componentName))
+        def rcNumber = jsonResponse.hits.hits[0]._source.rc_number
+        return rcNumber
+    }
+
+}

--- a/tests/jenkins/TestAddRcDetailsComment.groovy
+++ b/tests/jenkins/TestAddRcDetailsComment.groovy
@@ -1,0 +1,254 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.MatcherAssert.assertThat
+
+class TestAddRcDetailsComment extends BuildPipelineTest {
+
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('withCredentials', [Map])
+        helper.registerAllowedMethod('sleep', [Map])
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken'
+        ])
+        helper.registerAllowedMethod('withCredentials', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        def releaseIssueResponse = '''
+                    {
+                    
+                      "took": 5,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 11,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch_release_metrics",
+                            "_id": "86739a31-40db-320f-b52c-d38d50e179bc",
+                            "_score": null,
+                            "_source": {
+                              "release_issue": "https://github.com/opensearch-project/opensearch-build/issues/5152"
+                            },
+                            "sort": [
+                              1738963520807
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                    '''
+
+        def osLatestRcResponse = '''
+                    {
+                      "took": 16,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 40,
+                        "successful": 40,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 11,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch-distribution-build-results-02-2025",
+                            "_id": "xAsw15QB2OP_jOaCGo2o",
+                            "_score": null,
+                            "_source": {
+                              "rc_number": 5
+                            },
+                            "sort": [
+                              10787,
+                              5
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                    '''
+
+        def osdLatestRcResponse = '''
+                    {
+                      "took": 15,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 40,
+                        "successful": 40,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 14,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch-distribution-build-results-02-2025",
+                            "_id": "5MSv3pQBhoDV_8ni75zx",
+                            "_score": null,
+                            "_source": {
+                              "rc_number": 5
+                            },
+                            "sort": [
+                              8260,
+                              5
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                    '''
+
+        def osRcDistributionNumberResponse = '''
+                     {
+                      "took": 16,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 40,
+                        "successful": 40,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 1,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch-distribution-build-results-02-2025",
+                            "_id": "xAsw15QB2OP_jOaCGo2o",
+                            "_score": null,
+                            "_source": {
+                              "distribution_build_number": 10787
+                            },
+                            "sort": [
+                              10787
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                    '''
+
+        def osdRcDistributionNumberResponse = '''
+                    {
+                      "took": 16,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 40,
+                        "successful": 40,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 4,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch-distribution-build-results-02-2025",
+                            "_id": "5MSv3pQBhoDV_8ni75zx",
+                            "_score": null,
+                            "_source": {
+                              "distribution_build_number": 8260
+                            },
+                            "sort": [
+                              8260
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                    '''
+
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch_release_metrics/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}},{\\"match_phrase\\":{\\"repository\\":\\"opensearch-build\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+            return [stdout: releaseIssueResponse, exitValue: 0]
+        }
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-distribution-build-results/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"_source\\":\\"rc_number\\",\\"sort\\":[{\\"distribution_build_number\\":{\\"order\\":\\"desc\\"},\\"rc_number\\":{\\"order\\":\\"desc\\"}}],\\"size\\":1,\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"rc\\":\\"true\\"}},{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}}]}}}\" | jq '.'\n        """) { script ->
+            return [stdout: osLatestRcResponse, exitValue: 0]
+        }
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-distribution-build-results/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"_source\\":\\"rc_number\\",\\"sort\\":[{\\"distribution_build_number\\":{\\"order\\":\\"desc\\"},\\"rc_number\\":{\\"order\\":\\"desc\\"}}],\\"size\\":1,\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component\\":\\"OpenSearch-Dashboards\\"}},{\\"match_phrase\\":{\\"rc\\":\\"true\\"}},{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}}]}}}\" | jq '.'\n        """) { script ->
+            return [stdout: osdLatestRcResponse, exitValue: 0]
+        }
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-distribution-build-results/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"_source\\":\\"distribution_build_number\\",\\"sort\\":[{\\"distribution_build_number\\":{\\"order\\":\\"desc\\"}}],\\"size\\":1,\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"rc\\":\\"true\\"}},{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}},{\\"match_phrase\\":{\\"rc_number\\":\\"5\\"}}]}}}\" | jq '.'\n        """) { script ->
+            return [stdout: osRcDistributionNumberResponse, exitValue: 0]
+        }
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-distribution-build-results/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"_source\\":\\"distribution_build_number\\",\\"sort\\":[{\\"distribution_build_number\\":{\\"order\\":\\"desc\\"}}],\\"size\\":1,\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component\\":\\"OpenSearch-Dashboards\\"}},{\\"match_phrase\\":{\\"rc\\":\\"true\\"}},{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}},{\\"match_phrase\\":{\\"rc_number\\":\\"5\\"}}]}}}\" | jq '.'\n        """) { script ->
+            return [stdout: osdRcDistributionNumberResponse, exitValue: 0]
+        }
+    }
+
+    @Test
+    void testAddingComment() {
+        this.registerLibTester(new AddRcDetailsCommentLibTester('2.19.0'))
+        super.testPipeline('tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile')
+        assertThat(getCommands('sh', 'comment'), hasItem("{script=gh issue comment https://github.com/opensearch-project/opensearch-build/issues/5152 --body-file 'rc-details-comment-body.md', returnStdout=true}"))
+    }
+
+    @Test
+    void testCommentContent() {
+        this.registerLibTester(new AddRcDetailsCommentLibTester('2.19.0'))
+        runScript('tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile')
+        def fileContent = getCommands('writeFile', 'OpenSearch')[0]
+        assertThat(fileContent, containsString("{file=rc-details-comment-body.md, text=## See OpenSearch RC 5 and OpenSearch-Dashboards RC 5 details"))
+        assertThat(fileContent, containsString("OpenSearch 10787 and OpenSearch-Dashboards 8260 is ready for your test."))
+        assertThat(fileContent, containsString("image: opensearchstaging/opensearch:2.19.0.1078"))
+        assertThat(fileContent, containsString("image: opensearchstaging/opensearch-dashboards:2.19.0.8260"))
+    }
+
+    def getCommands(method, text) {
+        def shCommands = helper.callStack.findAll { call ->
+            call.methodName == method
+        }.collect { call ->
+            callArgsToString(call)
+        }.findAll { command ->
+            command.contains(text)
+        }
+        return shCommands
+    }
+}

--- a/tests/jenkins/TestReleaseCandidateStatus.groovy
+++ b/tests/jenkins/TestReleaseCandidateStatus.groovy
@@ -1,0 +1,250 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+import org.junit.*
+import groovy.json.JsonOutput
+import jenkins.ReleaseCandidateStatus
+import groovy.json.JsonSlurper
+
+
+class TestReleaseCandidateStatus {
+    private ReleaseCandidateStatus releaseCandidateStatus
+    private final String metricsUrl = 'http://example.com'
+    private final String awsAccessKey = 'testAccessKey'
+    private final String awsSecretKey = 'testSecretKey'
+    private final String awsSessionToken = 'testSessionToken'
+    private final String buildIndexName = 'opensearch-distribution-build-results'
+    private final String version = "2.19.0"
+    private def script
+
+
+    @Before
+    void setUp() {
+        releaseCandidateStatus = new ReleaseCandidateStatus(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, buildIndexName, version, script)
+    }
+
+    @Test
+    void testGetRcDistributionNumberQuery() {
+        String defaultExpectedOutput = JsonOutput.toJson([
+                _source: "distribution_build_number",
+                sort   : [
+                        [
+                                distribution_build_number: [
+                                        order: "desc"
+                                ],
+                                rc_number                : [
+                                        order: "desc"
+                                ]
+                        ]
+                ],
+                size   : 1,
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        component: "OpenSearch"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        rc: "true"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        version: "${version}"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ]
+        ]).replace('"', '\\"')
+        def defaultQueryResult = releaseCandidateStatus.getRcDistributionNumberQuery('OpenSearch')
+        assert defaultExpectedOutput == defaultQueryResult
+
+        String expectedOutputWithRcNumber = JsonOutput.toJson([
+                _source: "distribution_build_number",
+                sort   : [
+                        [
+                                distribution_build_number: [
+                                        order: "desc"
+                                ]
+                        ]
+                ],
+                size   : 1,
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        component: "OpenSearch"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        rc: "true"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        version: "${this.version}"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        rc_number: "9"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ]
+        ]).replace('"', '\\"')
+        def queryResultWithRc = releaseCandidateStatus.getRcDistributionNumberQuery(9, 'OpenSearch')
+        assert queryResultWithRc == expectedOutputWithRcNumber
+    }
+
+    @Test
+    void testGetLatestRcNumberQuery() {
+        String expectedOutput = JsonOutput.toJson([
+                _source: "rc_number",
+                sort   : [
+                        [
+                                distribution_build_number: [
+                                        order: "desc"
+                                ],
+                                rc_number                : [
+                                        order: "desc"
+                                ]
+                        ]
+                ],
+                size   : 1,
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        component: "OpenSearch"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        rc: "true"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        version: "${this.version}"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ]
+        ]).replace('"', '\\"')
+        def queryResult = releaseCandidateStatus.getLatestRcNumberQuery('OpenSearch')
+        assert queryResult == expectedOutput
+    }
+
+    @Test
+    void testGetRcDistributionNumber() {
+        def responseText = """
+                    {
+                      "took": 16,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 40,
+                        "successful": 40,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 11,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch-distribution-build-results-02-2025",
+                            "_id": "xAsw15QB2OP_jOaCGo2o",
+                            "_score": null,
+                            "_source": {
+                              "distribution_build_number": 10787
+                            },
+                            "sort": [
+                              10787,
+                              5
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                """
+        script = new Expando()
+        script.sh = { Map args ->
+            if (args.containsKey("script")) {
+                return responseText
+            }
+        }
+        ReleaseCandidateStatus releaseCandidateStatusOb = new ReleaseCandidateStatus(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, buildIndexName, version, script)
+        def expectedOutput = 10787
+        def result = releaseCandidateStatusOb.getRcDistributionNumber('OpenSearch')
+        assert result == expectedOutput
+    }
+
+    @Test
+    void testGetLatestRcNumber() {
+        def responseText = """
+                {
+                  "took": 15,
+                  "timed_out": false,
+                  "_shards": {
+                    "total": 40,
+                    "successful": 40,
+                    "skipped": 0,
+                    "failed": 0
+                  },
+                  "hits": {
+                    "total": {
+                      "value": 11,
+                      "relation": "eq"
+                    },
+                    "max_score": null,
+                    "hits": [
+                      {
+                        "_index": "opensearch-distribution-build-results-02-2025",
+                        "_id": "LDU115QBOi-lzDIlXPa2",
+                        "_score": null,
+                        "_source": {
+                          "rc_number": 5
+                        },
+                        "sort": [
+                          1738771668769,
+                          5
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """
+        script = new Expando()
+        script.sh = { Map args ->
+            if (args.containsKey("script")) {
+                return responseText
+            }
+        }
+        ReleaseCandidateStatus releaseCandidateStatusOb = new ReleaseCandidateStatus(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, buildIndexName, version, script)
+        def expectedOutput = 5
+        def result = releaseCandidateStatusOb.getLatestRcNumber('OpenSearch')
+        assert result == expectedOutput
+
+    }
+}

--- a/tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile
+++ b/tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile
@@ -1,0 +1,23 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+
+ The OpenSearch Contributors require contributions made to
+ this file be licensed under the Apache-2.0 license or a
+ compatible open source license.
+*/
+
+pipeline {
+    agent none
+    stages {
+        stage('addRCcommentToGHIssue') {
+            steps {
+                script {
+                    addRcDetailsComment(
+                        version: '2.19.0'
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile.txt
+++ b/tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile.txt
@@ -1,0 +1,186 @@
+   AddRcDetailsComment.run()
+      AddRcDetailsComment.pipeline(groovy.lang.Closure)
+         AddRcDetailsComment.echo(Executing on agent [label:none])
+         AddRcDetailsComment.stage(addRCcommentToGHIssue, groovy.lang.Closure)
+            AddRcDetailsComment.script(groovy.lang.Closure)
+               AddRcDetailsComment.addRcDetailsComment({version=2.19.0})
+                  addRcDetailsComment.string({credentialsId=jenkins-health-metrics-account-number, variable=METRICS_HOST_ACCOUNT})
+                  addRcDetailsComment.string({credentialsId=jenkins-health-metrics-cluster-endpoint, variable=METRICS_HOST_URL})
+                  addRcDetailsComment.withCredentials([METRICS_HOST_ACCOUNT, METRICS_HOST_URL], groovy.lang.Closure)
+                     addRcDetailsComment.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                        ReleaseMetricsData.getReleaseIssue(opensearch-build)
+                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"repository\":\"opensearch-build\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              addRcDetailsComment.println(Running query: {\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"repository\":\"opensearch-build\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              addRcDetailsComment.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"repository\":\"opensearch-build\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+        , returnStdout=true})
+                        ReleaseCandidateStatus.getLatestRcNumber(OpenSearch)
+                           OpenSearchMetricsQuery.fetchMetrics({\"_source\":\"rc_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"},\"rc_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}}]}}})
+                              addRcDetailsComment.println(Running query: {\"_source\":\"rc_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"},\"rc_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}}]}}})
+                              addRcDetailsComment.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch-distribution-build-results/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"_source\":\"rc_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"},\"rc_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}}]}}}" | jq '.'
+        , returnStdout=true})
+                        ReleaseCandidateStatus.getLatestRcNumber(OpenSearch-Dashboards)
+                           OpenSearchMetricsQuery.fetchMetrics({\"_source\":\"rc_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"},\"rc_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}}]}}})
+                              addRcDetailsComment.println(Running query: {\"_source\":\"rc_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"},\"rc_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}}]}}})
+                              addRcDetailsComment.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch-distribution-build-results/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"_source\":\"rc_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"},\"rc_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}}]}}}" | jq '.'
+        , returnStdout=true})
+                        ReleaseCandidateStatus.getRcDistributionNumber(5, OpenSearch)
+                           OpenSearchMetricsQuery.fetchMetrics({\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}})
+                              addRcDetailsComment.println(Running query: {\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}})
+                              addRcDetailsComment.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch-distribution-build-results/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}}" | jq '.'
+        , returnStdout=true})
+                        ReleaseCandidateStatus.getRcDistributionNumber(5, OpenSearch-Dashboards)
+                           OpenSearchMetricsQuery.fetchMetrics({\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}})
+                              addRcDetailsComment.println(Running query: {\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}})
+                              addRcDetailsComment.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch-distribution-build-results/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}}" | jq '.'
+        , returnStdout=true})
+                  addRcDetailsComment.libraryResource(release/rc-details-template.md)
+                  addRcDetailsComment.writeFile({file=rc-details-comment-body.md, text=## See OpenSearch RC 5 and OpenSearch-Dashboards RC 5 details
+<details><summary>OpenSearch 5 and OpenSearch-Dashboards 5 details</summary>
+<p>
+ ## OpenSearch 10787 and OpenSearch-Dashboards 8260 is ready for your test.
+
+OpenSearch - [Build 10787](https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch/detail/distribution-build-opensearch/10787/pipeline)
+OpenSearch Dashboards - [Build 8260](https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch-dashboards/detail/distribution-build-opensearch-dashboards/8260/pipeline)
+
+- Use the following Docker-Compose to setup a cluster
+  <details><summary>docker-compose.yml</summary>
+  <p>
+    <pre>
+    <code>
+  version: '3'
+  services:
+    opensearch-node1:
+      image: opensearchstaging/opensearch:2.19.0.10787
+      container_name: opensearch-node1
+      environment:
+        - cluster.name=opensearch-cluster
+        - node.name=opensearch-node1
+        - discovery.seed_hosts=opensearch-node1,opensearch-node2
+        - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+        - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+          hard: 65536
+      volumes:
+        - opensearch-data1:/usr/share/opensearch/data
+      ports:
+        - 9200:9200
+        - 9600:9600 # required for Performance Analyzer
+      networks:
+        - opensearch-net
+    opensearch-node2:
+      image: opensearchstaging/opensearch:2.19.0.10787
+      container_name: opensearch-node2
+      environment:
+        - cluster.name=opensearch-cluster
+        - node.name=opensearch-node2
+        - discovery.seed_hosts=opensearch-node1,opensearch-node2
+        - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+        - bootstrap.memory_lock=true
+        - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+        nofile:
+          soft: 65536
+          hard: 65536
+      volumes:
+        - opensearch-data2:/usr/share/opensearch/data
+      networks:
+        - opensearch-net
+    opensearch-dashboards:
+      image: opensearchstaging/opensearch-dashboards:2.19.0.8260
+      container_name: opensearch-dashboards
+      ports:
+        - 5601:5601
+      expose:
+        - "5601"
+      environment:
+        OPENSEARCH_HOSTS: '["https://opensearch-node1:9200","https://opensearch-node2:9200"]'
+      networks:
+        - opensearch-net
+  volumes:
+    opensearch-data1:
+    opensearch-data2:
+
+  networks:
+  opensearch-net:
+  </code>
+  </pre>
+
+  </p>
+  </details>
+
+    + Download the above docker-compose.yml on your machine.
+    + Get latest image versions `docker-compose pull`.
+    + Start the cluster `docker-compose up`.
+
+- [OpenSearch docker 2.19.0.10787](https://hub.docker.com/r/opensearchstaging/opensearch/tags?page=1&name=2.19.0.10787)
+    + Start without security
+        - Docker command `docker pull opensearchstaging/opensearch:2.19.0.10787 && docker run -it -p 9200:9200 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" opensearchstaging/opensearch:2.19.0.10787`
+        - Connect command `curl http://localhost:9200/`
+    + Start with security
+        - Docker command
+      ```
+      docker pull opensearchstaging/opensearch:2.19.0.10787 && docker run -it -p 9200:9200 -e "discovery.type=single-node" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" opensearchstaging/opensearch:2.19.0.10787
+      ```
+        - Connect command `curl --insecure 'https://admin:myStrongPassword123!@localhost:9200/'`
+- [OpenSearch-Dashboards docker 2.19.0.8260](https://hub.docker.com/r/opensearchstaging/opensearch-dashboards/tags?page=1&name=2.19.0.8260)
+    + Start without security
+        - Docker command `docker pull opensearchstaging/opensearch-dashboards:2.19.0.8260 && docker run -it --network="host" -e "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" opensearchstaging/opensearch-dashboards:2.19.0.8260`
+        - URL `http://localhost:5601/`
+    + Start with security
+        - Docker command `docker pull opensearchstaging/opensearch-dashboards:2.19.0.8260 && docker run -it --network="host" opensearchstaging/opensearch-dashboards:2.19.0.8260`
+        - URL `http://localhost:5601/`
+
+- Use TARs to deploy OpenSearch Manually
+    + OpenSearch - Build 10787 (Note: Windows version does not have performance analyzer plugin)
+        * arm64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/arm64/tar/dist/opensearch/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/arm64/tar/dist/opensearch/opensearch-2.19.0-linux-arm64.tar.gz)] [[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/arm64/rpm/dist/opensearch/opensearch-2.19.0-linux-arm64.rpm)][[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/arm64/deb/dist/opensearch/opensearch-2.19.0-linux-arm64.deb)]
+        * x64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/x64/tar/dist/opensearch/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/x64/tar/dist/opensearch/opensearch-2.19.0-linux-x64.tar.gz)] [[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/x64/rpm/dist/opensearch/opensearch-2.19.0-linux-x64.rpm)] [[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/linux/x64/deb/dist/opensearch/opensearch-2.19.0-linux-x64.deb)] [[windows](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.0/10787/windows/x64/zip/dist/opensearch/opensearch-2.19.0-windows-x64.zip)]
+
+
++ OpenSearch Dashboards - Build 8260
+    * arm64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/arm64/tar/dist/opensearch-dashboards/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/arm64/tar/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-linux-arm64.tar.gz)][[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/arm64/rpm/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-linux-arm64.rpm)][[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/arm64/deb/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-linux-arm64.deb)]
+    * x64 [[manifest](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/x64/tar/dist/opensearch-dashboards/manifest.yml)] [[tar](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-linux-x64.tar.gz)][[rpm](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/x64/rpm/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-linux-x64.rpm)] [[deb](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/linux/x64/deb/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-linux-x64.deb)] [[windows](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.19.0/8260/windows/x64/zip/dist/opensearch-dashboards/opensearch-dashboards-2.19.0-windows-x64.zip)]
+
+
+_Check how to install [opensearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/) and [dashboards](https://opensearch.org/docs/latest/install-and-configure/install-dashboards/index/) on different platforms_
+
+## Integration Test Results
+
+- Use the https://metrics.opensearch.org/_dashboards/goto/9ed74dd90eb31c7b83f3542e43328088?security_tenant=global.
+
+- Filter by the `distribution_build_number`. Use **10787** for OpenSearch and **8260** for OpenSearch Dashboards.
+  Example when filtered with **10787** we can see all the passed/failed OpenSearch components. Check the metrics [here](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/21aad140-49f6-11ef-bbdd-39a9b324a5aa?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now%2Fw,to:now%2Fw))&_a=(description:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',filters:!(('\$state':(store:appState),meta:(alias:!n,controlledBy:'1721852613904',disabled:!f,index:'16f55f10-4977-11ef-8565-15a1562cd0a0',key:version,negate:!f,params:(query:'2.19.0'),type:phrase),query:(match_phrase:(version:'2.19.0'))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'23eb6520-4977-11ef-bbdd-39a9b324a5aa',key:distribution_build_number,negate:!f,params:!('10787','%208260'),type:phrases,value:'10787,%20%208260'),query:(bool:(minimum_should_match:1,should:!((match_phrase:(distribution_build_number:'10787')),(match_phrase:(distribution_build_number:'%208260')))))),('\$state':(store:appState),meta:(alias:!n,controlledBy:'1722482131538',disabled:!f,index:'16f55f10-4977-11ef-8565-15a1562cd0a0',key:rc_number,negate:!f,params:(query:4),type:phrase),query:(match_phrase:(rc_number:4)))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',viewMode:view)).
+
+- Find the list of the created **AUTOCUT** issues here https://github.com/issues?page=1&q=is%3Aopen+is%3Aissue+user%3Aopensearch-project+label%3Av2.19.0+label%3Aautocut+%5BAUTOCUT%5D+in%3Atitle.
+
+Thank you
+</p>
+</details>
+})
+                  addRcDetailsComment.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                  addRcDetailsComment.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                     addRcDetailsComment.println(Adding RC details to the release issue as a comment.)
+                     addRcDetailsComment.sh({script=gh issue comment https://github.com/opensearch-project/opensearch-build/issues/5152 --body-file 'rc-details-comment-body.md', returnStdout=true})

--- a/tests/jenkins/lib-testers/AddRcDetailsCommentLibTester.groovy
+++ b/tests/jenkins/lib-testers/AddRcDetailsCommentLibTester.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.CoreMatchers.nullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class AddRcDetailsCommentLibTester extends LibFunctionTester{
+    private String version
+    private Integer opensearchRcNumber = 5
+    private Integer opensearchDashboardsRcNumber = 5
+
+    public AddRcDetailsCommentLibTester(version){
+        this.version = version
+    }
+
+    public AddRcDetailsCommentLibTester(version, opensearchRcNumber, opensearchDashboardsRcNumber){
+        this.version = version
+        this.opensearchRcNumber = opensearchRcNumber
+        this.opensearchDashboardsRcNumber = opensearchDashboardsRcNumber
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'addRcDetailsComment'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        assertThat(call.args.version.first(), notNullValue())
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.version.first().equals(this.version)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {}
+}

--- a/vars/addRcDetailsComment.groovy
+++ b/vars/addRcDetailsComment.groovy
@@ -54,8 +54,18 @@ void call(Map args = [:]) {
             OPENSEARCH_RC_BUILD_NUMBER: opensearchRcBuildNumber,
             OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER: opensearchDashboardsRcBuildNumber
     ]
+    println('Retrieved values: '+ rcValues)
 
     try {
+        // Check for null or empty values
+        def nullOrEmptyKeys = rcValues.findAll { k, v ->
+            v == null || (v instanceof String && v.trim().isEmpty())
+        }.keySet()
+
+        if (nullOrEmptyKeys) {
+            error "Following required values are null or empty: ${nullOrEmptyKeys.join(', ')}"
+        }
+
         // Load RC details template content
         def templateContent = libraryResource "release/rc-details-template.md"
 

--- a/vars/addRcDetailsComment.groovy
+++ b/vars/addRcDetailsComment.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import jenkins.ReleaseCandidateStatus
+import jenkins.ReleaseMetricsData
+
+/** Library to add Release Candidate Details to the release issue
+ *  @param Map args = [:] args A map of the following parameters
+ *  @param args.version <required> - Release version.
+ *  @param args.opensearchRcNumber <optional> - OpenSearch RC number. eg: 5. Defaults to latest RC number
+ *  @param args.opensearchDashboardsRcNumber <optional> - OpenSearch-Dashboards RC number. eg: 5. Defaults to latest RC number
+ * */
+void call(Map args = [:]) {
+    def buildIndexName = 'opensearch-distribution-build-results'
+    def version = args.version
+    def opensearchRcNumber
+    def opensearchDashboardsRcNumber
+    def opensearchRcBuildNumber
+    def opensearchDashboardsRcBuildNumber
+    def releaseIssueUrl
+
+    if (version.isEmpty()){
+        error('version is required to get RC details.')
+    }
+    withCredentials([
+            string(credentialsId: 'jenkins-health-metrics-account-number', variable: 'METRICS_HOST_ACCOUNT'),
+            string(credentialsId: 'jenkins-health-metrics-cluster-endpoint', variable: 'METRICS_HOST_URL')]) {
+        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+            def metricsUrl = env.METRICS_HOST_URL
+            def awsAccessKey = env.AWS_ACCESS_KEY_ID
+            def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+            def awsSessionToken = env.AWS_SESSION_TOKEN
+
+            ReleaseCandidateStatus releaseCandidateStatus = new ReleaseCandidateStatus(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, buildIndexName, version, this)
+            ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
+
+            releaseIssueUrl = releaseMetricsData.getReleaseIssue('opensearch-build')
+            opensearchRcNumber = args.opensearchRcNumber ?: releaseCandidateStatus.getLatestRcNumber('OpenSearch')
+            opensearchDashboardsRcNumber = args.opensearchDashboardsRcNumber ?: releaseCandidateStatus.getLatestRcNumber('OpenSearch-Dashboards')
+            opensearchRcBuildNumber = releaseCandidateStatus.getRcDistributionNumber(opensearchRcNumber, 'OpenSearch').toString()
+            opensearchDashboardsRcBuildNumber = releaseCandidateStatus.getRcDistributionNumber(opensearchDashboardsRcNumber, 'OpenSearch-Dashboards').toString()
+        }
+    }
+
+    def rcValues = [
+            VERSION: version,
+            OPENSEARCH_RC_NUMBER: opensearchRcNumber,
+            OPENSEARCH_DASHBOARDS_RC_NUMBER: opensearchDashboardsRcNumber,
+            OPENSEARCH_RC_BUILD_NUMBER: opensearchRcBuildNumber,
+            OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER: opensearchDashboardsRcBuildNumber
+    ]
+
+    try {
+        // Load RC details template content
+        def templateContent = libraryResource "release/rc-details-template.md"
+
+        // Create binding for template variables
+        def binding = [:]
+        rcValues.each { k, v -> binding[k] = v }
+
+        // Process template using simple string replacement
+        def processedContent = templateContent
+        binding.each { key, value ->
+            processedContent = processedContent.replace('${' + key + '}', value.toString())
+        }
+
+        // Write the processed content
+        writeFile(file: "rc-details-comment-body.md", text: processedContent)
+    } catch (Exception e) {
+        error "Failed to process template: ${e.getMessage()}"
+    }
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        println('Adding RC details to the release issue as a comment.')
+        sh(
+                script: "gh issue comment ${releaseIssueUrl} --body-file 'rc-details-comment-body.md'",
+                returnStdout: true
+        )
+    }
+}

--- a/vars/updateIntegTestFailureIssues.groovy
+++ b/vars/updateIntegTestFailureIssues.groovy
@@ -38,7 +38,7 @@ void call(Map args = [:]) {
             def awsSessionToken = env.AWS_SESSION_TOKEN
             def distributionBuildNumber = args.distributionBuildNumber ?: new ComponentBuildStatus(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, buildIndexName, product, version, this).getLatestDistributionBuildNumber().toString()
             ComponentIntegTestStatus componentIntegTestStatus = new ComponentIntegTestStatus(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, integTestIndexName, product, version, distributionBuildNumber, this)
-            ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, releaseIndexName, version, this)
+            ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, releaseIndexName, this)
             println('Distribution Build Number: ' + distributionBuildNumber)
             passedComponents = componentIntegTestStatus.getComponents('passed')
             failedComponents = componentIntegTestStatus.getComponents('failed')


### PR DESCRIPTION
### Description
This change retrieves the RC number (if one not provided) from the metrics cluster indexed data, retrieves opensearch-build release issue number, RC build number of both OS and OSD and adds a comment in the markdown format with retrieved details. See the [template](https://github.com/gaiksaya/opensearch-build-libraries/blob/ae2f0f94b5a4c3609e0be966a139e4c65fca1a0a/resources/release/rc-details-template.md).
See the [sample comment](https://github.com/gaiksaya/opensearch-build/issues/49#issuecomment-2649122181) that will be posted. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5022

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
