### PR TITLE
Update trivy image scan cleanup commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.2.1'
+String version = '8.2.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/jobs/ScanDockerImage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/ScanDockerImage_Jenkinsfile.txt
@@ -6,7 +6,7 @@
                ScanDockerImage_Jenkinsfile.scanDockerImage({imageFullName=opensearchstaging/opensearch:2.0.0, imageResultFile=scan_docker_image})
                   scanDockerImage.sh(
         touch scan_docker_image.txt scan_docker_image.json
-        trivy image --clear-cache
+        trivy clean --all
         docker rmi `docker images -f "dangling=true" -q` || echo
         docker rmi opensearchstaging/opensearch:2.0.0 || echo
         trivy image --format table --output scan_docker_image.txt opensearchstaging/opensearch:2.0.0

--- a/vars/scanDockerImage.groovy
+++ b/vars/scanDockerImage.groovy
@@ -10,7 +10,7 @@ void call(Map args = [:]) {
 
     sh """
         touch ${args.imageResultFile}.txt ${args.imageResultFile}.json
-        trivy image --clear-cache
+        trivy clean --all
         docker rmi `docker images -f "dangling=true" -q` || echo
         docker rmi ${args.imageFullName} || echo
         trivy image --format table --output ${args.imageResultFile}.txt ${args.imageFullName}


### PR DESCRIPTION
### Description
Update trivy image scan cleanup commands
Trivy recently replace the old cleanup commands in newer versions: https://github.com/aquasecurity/trivy/issues/6992

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
