### PR TITLE
Add communication templates

### DIFF
--- a/resources/release/criteria-not-met-template.md
+++ b/resources/release/criteria-not-met-template.md
@@ -1,7 +1,7 @@
 Hi ${RELEASE_OWNER}, </br>
 
 The below ${TYPE_OF_CRITERIA} criteria for your component has not been met. </br>
-Please review the issue and address it as soon as possible. </br>
+Please review the issue and address it with high priority. </br>
 
 ${CRITERIA}
 

--- a/resources/release/criteria-not-met-template.md
+++ b/resources/release/criteria-not-met-template.md
@@ -1,0 +1,8 @@
+Hi ${RELEASE_OWNER}, </br>
+
+The below ${TYPE_OF_CRITERIA} criteria for your component has not been met. </br>
+Please review the issue and address it as soon as possible. </br>
+
+${CRITERIA}
+
+Thanks!

--- a/resources/release/release-announcement-template.md
+++ b/resources/release/release-announcement-template.md
@@ -1,0 +1,11 @@
+We're excited to announce the release of OpenSearch ${RELEASE_VERSION}! :tada:! </br>
+
+• Download: https://opensearch.org/downloads.html </br>
+• Release Notes: https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-${RELEASE_VERSION}.md </br>
+• Documentation: https://opensearch.org/docs/latest/about/ </br>
+For detailed information about what's new, check out our blog post: https://www.opensearch.org/blog/explore-OpenSearch-2-19/ </br>
+
+Thanks everyone for the help to release OpenSearch and OpenSearch Dashboards ${RELEASE_VERSION}. </br>
+Component repo owners please create a github release based on the tags of ${RELEASE_VERSION}.0. </br>
+
+Here is the retrospective issue ${RELEASE_RETRO_ISSUE_LINK} for the release. Please feel free to share your valuable feedback to help us make improvements for the upcoming releases.

--- a/resources/release/release-owner-assignment-template.md
+++ b/resources/release/release-owner-assignment-template.md
@@ -1,6 +1,6 @@
 Hi ${RELEASE_OWNER}, </br>
 
-Since no one has volunteered to take on the role of release owner for this component, we are randomly selecting you to be the release owner. </br>
+Since this component currently does not have a release owner, we will assign you to this role for the time being! </br>
 If you feel this should be reassigned, please feel free to delegate it to the appropriate maintainer. </br>
 
 Thank you!

--- a/resources/release/release-owner-assignment-template.md
+++ b/resources/release/release-owner-assignment-template.md
@@ -1,0 +1,6 @@
+Hi ${RELEASE_OWNER}, </br>
+
+Since no one has volunteered to take on the role of release owner for this component, we are randomly selecting you to be the release owner. </br>
+If you feel this should be reassigned, please feel free to delegate it to the appropriate maintainer. </br>
+
+Thank you!

--- a/resources/release/request-release-owner-template.md
+++ b/resources/release/request-release-owner-template.md
@@ -3,4 +3,4 @@ Hi ${LIST_OF_MAINTAINERS}, </br>
 Could someone kindly volunteer to take on the role of release owner for this component in order to meet the [entrance criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window) ? </br>
 If no one is able to take it on, we may need to assign someone randomly before the release window opens. </br>
 
-Thanks in advance for your help!
+Thank you in advance for your help!

--- a/resources/release/request-release-owner-template.md
+++ b/resources/release/request-release-owner-template.md
@@ -1,0 +1,6 @@
+Hi ${LIST_OF_MAINTAINERS}, </br>
+
+Could someone kindly volunteer to take on the role of release owner for this component in order to meet the [entrance criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window) ? </br>
+If no one is able to take it on, we may need to assign someone randomly before the release window opens. </br>
+
+Thanks in advance for your help!


### PR DESCRIPTION
### Description
Add communication templates that will be used in automations to communicate release updates. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5329

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
