### PR TITLE
Add library to check and notify release notes based on old workflow

### DIFF
--- a/resources/release/criteria-not-met-template.md
+++ b/resources/release/criteria-not-met-template.md
@@ -1,4 +1,4 @@
-Hi ${RELEASE_OWNER}, </br>
+Hi @${RELEASE_OWNER}, </br>
 
 The below ${TYPE_OF_CRITERIA} criteria for your component has not been met. </br>
 Please review the issue and address it with high priority. </br>

--- a/resources/release/missing-release-notes.md
+++ b/resources/release/missing-release-notes.md
@@ -1,0 +1,5 @@
+Hi, </br>
+
+This component is missing release notes at ${BRANCH} ref. Please add them on priority in order to meet the entrance criteria for the release.
+
+Thank you!

--- a/resources/release/missing-release-notes.md
+++ b/resources/release/missing-release-notes.md
@@ -1,5 +1,6 @@
 Hi, </br>
 
-This component is missing release notes at ${BRANCH} ref. Please add them on priority in order to meet the entrance criteria for the release.
+This component is missing release notes at ${BRANCH} ref. Please add them on priority in order to meet the entrance criteria for the release. </br>
+Please check out the [guidelines](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md) for the release notes. </br>
 
 Thank you!

--- a/src/jenkins/ParseReleaseNotesMarkdownTable.groovy
+++ b/src/jenkins/ParseReleaseNotesMarkdownTable.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+class ParseReleaseNotesMarkdownTable {
+    String markdown
+
+    ParseReleaseNotesMarkdownTable(String markdown) {
+        this.markdown = markdown
+    }
+
+    def parseReleaseNotesMarkdownTableRows() {
+        try {
+            def rows = markdown.readLines().findAll { it.startsWith('|') }
+            // Skipping headers
+            rows = rows[2..-1]
+            return rows.collect { row ->
+                def cells = row.split("\\|")
+                return [
+                        'Component': cells[1].trim(),
+                        'Branch': cells[2].trim(),
+                        'Commit ID': cells[3].trim(),
+                        'Commit Date': cells[4].trim(),
+                        'Status': cells[5].trim()
+                ]
+            }
+        } catch (Exception ex) {
+            error("Unable to parse the release notes markdown table: ${ex.getMessage()}")
+        }
+    }
+}

--- a/src/jenkins/ReleaseMetricsData.groovy
+++ b/src/jenkins/ReleaseMetricsData.groovy
@@ -79,7 +79,7 @@ class ReleaseMetricsData {
         return query.replace('"', '\\"')
     }
 
-    String getReleaseIssueQuery(String repository) {
+    String getReleaseIssueQuery(String repository, String changedMatchPhraseKey = "repository") {
         def queryMap = [
                 size   : 1,
                 _source: "release_issue",
@@ -93,7 +93,7 @@ class ReleaseMetricsData {
                                         ],
                                         [
                                                 match_phrase: [
-                                                        repository: "${repository}"
+                                                        "${changedMatchPhraseKey}": "${repository}"
                                                 ]
                                         ]
                                 ]
@@ -122,9 +122,9 @@ ArrayList getReleaseOwners(String component) {
         }
 }
 
-String getReleaseIssue(String repository) {
+String getReleaseIssue(String repository, String changedMatchPhraseKey="repository") {
         try {
-                def jsonResponse = this.openSearchMetricsQuery.fetchMetrics(getReleaseIssueQuery(repository))
+                def jsonResponse = this.openSearchMetricsQuery.fetchMetrics(getReleaseIssueQuery(repository, changedMatchPhraseKey))
                 def releaseIssue = jsonResponse.hits.hits._source.release_issue[0]
                 return releaseIssue.toString()
         } catch (Exception e) {

--- a/tests/data/release-notes-check.md
+++ b/tests/data/release-notes-check.md
@@ -1,0 +1,12 @@
+# Core Components CommitID(after 2025-02-11) & Release Notes info
+|              Repo              |Branch|CommitID|Commit Date| Release Notes Exists |
+|--------------------------------|------|--------|-----------|----------------------|
+|OpenSearch                      |[main]|f58d846f|2025-03-17 | False                |
+|OpenSearch-Dashboards           |[main]|f52b5d2 |2025-03-17 | True                 |
+|functionalTestDashboards        |[main]|5fe4c27 |2025-03-14 | False                |
+|alerting                        |[main]|d6c838b |2025-03-14 | True                 |
+|alertingDashboards              |[main]|d32321d |2025-03-14 | True                 |
+|anomaly-detection               |[main]|41db8c0 |2025-03-06 | True                 |
+|anomalyDetectionDashboards      |[main]|262c16d |2025-03-13 | True                 |
+|notifications-core              |[main]|830ced9 |2025-03-14 | True                 |
+

--- a/tests/jenkins/TestCheckReleaseNotes.groovy
+++ b/tests/jenkins/TestCheckReleaseNotes.groovy
@@ -86,7 +86,7 @@ class TestCheckReleaseNotes extends BuildPipelineTest {
         super.testPipeline('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
         def fileContent = getCommands('writeFile', 'release')[0]
         assertThat(fileContent, allOf(containsString("{file=/tmp/workspace/OpenSearch.md, text=Hi, </br>"),
-        containsString("This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release.")))
+        containsString("This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release. </br>")))
         assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch, functionalTestDashboards]"))
         assertThat(getCommands('sh', 'opensearch'), hasItem("{script=gh issue comment https://github.com/opensearch-project/opensearch/issues/123 --body-file /tmp/workspace/OpenSearch.md, returnStdout=true}"))
         assertThat(getCommands('sh', 'functionalTestDashboards').size(), equalTo(0))

--- a/tests/jenkins/TestCheckReleaseNotes.groovy
+++ b/tests/jenkins/TestCheckReleaseNotes.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import jenkins.tests.BuildPipelineTest
+import jenkins.tests.CheckReleaseNotesLibTester
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.allOf
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.MatcherAssert.assertThat
+
+class TestCheckReleaseNotes extends BuildPipelineTest {
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('withCredentials', [Map])
+        helper.registerAllowedMethod('sleep', [Map])
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken'
+        ])
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        String testData = new File('tests/data/release-notes-check.md').text
+        helper.addFileExistsMock('tests/data/release-notes-check.md', true)
+        helper.addReadFileMock('tests/data/release-notes-check.md', testData)
+
+        def releaseIssueResponse = '''
+                    {
+                    
+                      "took": 5,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 11,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch_release_metrics",
+                            "_id": "86739a31-40db-320f-b52c-d38d50e179bc",
+                            "_score": null,
+                            "_source": {
+                              "release_issue": "https://github.com/opensearch-project/opensearch/issues/123"
+                            },
+                            "sort": [
+                              1738963520807
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                    '''
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}},{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}" | jq '.'\n        """) { script ->
+            return [stdout: releaseIssueResponse, exitValue: 0]
+        }
+    }
+
+
+    @Test
+    void testNotifyAction() {
+        addParam('ACTION', 'notify')
+        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'notify'))
+        super.testPipeline('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
+        def fileContent = getCommands('writeFile', 'release')[0]
+        assertThat(fileContent, allOf(containsString("{file=/tmp/workspace/OpenSearch.md, text=Hi, </br>"),
+        containsString("This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release.")))
+        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch, functionalTestDashboards]"))
+        assertThat(getCommands('sh', 'opensearch'), hasItem("{script=gh issue comment https://github.com/opensearch-project/opensearch/issues/123 --body-file /tmp/workspace/OpenSearch.md, returnStdout=true}"))
+        assertThat(getCommands('sh', 'functionalTestDashboards').size(), equalTo(0))
+    }
+
+    @Test
+    void testCheckAction() {
+        addParam('ACTION', 'check')
+        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'check'))
+        runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
+        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch, functionalTestDashboards]"))
+    }
+
+    @Test
+    void testMispelledAction() {
+        addParam('ACTION', 'chek')
+        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'chek'))
+        runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
+        assertThat(getCommands('error', ''), hasItem("Invalid action 'chek'. Valid values: check, notify"))
+        assertJobStatusFailure()
+    }
+
+    @Test
+    void testParsingError() {
+        addParam('ACTION', 'check')
+        helper.addReadFileMock('tests/data/release-notes-check.md', "testData")
+        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'check'))
+        runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
+        assertThat(getCommands('error', ''), hasItem("Unable to parse the release notes markdown table: fromIndex = -1"))
+        assertJobStatusFailure()
+    }
+
+    def getCommands(method, text) {
+        def shCommands = helper.callStack.findAll { call ->
+            call.methodName == method
+        }.collect { call ->
+            callArgsToString(call)
+        }.findAll { command ->
+            command.contains(text)
+        }
+        return shCommands
+    }
+}

--- a/tests/jenkins/TestParseReleaseNotesMarkdownTable.groovy
+++ b/tests/jenkins/TestParseReleaseNotesMarkdownTable.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import jenkins.ParseReleaseNotesMarkdownTable
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+
+class TestParseReleaseNotesMarkdownTable {
+    @Test
+    void testParseMarkdownTableRows() {
+        def markdown = """
+# Core Components CommitID(after 2025-02-11) & Release Notes info
+|              Repo              |Branch|CommitID|Commit Date|Release Notes Exists|
+|--------------------------------|------|--------|-----------|--------------------|
+|OpenSearch                      |[main]|6c0a95b9|2025-03-17 |False               |
+|OpenSearch-Dashboards           |[main]|29f05d7 |2025-03-17 |False               |
+|alerting                        |[main]|d6c838b |2025-03-14 |True                |
+|alertingDashboards              |[main]|d32321d |2025-03-14 |True                |
+|anomaly-detection               |[main]|41db8c0 |2025-03-06 |True                |
+|anomalyDetectionDashboards      |[main]|262c16d |2025-03-13 |True                |
+|assistantDashboards             |[main]|c7d1c37 |2025-03-17 |True                |
+|asynchronous-search             |[main]|e1cea9c |2025-02-20 |False               |
+|common-utils                    |[main]|c9c0747 |2025-03-10 |True                |
+|cross-cluster-replication       |[main]|ca5bbd4 |2025-03-15 |True                |
+"""
+        ParseReleaseNotesMarkdownTable parser = new ParseReleaseNotesMarkdownTable(markdown)
+        def result = parser.parseReleaseNotesMarkdownTableRows()
+        assertEquals("Expected 10 row in the result", 10, result.size())
+        assertEquals("OpenSearch", result[0]['Component'])
+        assertEquals("[main]", result[0]['Branch'])
+        assertEquals("6c0a95b9", result[0]['Commit ID'])
+        assertEquals("2025-03-17", result[0]['Commit Date'])
+        assertEquals("False", result[0]['Status'])
+    }
+}

--- a/tests/jenkins/TestParseReleaseNotesMarkdownTable.groovy
+++ b/tests/jenkins/TestParseReleaseNotesMarkdownTable.groovy
@@ -12,8 +12,18 @@ package jenkins.tests
 import jenkins.ParseReleaseNotesMarkdownTable
 import org.junit.Test
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
 
 class TestParseReleaseNotesMarkdownTable {
+    // Helper method to create a testable subclass that overrides error()
+    private ParseReleaseNotesMarkdownTable createParser(String markdown) {
+        return new ParseReleaseNotesMarkdownTable(markdown) {
+            def error(String message) {
+                throw new Exception(message)
+            }
+        }
+    }
+
     @Test
     void testParseMarkdownTableRows() {
         def markdown = """
@@ -39,5 +49,18 @@ class TestParseReleaseNotesMarkdownTable {
         assertEquals("6c0a95b9", result[0]['Commit ID'])
         assertEquals("2025-03-17", result[0]['Commit Date'])
         assertEquals("False", result[0]['Status'])
+    }
+
+    @Test
+    void testInvalidMarkdownParsing() {
+        def invalidMarkdown = "This is not a valid markdown table"
+        def parser = createParser(invalidMarkdown)
+
+        try {
+            parser.parseReleaseNotesMarkdownTableRows()
+            fail("Expected an exception to be thrown")
+        } catch (Exception e) {
+            assertTrue(e.getMessage().startsWith("Unable to parse the release notes markdown table:"))
+        }
     }
 }

--- a/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile
+++ b/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile
@@ -1,0 +1,32 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+
+ The OpenSearch Contributors require contributions made to
+ this file be licensed under the Apache-2.0 license or a
+ compatible open source license.
+*/
+
+pipeline {
+    agent none
+    parameters {
+        string(
+            name: 'ACTION',
+            description: 'What action you want to take for missing release owners',
+            trim: true
+        )
+    }
+    stages {
+        stage('checkReleaseNotes') {
+            steps {
+                script {
+                    checkReleaseNotes(
+                        version: '2.19.0',
+                        dataTable: 'tests/data/release-notes-check.md',
+                        action: "${params.ACTION}"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
+++ b/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
@@ -24,7 +24,8 @@
                         checkReleaseNotes.libraryResource(release/missing-release-notes.md)
                         checkReleaseNotes.writeFile({file=/tmp/workspace/OpenSearch.md, text=Hi, </br>
 
-This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release.
+This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release. </br>
+Please check out the [guidelines](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md) for the release notes. </br>
 
 Thank you!
 })

--- a/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
+++ b/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
@@ -1,0 +1,37 @@
+   CheckReleaseNotes_JenkinsFile.run()
+      CheckReleaseNotes_JenkinsFile.pipeline(groovy.lang.Closure)
+         CheckReleaseNotes_JenkinsFile.echo(Executing on agent [label:none])
+         CheckReleaseNotes_JenkinsFile.stage(checkReleaseNotes, groovy.lang.Closure)
+            CheckReleaseNotes_JenkinsFile.script(groovy.lang.Closure)
+               CheckReleaseNotes_JenkinsFile.checkReleaseNotes({version=2.19.0, dataTable=tests/data/release-notes-check.md, action=notify})
+                  checkReleaseNotes.fileExists(tests/data/release-notes-check.md)
+                  checkReleaseNotes.readFile(tests/data/release-notes-check.md)
+                  ParseReleaseNotesMarkdownTable.parseReleaseNotesMarkdownTableRows()
+                  checkReleaseNotes.echo(Components missing release notes: [OpenSearch, functionalTestDashboards])
+                  checkReleaseNotes.echo(Notifying all the components with missing release notes.)
+                  checkReleaseNotes.string({credentialsId=jenkins-health-metrics-account-number, variable=METRICS_HOST_ACCOUNT})
+                  checkReleaseNotes.string({credentialsId=jenkins-health-metrics-cluster-endpoint, variable=METRICS_HOST_URL})
+                  checkReleaseNotes.withCredentials([METRICS_HOST_ACCOUNT, METRICS_HOST_URL], groovy.lang.Closure)
+                     checkReleaseNotes.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                        ReleaseMetricsData.getReleaseIssue(OpenSearch, component.keyword)
+                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkReleaseNotes.println(Running query: {\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkReleaseNotes.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+        , returnStdout=true})
+                        checkReleaseNotes.libraryResource(release/missing-release-notes.md)
+                        checkReleaseNotes.writeFile({file=/tmp/workspace/OpenSearch.md, text=Hi, </br>
+
+This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release.
+
+Thank you!
+})
+                        checkReleaseNotes.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                        checkReleaseNotes.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                           checkReleaseNotes.sh({script=gh issue comment https://github.com/opensearch-project/opensearch/issues/123 --body-file /tmp/workspace/OpenSearch.md, returnStdout=true})
+                  checkReleaseNotes.string({credentialsId=jenkins-health-metrics-account-number, variable=METRICS_HOST_ACCOUNT})
+                  checkReleaseNotes.string({credentialsId=jenkins-health-metrics-cluster-endpoint, variable=METRICS_HOST_URL})
+                  checkReleaseNotes.withCredentials([METRICS_HOST_ACCOUNT, METRICS_HOST_URL], groovy.lang.Closure)
+                     checkReleaseNotes.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)

--- a/tests/jenkins/lib-testers/CheckReleaseNotesLibTester.groovy
+++ b/tests/jenkins/lib-testers/CheckReleaseNotesLibTester.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class CheckReleaseNotesLibTester extends LibFunctionTester{
+    private String version
+    private String dataTable
+    private String action = 'check'
+
+    public CheckReleaseNotesLibTester(version, dataTable, action){
+        this.version = version
+        this.dataTable = dataTable
+        this.action = action
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'checkReleaseNotes'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        assertThat(call.args.version.first(), notNullValue())
+        assertThat(call.args.dataTable.first(), notNullValue())
+        assertThat(call.args.action.first(), notNullValue())
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.version.first().equals(this.version)
+                && call.args.dataTable.first().equals(this.dataTable)
+                && call.args.action.first().toString().equals(this.action)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {}
+}
+

--- a/vars/checkReleaseIssues.groovy
+++ b/vars/checkReleaseIssues.groovy
@@ -10,7 +10,7 @@ import jenkins.ReleaseMetricsData
  /**
  * Library to check if release issue exists in the component repo.
  * @param Map args = [:] args A map of the following parameters
- * @param args.inputManifest <required> - Input manifest file(s) eg: [2.0.0/opensearch-2.0.0.yml, 2.0.0/opensearch-dashboards-2.0.0.yml] .
+ * @param args.inputManifest <required> - Input manifest file(s) eg: [manifests/2.0.0/opensearch-2.0.0.yml,manifests/2.0.0/opensearch-dashboards-2.0.0.yml] .
  * @param args.action <optional> - Action to be performed. Default is 'check'. Acceptable values are 'check' and 'create'.
  */
 void call(Map args = [:]) {

--- a/vars/checkReleaseNotes.groovy
+++ b/vars/checkReleaseNotes.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import jenkins.ReleaseMetricsData
+import jenkins.ParseReleaseNotesMarkdownTable
+/**
+ * Library to check and notify missing release notes.
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.version <required> - Release version. eg: 3.0.0
+ * @param args.dataTable <required> - Markdown data table file in the format: https://github.com/opensearch-project/opensearch-build/issues/3747#issuecomment-2704366641 eg: ./table.md
+ * @param args.action <optional> - Action to perform. Default is 'check'. Acceptable values are 'check' and 'notify'.
+ */
+void call(Map args = [:]) {
+    String action = args.action ?: 'check'
+    // Parameter check
+    validateParameters(args, action)
+    def version = args.version.tokenize('-')[0]
+
+    def parsedContent = new ParseReleaseNotesMarkdownTable(readFile(args.dataTable)).parseReleaseNotesMarkdownTableRows()
+    def componentsWithFalseStatus = parsedContent.findAll { it['Status'] == 'False' }
+    echo("Components missing release notes: " + componentsWithFalseStatus.collect { it['Component'] })
+
+    if (action == 'notify' && !componentsWithFalseStatus.isEmpty()) {
+        echo "Notifying all the components with missing release notes."
+        notifyReleaseOwners(version, componentsWithFalseStatus)
+    }
+}
+
+/**
+ * Validates input parameters
+ */
+private void validateParameters(Map args, String action) {
+    if (!args.version) {
+        error "Version parameter is required."
+    }
+
+    if (!args.dataTable || args.dataTable.isEmpty()) {
+        error "dataTable is required to get the content."
+    } else {
+        if (!fileExists(args.dataTable)) {
+            error("Invalid path.Data Table file does not exist at ${args.dataTable}")
+        }
+    }
+
+    List<String> validActions = ['check', 'notify']
+    if (!validActions.contains(action)) {
+        error "Invalid action '${action}'. Valid values: ${validActions.join(', ')}"
+    }
+}
+
+/**
+ * Notify components regarding the missing release notes by adding a comment to the release issue.
+ * @param version: Release version.
+ * @param componentsWithFalseStatus: Parsed content with status as False.
+ */
+private void notifyReleaseOwners(String version,def componentsWithFalseStatus) {
+    componentsWithFalseStatus.each { component ->
+        withCredentials([
+                string(credentialsId: 'jenkins-health-metrics-account-number', variable: 'METRICS_HOST_ACCOUNT'),
+                string(credentialsId: 'jenkins-health-metrics-cluster-endpoint', variable: 'METRICS_HOST_URL')]) {
+            withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+                def metricsUrl = env.METRICS_HOST_URL
+                def awsAccessKey = env.AWS_ACCESS_KEY_ID
+                def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+                def awsSessionToken = env.AWS_SESSION_TOKEN
+
+                ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
+                def componentName = component["Component"]
+                if(componentName != 'functionalTestDashboards') {
+                    def releaseIssueUrl = releaseMetricsData.getReleaseIssue("${componentName}", "component.keyword")
+                    def ghCommentContent = getNotificationMessageBodyFile(componentName, component["Branch"] )
+                    addComment(releaseIssueUrl, ghCommentContent)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Add a comment on the Release issue.
+ * @param releaseIssueUrl: Component release issue URL.
+ * @param commentBodyFile: Path to the file containing GitHub comment content.
+ */
+private void addComment(String releaseIssueUrl, def commentBodyFile) {
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        sh(
+                script: "gh issue comment ${releaseIssueUrl} --body-file ${commentBodyFile}",
+                returnStdout: true
+        )
+    }
+}
+/**
+ * Get notification message body file.
+ * @param component: Component Name.
+ * @param branch: Branch against which release notes are checked.
+ */
+def getNotificationMessageBodyFile(String component, String branch) {
+    try {
+        // Load RC details template content
+        def templateContent = libraryResource "release/missing-release-notes.md"
+
+        // Process template using simple string replacement
+        def processedContent = templateContent
+
+        processedContent = processedContent.replace('${BRANCH}', branch.trim())
+        // Write the processed content
+        String commentBodyFilePath = "${WORKSPACE}/${component}.md"
+        writeFile(file: commentBodyFilePath , text: processedContent)
+        return commentBodyFilePath
+    } catch (Exception e) {
+        error "Failed to process template: ${e.getMessage()}"
+    }
+}


### PR DESCRIPTION
### Description
The python [release workflow](https://github.com/opensearch-project/opensearch-build/tree/main/src/release_notes_workflow) in build-repo generates a markdown table in the format: https://github.com/opensearch-project/opensearch-build/issues/3747#issuecomment-2704366641
This change adds below things:
- Adds a class to parse the markdown file and return each component with respective values mapped to the keys.
- Adds a new library that will `check` or `notify` the release owners about the missing release notes. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5332

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
