### PR TITLE
Fix regex serialization issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.3.2'
+String version = '8.3.3'
 
 task updateVersion {
     doLast {

--- a/vars/addRcDetailsComment.groovy
+++ b/vars/addRcDetailsComment.groovy
@@ -17,24 +17,22 @@ import jenkins.ReleaseMetricsData
  * */
 void call(Map args = [:]) {
     def buildIndexName = 'opensearch-distribution-build-results'
-    def version = args.version
-    def qualifier = "None"
-    def matcher = version =~ /^([\d.]+)(?:-(.+))?$/
-    if (matcher) {
-        version = matcher[0][1]  // Captures the numeric part (3.0.0)
-        qualifier = matcher[0][2] ?: "None" // Captures the qualifier (beta1) or None if no qualifier
-        // Explicitly null out the matcher after using it to avoid serialization issues with jenkins
-        matcher = null
+    if (args.version.isEmpty()){
+        error('version is required to get RC details.')
     }
+    def (version, qualifier) = { localVersion ->
+        def localMatcher = localVersion =~ /^([\d.]+)(?:-(.+))?$/
+        if (localMatcher) {
+            return [localMatcher[0][1], localMatcher[0][2] ?: "None"]
+        }
+        return [localVersion, "None"]
+    }(args.version)
     def opensearchRcNumber
     def opensearchDashboardsRcNumber
     def opensearchRcBuildNumber
     def opensearchDashboardsRcBuildNumber
     String releaseIssueUrl
 
-    if (version.isEmpty()){
-        error('version is required to get RC details.')
-    }
     withCredentials([
             string(credentialsId: 'jenkins-health-metrics-account-number', variable: 'METRICS_HOST_ACCOUNT'),
             string(credentialsId: 'jenkins-health-metrics-cluster-endpoint', variable: 'METRICS_HOST_URL')]) {

--- a/vars/addRcDetailsComment.groovy
+++ b/vars/addRcDetailsComment.groovy
@@ -23,6 +23,8 @@ void call(Map args = [:]) {
     if (matcher) {
         version = matcher[0][1]  // Captures the numeric part (3.0.0)
         qualifier = matcher[0][2] ?: "None" // Captures the qualifier (beta1) or None if no qualifier
+        // Explicitly null out the matcher after using it to avoid serialization issues with jenkins
+        matcher = null
     }
     def opensearchRcNumber
     def opensearchDashboardsRcNumber

--- a/vars/addRcDetailsComment.groovy
+++ b/vars/addRcDetailsComment.groovy
@@ -20,13 +20,9 @@ void call(Map args = [:]) {
     if (args.version.isEmpty()){
         error('version is required to get RC details.')
     }
-    def (version, qualifier) = { localVersion ->
-        def localMatcher = localVersion =~ /^([\d.]+)(?:-(.+))?$/
-        if (localMatcher) {
-            return [localMatcher[0][1], localMatcher[0][2] ?: "None"]
-        }
-        return [localVersion, "None"]
-    }(args.version)
+    def versionTokenize = args.version.tokenize('-')
+    def version = versionTokenize[0]
+    def qualifier = versionTokenize[1] ?: "None"
     def opensearchRcNumber
     def opensearchDashboardsRcNumber
     def opensearchRcBuildNumber

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -47,13 +47,13 @@ void call(Map args = [:]) {
     // Qualifier is in-built in the version. Splitting it until https://github.com/opensearch-project/opensearch-build/issues/5386 is resolved
     def version = manifest.version.toString()
     def qualifier = "None"
-    def matcher = version =~ /^([\d.]+)(?:-(.+))?$/
-    if (matcher) {
-        version = matcher[0][1]  // Captures the numeric part (3.0.0)
-        qualifier = matcher[0][2] ?: "None" // Captures the qualifier (beta1) or None if no qualifier
-        // Explicitly null out the matcher after using it to avoid serialization issues with jenkins
-        matcher = null
-    }
+    (version, qualifier) = { localVersion ->
+        def localMatcher = localVersion =~ /^([\d.]+)(?:-(.+))?$/
+        if (localMatcher) {
+            return [localMatcher[0][1], localMatcher[0][2] ?: "None"]
+        }
+        return [localVersion, "None"]
+    }(version)
     def distributionBuildNumber = manifest.id
     def rcNumber = manifest.rc.toInteger()
     def rc = (rcNumber > 0)

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -45,15 +45,9 @@ void call(Map args = [:]) {
     def testFailuresindexName = "opensearch-integration-test-failures-${formattedDate}"
     def finalJsonDoc = ""
     // Qualifier is in-built in the version. Splitting it until https://github.com/opensearch-project/opensearch-build/issues/5386 is resolved
-    def version = manifest.version.toString()
-    def qualifier = "None"
-    (version, qualifier) = { localVersion ->
-        def localMatcher = localVersion =~ /^([\d.]+)(?:-(.+))?$/
-        if (localMatcher) {
-            return [localMatcher[0][1], localMatcher[0][2] ?: "None"]
-        }
-        return [localVersion, "None"]
-    }(version)
+    def versionTokenize = manifest.version.tokenize('-')
+    def version = versionTokenize[0]
+    def qualifier = versionTokenize[1] ?: "None"
     def distributionBuildNumber = manifest.id
     def rcNumber = manifest.rc.toInteger()
     def rc = (rcNumber > 0)

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -51,6 +51,8 @@ void call(Map args = [:]) {
     if (matcher) {
         version = matcher[0][1]  // Captures the numeric part (3.0.0)
         qualifier = matcher[0][2] ?: "None" // Captures the qualifier (beta1) or None if no qualifier
+        // Explicitly null out the matcher after using it to avoid serialization issues with jenkins
+        matcher = null
     }
     def distributionBuildNumber = manifest.id
     def rcNumber = manifest.rc.toInteger()


### PR DESCRIPTION
### Description
Matcher object is not serializable and jenkins needs it to be serializable for maintaining the state. Scoping down the matcher variable from global to local. Tested it in jenkins environment and it goes through.

### Issues Resolved
https://build.ci.opensearch.org/job/distribution-release-chores/6/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
