### PR TITLE
Add library to check documentation issue status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.3.3'
+String version = '8.4.0'
 
 task updateVersion {
     doLast {

--- a/resources/release/documentation-issues-template.md
+++ b/resources/release/documentation-issues-template.md
@@ -1,0 +1,10 @@
+Hi @${OWNER}, </br>
+
+As part of the [entrance criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window), all the documentation pull requests need to be drafted and in technical review. </br>
+**Since there is no pull request linked to this issue, please take one of the following actions:** </br>
+* Create the pull request and [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>
+* If you already have a pull request created, please [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>
+* If this feature is not targeted for the currently labeled release version, please update the issue with the correct release version. </br>
+
+Please note: Missing documentation can block the release and cause delays in the overall process. </br>
+Thank you!

--- a/tests/jenkins/TestCheckDocumentationIssues.groovy
+++ b/tests/jenkins/TestCheckDocumentationIssues.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.allOf
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.MatcherAssert.assertThat
+
+class TestCheckDocumentationIssues extends BuildPipelineTest {
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('withCredentials', [Map])
+        helper.addShMock("""gh issue list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-linked:pr" --json number --jq '.[].number'""") { script ->
+            return [stdout: "22\n23", exitValue: 0]
+        }
+        addParam('VERSION', '3.0.0')
+    }
+
+    @Test
+    void testNotifyActionWithAssignee(){
+        addParam('ACTION', 'notify')
+        helper.addShMock("""gh issue view 22 --repo opensearch-project/documentation-website --json assignees --jq '.assignees[0].login'""") { script ->
+            return [stdout: "foo", exitValue: 0]
+        }
+        this.registerLibTester(new CheckDocumentationIssuesLibTester('3.0.0', 'notify'))
+        super.testPipeline('tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile')
+        assertThat(getCommands('sh', 'issue'), hasItem("{script=gh issue comment 22 --repo opensearch-project/documentation-website --body-file /tmp/workspace/22.md, returnStdout=true}"))
+        def fileContent = getCommands('writeFile', 'documentation')[0]
+        assertThat(fileContent, allOf(
+                containsString("{file=/tmp/workspace/22.md, text=Hi @foo, </br>"),
+                containsString("As part of the [entrance criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window), all the documentation pull requests need to be drafted and in technical review. </br>"),
+                containsString("**Since there is no pull request linked to this issue, please take one of the following actions:** </br>"),
+                containsString("* Create the pull request and [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>"),
+                containsString("* If you already have a pull request created, please [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>"),
+                containsString("* If this feature is not targeted for the currently labeled release version, please update the issue with the correct release version. </br>"),
+                containsString("Please note: Missing documentation can block the release and cause delays in the overall process. </br>")
+        ))
+    }
+    @Test
+    void testCheckAction(){
+        addParam('ACTION', 'check')
+        this.registerLibTester(new CheckDocumentationIssuesLibTester('3.0.0', 'check'))
+        runScript('tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile')
+        assertThat(getCommands('echo', 'documentation'), hasItem("Open documentation issues found. Issue numbers: [22, 23]"))
+    }
+
+    @Test
+    void testCheckActionWithQualifier(){
+        addParam('VERSION', '3.0.0-alpha1')
+        addParam('ACTION', 'check')
+        this.registerLibTester(new CheckDocumentationIssuesLibTester('3.0.0', 'check'))
+        runScript('tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile')
+        assertThat(getCommands('echo', 'documentation'), hasItem("Open documentation issues found. Issue numbers: [22, 23]"))
+    }
+
+    @Test
+    void testCheckActionWithNoOpenIssues(){
+        addParam('ACTION', 'check')
+        helper.addShMock("""gh issue list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-linked:pr" --json number --jq '.[].number'""") { script ->
+            return [stdout: "", exitValue: 0]
+        }
+        this.registerLibTester(new CheckDocumentationIssuesLibTester('3.0.0', 'check'))
+        runScript('tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile')
+        assertThat(getCommands('echo', 'documentation'), not(hasItem("Open documentation issues found. Issue numbers: [22, 23]")))
+        assertThat(getCommands('echo', 'documentation'), hasItem("No open documentation issues found without a linked PR!"))
+    }
+
+    @Test
+    void testNotifyActionWithAuthor(){
+        addParam('ACTION', 'notify')
+        helper.addShMock("""gh issue view 22 --repo opensearch-project/documentation-website --json assignees --jq '.assignees[0].login'""") { script ->
+            return [stdout: "", exitValue: 0]
+        }
+        helper.addShMock("""gh issue view 22 --repo opensearch-project/documentation-website --json author --jq '.author.login'""") { script ->
+            return [stdout: "bar", exitValue: 0]
+        }
+        this.registerLibTester(new CheckDocumentationIssuesLibTester('3.0.0', 'notify'))
+        runScript('tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile')
+        assertThat(getCommands('sh', 'issue'), hasItem("{script=gh issue comment 22 --repo opensearch-project/documentation-website --body-file /tmp/workspace/22.md, returnStdout=true}"))
+        def fileContent = getCommands('writeFile', 'documentation')[0]
+        assertThat(fileContent, containsString("{file=/tmp/workspace/22.md, text=Hi @bar, </br>"))
+    }
+
+    def getCommands(method, text) {
+        def shCommands = helper.callStack.findAll { call ->
+            call.methodName == method
+        }.collect { call ->
+            callArgsToString(call)
+        }.findAll { command ->
+            command.contains(text)
+        }
+        return shCommands
+    }
+}

--- a/tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile
+++ b/tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile
@@ -1,0 +1,36 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+*/
+
+pipeline {
+    agent none
+    parameters {
+        string(
+            name: 'VERSION',
+            description: 'Release version',
+            trim: true
+        )
+        string(
+            name: 'ACTION',
+            description: 'Actions to take',
+            trim: true
+        )
+    }
+    stages {
+        stage('check-doc-issues') {
+            steps {
+                script {
+                    checkDocumentationIssues(
+                        version: "${params.VERSION}",
+                        action: "${params.ACTION}"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CheckDocumentationIssues_Jenkinsfile.txt
@@ -1,0 +1,39 @@
+   CheckDocumentationIssues_Jenkinsfile.run()
+      CheckDocumentationIssues_Jenkinsfile.pipeline(groovy.lang.Closure)
+         CheckDocumentationIssues_Jenkinsfile.echo(Executing on agent [label:none])
+         CheckDocumentationIssues_Jenkinsfile.stage(check-doc-issues, groovy.lang.Closure)
+            CheckDocumentationIssues_Jenkinsfile.script(groovy.lang.Closure)
+               CheckDocumentationIssues_Jenkinsfile.checkDocumentationIssues({version=3.0.0, action=notify})
+                  checkDocumentationIssues.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                  checkDocumentationIssues.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                     checkDocumentationIssues.sh({script=gh issue list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-linked:pr" --json number --jq '.[].number', returnStdout=true})
+                     checkDocumentationIssues.echo(Open documentation issues found. Issue numbers: [22, 23])
+                     checkDocumentationIssues.sh({script=gh issue view 22 --repo opensearch-project/documentation-website --json assignees --jq '.assignees[0].login', returnStdout=true})
+                     checkDocumentationIssues.libraryResource(release/documentation-issues-template.md)
+                     checkDocumentationIssues.writeFile({file=/tmp/workspace/22.md, text=Hi @foo, </br>
+
+As part of the [entrance criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window), all the documentation pull requests need to be drafted and in technical review. </br>
+**Since there is no pull request linked to this issue, please take one of the following actions:** </br>
+* Create the pull request and [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>
+* If you already have a pull request created, please [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>
+* If this feature is not targeted for the currently labeled release version, please update the issue with the correct release version. </br>
+
+Please note: Missing documentation can block the release and cause delays in the overall process. </br>
+Thank you!
+})
+                     checkDocumentationIssues.sh({script=gh issue comment 22 --repo opensearch-project/documentation-website --body-file /tmp/workspace/22.md, returnStdout=true})
+                     checkDocumentationIssues.sh({script=gh issue view 23 --repo opensearch-project/documentation-website --json assignees --jq '.assignees[0].login', returnStdout=true})
+                     checkDocumentationIssues.libraryResource(release/documentation-issues-template.md)
+                     checkDocumentationIssues.writeFile({file=/tmp/workspace/23.md, text=Hi @bbb
+ccc, </br>
+
+As part of the [entrance criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window), all the documentation pull requests need to be drafted and in technical review. </br>
+**Since there is no pull request linked to this issue, please take one of the following actions:** </br>
+* Create the pull request and [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>
+* If you already have a pull request created, please [link it](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to this issue. </br>
+* If this feature is not targeted for the currently labeled release version, please update the issue with the correct release version. </br>
+
+Please note: Missing documentation can block the release and cause delays in the overall process. </br>
+Thank you!
+})
+                     checkDocumentationIssues.sh({script=gh issue comment 23 --repo opensearch-project/documentation-website --body-file /tmp/workspace/23.md, returnStdout=true})

--- a/tests/jenkins/jobs/CheckReleaseIssues_Jenkinsfile
+++ b/tests/jenkins/jobs/CheckReleaseIssues_Jenkinsfile
@@ -1,11 +1,10 @@
 /**
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
-
- The OpenSearch Contributors require contributions made to
- this file be licensed under the Apache-2.0 license or a
- compatible open source license.
-*/
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 
 pipeline {
     agent none

--- a/tests/jenkins/lib-testers/CheckDocumentationIssuesLibTester.groovy
+++ b/tests/jenkins/lib-testers/CheckDocumentationIssuesLibTester.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class CheckDocumentationIssuesLibTester extends LibFunctionTester {
+    private String version
+    private String action
+
+    public CheckDocumentationIssuesLibTester(version, action) {
+        this.version = version
+        this.action = action
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'checkDocumentationIssues'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        assertThat(call.args.version.first(), notNullValue())
+        assertThat(call.args.action.first(), notNullValue())
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.version.first().toString().equals(this.version)
+                && call.args.action.first().toString().equals(this.action)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {}
+}
+

--- a/vars/checkDocumentationIssues.groovy
+++ b/vars/checkDocumentationIssues.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/**
+ * Library to check documentation issues per release.
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.version <required> - Release version to track the documentation PRs for.
+ * @param args.action <optional> - Action to be performed. Default is 'check'. Acceptable values are 'check' and 'notify'.
+ */
+void call(Map args = [:]) {
+    String action = args.action ?: 'check'
+    // Validate Parameters
+    validateParameters(args)
+    def versionTokenize = args.version.tokenize('-')
+    // Qualifiers are not a part of the labels in GitHub. Ignoring it.
+    def version = versionTokenize[0]
+
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        def openIssues = sh(
+                script: "gh issue list --repo opensearch-project/documentation-website --state open --label v${version} -S \"-linked:pr\" --json number --jq '.[].number'",
+                returnStdout: true
+        )
+        if (openIssues) {
+            def openIssuesList = openIssues.readLines()
+            echo("Open documentation issues found. Issue numbers: ${openIssuesList}")
+            if(action == 'notify') {
+                notifyTheOwners(openIssuesList)
+            }
+        } else {
+            echo("No open documentation issues found without a linked PR!")
+        }
+    }
+}
+
+/**
+ * Validates input parameters
+ */
+private void validateParameters(Map args) {
+    if (!args.version) {
+        error ('Version is required parameter.')
+    }
+    List<String> validActions = ['check', 'notify']
+    if (!validActions.contains(args.action.toString())) {
+        error "Invalid action '${args.action}'. Valid values: ${validActions.join(', ')}"
+    }
+}
+
+/**
+ * Get author or assignee of the issue
+ * @param issueNumber
+ * @return assignee or author
+ */
+private String getAuthorOrAssignee(String issueNumber) {
+    try {
+        def assignee = sh(
+                script: "gh issue view ${issueNumber} --repo opensearch-project/documentation-website --json assignees --jq '.assignees[0].login'",
+                returnStdout: true
+        )
+        if (!isNullOrEmpty(assignee)) {
+            return assignee
+        } else {
+            def author = sh(
+                    script: "gh issue view ${issueNumber} --repo opensearch-project/documentation-website --json author --jq '.author.login'",
+                    returnStdout: true
+            )
+            return author
+        }
+    } catch (Exception e) {
+        error "Failed to get author or assignee for issue number ${issueNumber}: ${e.getMessage()}"
+    }
+}
+
+/**
+ * Create and return notification message file path
+ */
+def getNotificationMessageBodyFile(String owner, String issueNumber) {
+    try {
+        // Load RC details template content
+        def templateContent = libraryResource "release/documentation-issues-template.md"
+
+        // Process template using simple string replacement
+        def processedContent = templateContent
+
+        if(owner) {
+            processedContent = processedContent.replace('${OWNER}', owner.trim())
+        } else {
+            processedContent = processedContent.replace('@{OWNER}', '')
+        }
+        // Write the processed content
+        String commentBodyFilePath = "${WORKSPACE}/${issueNumber}.md"
+        writeFile(file: commentBodyFilePath , text: processedContent)
+        return commentBodyFilePath
+    } catch (Exception e) {
+        error "Failed to process template: ${e.getMessage()}"
+    }
+}
+
+/**
+ * Notify the owners about the possible actions
+ * @param openIssuesList
+ * @return
+ */
+private void notifyTheOwners(ArrayList openIssuesList) {
+    openIssuesList.each { issueNumber ->
+        def owner = getAuthorOrAssignee(issueNumber.toString())
+        def githubCommentBody = getNotificationMessageBodyFile(owner, issueNumber.toString())
+        sh(
+                script: "gh issue comment ${issueNumber} --repo opensearch-project/documentation-website --body-file ${githubCommentBody}",
+                returnStdout: true
+        )
+    }
+}
+
+private boolean isNullOrEmpty(String str) { return (str == null || str.allWhitespace || str.isEmpty()) }


### PR DESCRIPTION
### Description
Add library to check documentation issue status.
This is how it will comment on the issues that do not have PR linked https://github.com/gaiksaya/documentation-website/issues/3#issuecomment-2722769011
You can also check how it skipped the linked PR issue here: https://github.com/gaiksaya/documentation-website/issues
The template is approved by @kolchfa-aws

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5332

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
