### PR TITLE
Refactor exclusive type to Optional typing

### DIFF
--- a/src/jenkins/ReleaseCandidateStatus.groovy
+++ b/src/jenkins/ReleaseCandidateStatus.groovy
@@ -20,7 +20,7 @@ class ReleaseCandidateStatus {
     String indexName
     String version
     def script
-    OpenSearchMetricsQuery openSearchMetricsQuery
+    def openSearchMetricsQuery
 
     ReleaseCandidateStatus(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String indexName, String version, def script) {
         this.metricsUrl = metricsUrl

--- a/src/jenkins/ReleaseMetricsData.groovy
+++ b/src/jenkins/ReleaseMetricsData.groovy
@@ -21,7 +21,7 @@ class ReleaseMetricsData {
     String version
     String indexName
     def script
-    OpenSearchMetricsQuery openSearchMetricsQuery
+    def openSearchMetricsQuery
 
     ReleaseMetricsData(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String version, def script) {
         this.metricsUrl = metricsUrl


### PR DESCRIPTION
### Description
After thorough debugging, as to why the groovy tests were hanging in build-repo (atleast in local), looks like class loading was the issue. Even though both classes `ReleaseMetricsData` and `ReleaseCandidateStatus` do not depend on each other in anyway, specifying explicit type `OpenSearchMetricsQuery` in field declarations was causing the issue. 

Changed it to `def` which just treats it as a generic Object. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
