### PR TITLE
Upgrade junit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ sharedLibrary {
         dependency('org.jenkins-ci.plugins', 'script-security', '1229.v4880b_b_e905a_6')
         dependency('org.jenkins-ci.plugins', 'credentials', '1112.vc87b_7a_3597f6')
         dependency('org.jenkins-ci.plugins', 'git-client', '3.11.1')
-        dependency('org.jenkins-ci.plugins', 'junit', '1166.1168.vd6b_8042a_06de')
+        dependency('org.jenkins-ci.plugins', 'junit', '1207.va_09d5100410f')
         dependency('org.jenkins-ci.plugins', 'mailer', '408.vd726a_1130320') // https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mailer/
     }
 }


### PR DESCRIPTION
### Description
Upgrade junit dependency to resolve a CVE. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/577

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
