### PR TITLE
Add 'null' string validation if null is returned on cigroups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.3.1'
+String version = '8.3.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/jobs/RunIntegTestScript_Jenkinsfile
+++ b/tests/jenkins/jobs/RunIntegTestScript_Jenkinsfile
@@ -17,8 +17,7 @@ pipeline {
                         jobName: 'dummy_job',
                         componentName: 'OpenSearch',
                         buildManifest: 'tests/data/opensearch-1.3.0-build.yml',
-                        testManifest: 'tests/data/opensearch-1.3.0-test.yml',
-                        ciGroup: ""
+                        testManifest: 'tests/data/opensearch-1.3.0-test.yml'
                     )
                 }
             }

--- a/tests/jenkins/jobs/RunIntegTestScript_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunIntegTestScript_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          RunIntegTestScript_Jenkinsfile.echo(Executing on agent [label:none])
          RunIntegTestScript_Jenkinsfile.stage(integ-test, groovy.lang.Closure)
             RunIntegTestScript_Jenkinsfile.script(groovy.lang.Closure)
-               RunIntegTestScript_Jenkinsfile.runIntegTestScript({jobName=dummy_job, componentName=OpenSearch, buildManifest=tests/data/opensearch-1.3.0-build.yml, testManifest=tests/data/opensearch-1.3.0-test.yml, ciGroup=})
+               RunIntegTestScript_Jenkinsfile.runIntegTestScript({jobName=dummy_job, componentName=OpenSearch, buildManifest=tests/data/opensearch-1.3.0-build.yml, testManifest=tests/data/opensearch-1.3.0-test.yml})
                   runIntegTestScript.legacySCM(groovy.lang.Closure)
                   runIntegTestScript.library({identifier=jenkins@main, retriever=null})
                   runIntegTestScript.readYaml({file=tests/data/opensearch-1.3.0-build.yml})

--- a/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Jenkinsfile
+++ b/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Jenkinsfile
@@ -18,8 +18,7 @@ pipeline {
                         componentName: 'OpenSearch-Dashboards',
                         buildManifest: 'tests/data/opensearch-dashboards-1.2.0-build.yml',
                         testManifest: 'tests/data/opensearch-dashboards-1.2.0-test.yml',
-                        localPath: 'tests/jenkins/artifacts/tar',
-                        ciGroup: ""
+                        localPath: 'tests/jenkins/artifacts/tar'
                     )
                 }
             }

--- a/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          RunIntegTestScript_LocalPath_Jenkinsfile.echo(Executing on agent [label:none])
          RunIntegTestScript_LocalPath_Jenkinsfile.stage(integ-test, groovy.lang.Closure)
             RunIntegTestScript_LocalPath_Jenkinsfile.script(groovy.lang.Closure)
-               RunIntegTestScript_LocalPath_Jenkinsfile.runIntegTestScript({jobName=dummy_job, componentName=OpenSearch-Dashboards, buildManifest=tests/data/opensearch-dashboards-1.2.0-build.yml, testManifest=tests/data/opensearch-dashboards-1.2.0-test.yml, localPath=tests/jenkins/artifacts/tar, ciGroup=})
+               RunIntegTestScript_LocalPath_Jenkinsfile.runIntegTestScript({jobName=dummy_job, componentName=OpenSearch-Dashboards, buildManifest=tests/data/opensearch-dashboards-1.2.0-build.yml, testManifest=tests/data/opensearch-dashboards-1.2.0-test.yml, localPath=tests/jenkins/artifacts/tar})
                   runIntegTestScript.legacySCM(groovy.lang.Closure)
                   runIntegTestScript.library({identifier=jenkins@main, retriever=null})
                   runIntegTestScript.readYaml({file=tests/data/opensearch-dashboards-1.2.0-build.yml})

--- a/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile
+++ b/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile
@@ -19,8 +19,7 @@ pipeline {
                         buildManifest: 'tests/data/opensearch-1.3.0-build.yml',
                         testManifest: 'tests/data/opensearch-1.3.0-test.yml',
                         localPath: 'tests/jenkins/artifacts/tar',
-                        switchUserNonRoot: 'true',
-                        ciGroup: ""
+                        switchUserNonRoot: 'true'
                     )
                 }
             }

--- a/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.echo(Executing on agent [label:none])
          RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.stage(integ-test, groovy.lang.Closure)
             RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.script(groovy.lang.Closure)
-               RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.runIntegTestScript({jobName=dummy_job, componentName=OpenSearch, buildManifest=tests/data/opensearch-1.3.0-build.yml, testManifest=tests/data/opensearch-1.3.0-test.yml, localPath=tests/jenkins/artifacts/tar, switchUserNonRoot=true, ciGroup=})
+               RunIntegTestScript_LocalPath_Switch_Non_Root_Jenkinsfile.runIntegTestScript({jobName=dummy_job, componentName=OpenSearch, buildManifest=tests/data/opensearch-1.3.0-build.yml, testManifest=tests/data/opensearch-1.3.0-test.yml, localPath=tests/jenkins/artifacts/tar, switchUserNonRoot=true})
                   runIntegTestScript.legacySCM(groovy.lang.Closure)
                   runIntegTestScript.library({identifier=jenkins@main, retriever=null})
                   runIntegTestScript.readYaml({file=tests/data/opensearch-1.3.0-build.yml})

--- a/vars/runIntegTestScript.groovy
+++ b/vars/runIntegTestScript.groovy
@@ -110,4 +110,4 @@ String generateBasePaths(buildManifest) {
     return ["${env.PUBLIC_ARTIFACT_URL}", "${env.JOB_NAME}", buildManifest.build.version, buildManifest.build.id, buildManifest.build.platform, buildManifest.build.architecture, buildManifest.build.distribution].join("/")
 }
 
-boolean isNullOrEmpty(String str) { return (str == null || str.allWhitespace || str.isEmpty()) }
+boolean isNullOrEmpty(String str) { return (str == null || str.allWhitespace || str.isEmpty() || str == 'null') }


### PR DESCRIPTION
### Description
Add 'null' string validation if null is returned on cigroups

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
