### PR TITLE
Add a library to check code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ sourceSets {
 
     test {
         groovy {
-            srcDirs = ['tests/jenkins', 'tests/gradlecheck']
+            srcDirs = ['tests/jenkins', 'tests/gradlecheck', 'tests/utils']
         }
     }
 

--- a/resources/release/missing-code-coverage.md
+++ b/resources/release/missing-code-coverage.md
@@ -1,0 +1,6 @@
+Hi, </br>
+
+This component is not reporting code-coverage for branch [$BRANCH]($CODECOV_URL). </br>
+Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>
+
+Thank you!

--- a/resources/release/missing-code-coverage.md
+++ b/resources/release/missing-code-coverage.md
@@ -1,6 +1,6 @@
 Hi, </br>
 
-This component is not reporting code-coverage for branch [$BRANCH]($CODECOV_URL). </br>
+$COMPONENT_NAME is not reporting code-coverage for branch [$BRANCH]($CODECOV_URL). </br>
 Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>
 
 Thank you!

--- a/src/jenkins/ComponentRepoData.groovy
+++ b/src/jenkins/ComponentRepoData.groovy
@@ -18,19 +18,15 @@ class ComponentRepoData {
     String awsSecretKey
     String awsSessionToken
     String version
-    String indexName
     def script
-    def openSearchMetricsQuery
 
-    ComponentRepoData(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String version, String indexName, def script) {
+    ComponentRepoData(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String version, def script) {
         this.metricsUrl = metricsUrl
         this.awsAccessKey = awsAccessKey
         this.awsSecretKey = awsSecretKey
         this.awsSessionToken = awsSessionToken
         this.version = version
-        this.indexName = indexName
         this.script = script
-        this.openSearchMetricsQuery = new OpenSearchMetricsQuery(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, script)
     }
 
     String getMaintainersQuery(String repository, Boolean inactive=false) {
@@ -68,13 +64,67 @@ class ComponentRepoData {
         return query.replace('"', '\\"')
     }
 
-    ArrayList getMaintainers(String repository, Boolean inactive=false) {
+    String getCodeCoverageQuery(String repository) {
+        def queryMap = [
+                size   : 1,
+                _source: [
+                        "coverage",
+                        "branch",
+                        "state",
+                        "url"
+                ],
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        "repository.keyword": "${repository}"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        "version": "${this.version}"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ],
+                sort   : [
+                        [
+                                current_date: [
+                                        order: "desc"
+                                ]
+                        ]
+                ]
+        ]
+        String query = JsonOutput.toJson(queryMap)
+        return query.replace('"', '\\"')
+    }
+
+    ArrayList getMaintainers(String repository, String indexName, Boolean inactive=false) {
         try {
-            def jsonResponse = this.openSearchMetricsQuery.fetchMetrics(getMaintainersQuery(repository, inactive))
+            def openSearchMetricsQuery = new OpenSearchMetricsQuery(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, script)
+            def jsonResponse = openSearchMetricsQuery.fetchMetrics(getMaintainersQuery(repository, inactive))
             def maintainers = jsonResponse.hits.hits.collect { it._source.github_login }
             return maintainers
         } catch (Exception e) {
             this.script.println("Error fetching the maintainers for ${repository}: ${e.message}")
+            return null
+        }
+    }
+
+    def getCodeCoverage(String repository, String indexName) {
+        try {
+            def openSearchMetricsQuery = new OpenSearchMetricsQuery(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, script)
+            def jsonResponse = openSearchMetricsQuery.fetchMetrics(getCodeCoverageQuery(repository))
+            return [
+                    coverage: jsonResponse.hits.hits[0]._source.coverage,
+                    state: jsonResponse.hits.hits[0]._source.state,
+                    branch: jsonResponse.hits.hits[0]._source.branch,
+                    url: jsonResponse.hits.hits[0]._source.url
+            ]
+        } catch (Exception e) {
+            this.script.println("Error fetching code coverage metrics for ${repository}: ${e.message}")
             return null
         }
     }

--- a/src/utils/TemplateProcessor.groovy
+++ b/src/utils/TemplateProcessor.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils
+
+import groovy.text.GStringTemplateEngine
+
+class TemplateProcessor implements Serializable {
+    def script
+
+    TemplateProcessor(script) {
+        this.script = script
+    }
+
+    def process(String pathToTemplate, def bindings, String outputDir) {
+        try {
+            def randomName = getRandomName()
+            def content = this.script.libraryResource pathToTemplate
+            String result = new GStringTemplateEngine().createTemplate(content).make(bindings).toString()
+            String processedTemplatePath = "${outputDir}/${randomName}.md"
+            this.script.writeFile(file: processedTemplatePath , text: result.toString())
+            this.script.println("Wrote file to ${processedTemplatePath}")
+            return processedTemplatePath
+        } catch (Exception e) {
+            this.script.error("Failed to process template: ${e.getMessage()}")
+        }
+    }
+
+    private static getRandomName(){
+        def random = new Random()
+        def randomName = (1..10).collect { ('A'..'Z')[random.nextInt(26)] }.join("")
+        return randomName
+    }
+}

--- a/tests/jenkins/TestCheckCodeCoverage.groovy
+++ b/tests/jenkins/TestCheckCodeCoverage.groovy
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import jenkins.tests.BuildPipelineTest
+import jenkins.tests.CheckCodeCoverageLibTester
+import jenkins.tests.CheckReleaseNotesLibTester
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.allOf
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.MatcherAssert.assertThat
+import utils.TemplateProcessor
+
+class TestCheckCodeCoverage extends BuildPipelineTest {
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('withCredentials', [Map])
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken'
+        ])
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.addFileExistsMock('tests/data/opensearch-1.3.0.yml', true)
+        def coverageResponse = '''
+                {
+                  "took": 3,
+                  "timed_out": false,
+                  "_shards": {
+                    "total": 5,
+                    "successful": 5,
+                    "skipped": 0,
+                    "failed": 0
+                  },
+                  "hits": {
+                    "total": {
+                      "value": 20,
+                      "relation": "eq"
+                    },
+                    "max_score": null,
+                    "hits": [
+                      {
+                        "_index": "opensearch-codecov-metrics-03-2025",
+                        "_id": "5e8f90ec-983d-362c-8828-ecff1731f301",
+                        "_score": null,
+                        "_source": {
+                          "coverage": 0,
+                          "state": "no-coverage",
+                          "branch": "1.3",
+                          "url": "https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3"
+                        },
+                        "sort": [
+                          1742505921205
+                        ]
+                      }
+                    ]
+                  }
+                }
+                    '''
+
+
+        def releaseIssueResponse = '''
+                    {
+                      "took": 5,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 10,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch_release_metrics",
+                            "_id": "fec68961-abdb-3e49-b97f-b656b0a9a510",
+                            "_score": null,
+                            "_source": {
+                              "release_issue": "https://github.com/opensearch-project/OpenSearch/issues/5152"
+                            },
+                            "sort": [
+                              1738866320789
+                            ]
+                          }
+                        ]
+                      }
+                    }
+'''
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-codecov-metrics-03-2025/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+            return [stdout: coverageResponse, exitValue: 0]
+        }
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch_release_metrics/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}},{\\"match_phrase\\":{\\"repository\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+            return [stdout: releaseIssueResponse, exitValue: 0]
+        }
+    }
+
+    @Test
+    void testNotifyAction() {
+        addParam('ACTION', 'notify')
+        this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'notify'))
+        super.testPipeline('tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile')
+        def fileContent = getCommands('writeFile', 'code-coverage')[0]
+        assertThat(fileContent, allOf(
+                containsString("This component is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>"),
+                containsString("Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>")
+        ))
+        assertThat(getCommands('sh', 'script'), hasItem(containsString("gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file")))
+    }
+
+    @Test
+    void testCheckAction() {
+        addParam('ACTION', 'check')
+        def coverageResponse = '''
+                {
+                  "took": 4,
+                  "timed_out": false,
+                  "_shards": {
+                    "total": 5,
+                    "successful": 5,
+                    "skipped": 0,
+                    "failed": 0
+                  },
+                  "hits": {
+                    "total": {
+                      "value": 20,
+                      "relation": "eq"
+                    },
+                    "max_score": null,
+                    "hits": [
+                      {
+                        "_index": "opensearch-codecov-metrics-03-2025",
+                        "_id": "5e8f90ec-983d-362c-8828-ecff1731f301",
+                        "_score": null,
+                        "_source": {
+                          "coverage": 71.98,
+                          "state": "complete",
+                          "branch": "1.3",
+                          "url": "https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3"
+                        },
+                        "sort": [
+                          1742505921205
+                        ]
+                      }
+                    ]
+                  }
+                }
+                    '''
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-codecov-metrics-03-2025/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+            return [stdout: coverageResponse, exitValue: 0]
+        }
+        this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'check'))
+        runScript('tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile')
+        assertThat(getCommands('echo', 'components'), hasItem("All components are reporting code coverage."))
+    }
+
+    @Test
+    void testMispelledAction() {
+        addParam('ACTION', 'chek')
+        this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'chek'))
+        runScript('tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile')
+        assertThat(getCommands('error', ''), hasItem("Invalid action 'chek'. Valid values: check, notify"))
+        assertJobStatusFailure()
+    }
+
+    def getCommands(method, text) {
+        def shCommands = helper.callStack.findAll { call ->
+            call.methodName == method
+        }.collect { call ->
+            callArgsToString(call)
+        }.findAll { command ->
+            command.contains(text)
+        }
+        return shCommands
+    }
+}

--- a/tests/jenkins/TestCheckCodeCoverage.groovy
+++ b/tests/jenkins/TestCheckCodeCoverage.groovy
@@ -17,9 +17,7 @@ import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.hasItem
-import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
-import utils.TemplateProcessor
 
 class TestCheckCodeCoverage extends BuildPipelineTest {
     @Override
@@ -118,14 +116,16 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
     @Test
     void testNotifyAction() {
         addParam('ACTION', 'notify')
+        Random.metaClass.nextInt = { int max -> 1 }
         this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'notify'))
         super.testPipeline('tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile')
         def fileContent = getCommands('writeFile', 'code-coverage')[0]
         assertThat(fileContent, allOf(
+                containsString("{file=/tmp/workspace/BBBBBBBBBB.md, text=Hi, </br>"),
                 containsString("This component is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>"),
                 containsString("Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>")
         ))
-        assertThat(getCommands('sh', 'script'), hasItem(containsString("gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file")))
+        assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file /tmp/workspace/BBBBBBBBBB.md, returnStdout=true}"))
     }
 
     @Test

--- a/tests/jenkins/TestCheckCodeCoverage.groovy
+++ b/tests/jenkins/TestCheckCodeCoverage.groovy
@@ -122,7 +122,7 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
         def fileContent = getCommands('writeFile', 'code-coverage')[0]
         assertThat(fileContent, allOf(
                 containsString("{file=/tmp/workspace/BBBBBBBBBB.md, text=Hi, </br>"),
-                containsString("This component is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>"),
+                containsString("OpenSearch is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>"),
                 containsString("Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>")
         ))
         assertThat(getCommands('sh', 'script'), hasItem("{script=gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file /tmp/workspace/BBBBBBBBBB.md, returnStdout=true}"))

--- a/tests/jenkins/TestComponentRepoData.groovy
+++ b/tests/jenkins/TestComponentRepoData.groovy
@@ -146,4 +146,112 @@ class TestComponentRepoData {
         def result = componentRepoData.getMaintainers('sql', maintainersIndexName )
         assert result == null
     }
+
+    @Test
+    void testGetCodeCoverageQuery() {
+        String expectedOutput = JsonOutput.toJson([
+                size   : 1,
+                _source: [
+                        "coverage",
+                        "branch",
+                        "state",
+                        "url"
+                ],
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        "repository.keyword": "OpenSearch"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        "version": "${this.version}"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ],
+                sort   : [
+                        [
+                                current_date: [
+                                        order: "desc"
+                                ]
+                        ]
+                ]
+        ]).replace('"', '\\"')
+        def result = componentRepoData.getCodeCoverageQuery('OpenSearch')
+        assert result == expectedOutput
+    }
+
+    @Test
+    void testGetCodeCoverage() {
+        script = new Expando()
+        script.sh = { Map args ->
+            if (args.containsKey("script")) {
+                return """
+                    {
+                      "took": 4,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 22,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch-codecov-metrics-03-2025",
+                            "_id": "a23e3d82-d0fa-3904-989d-5eb6b6a38efc",
+                            "_score": null,
+                            "_source": {
+                              "coverage": 71.98,
+                              "state": "complete",
+                              "branch": "2.18",
+                              "url": "https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=2.18"
+                            },
+                            "sort": [
+                              1742603121408
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                """
+            }
+            return ""
+        }
+        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
+        def expectedOutput = [
+                coverage: 71.98,
+                state: "complete",
+                branch: "2.18",
+                url: "https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=2.18"
+        ]
+        def result = componentRepoData.getCodeCoverage('OpenSearch', 'opensearch-code-coverage-metrics')
+        assert  result == expectedOutput
+    }
+
+    @Test
+    void testGetCodeCoverageException() {
+        script = new Expando()
+        script.println = { String message ->
+            assert message.startsWith("Error fetching code coverage metrics for OpenSearch:")
+        }
+        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
+        componentRepoData.metaClass.openSearchMetricsQuery = [
+                fetchMetrics: { query ->
+                    throw new RuntimeException("Test exception")
+                }
+        ]
+        def result = componentRepoData.getCodeCoverage('OpenSearch', 'opensearch-code-coverage-metrics')
+        assert result == null
+    }
 }

--- a/tests/jenkins/TestComponentRepoData.groovy
+++ b/tests/jenkins/TestComponentRepoData.groovy
@@ -20,7 +20,7 @@ class TestComponentRepoData {
     private final String awsSecretKey = 'testSecretKey'
     private final String awsSessionToken = 'testSessionToken'
     private final String version = "2.18.0"
-    private final String indexName = 'maintainer-inactivity-03-2025'
+    private final String maintainersIndexName = 'maintainer-inactivity-03-2025'
     private def script
 
     @Before
@@ -84,7 +84,7 @@ class TestComponentRepoData {
             }
             return ""
         }
-        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, indexName, script)
+        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
     }
 
     @Test
@@ -127,7 +127,7 @@ class TestComponentRepoData {
     @Test
     void testGetMaintainers(){
         def expectedOutput = ['foo', 'bar']
-        def result = componentRepoData.getMaintainers('sql')
+        def result = componentRepoData.getMaintainers('sql', maintainersIndexName)
         assert  result == expectedOutput
     }
 
@@ -137,13 +137,13 @@ class TestComponentRepoData {
         script.println = { String message ->
             assert message.startsWith("Error fetching the maintainers for sql:")
         }
-        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, indexName, script)
-        componentRepoData.openSearchMetricsQuery = [
+        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
+        componentRepoData.metaClass.openSearchMetricsQuery = [
                 fetchMetrics: { query ->
                     throw new RuntimeException("Test exception")
                 }
         ]
-        def result = componentRepoData.getMaintainers('sql')
+        def result = componentRepoData.getMaintainers('sql', maintainersIndexName )
         assert result == null
     }
 }

--- a/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile
+++ b/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile
@@ -1,0 +1,31 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+*/
+
+pipeline {
+    agent none
+    parameters {
+        string(
+            name: 'ACTION',
+            description: 'Actions to take',
+            trim: true
+        )
+    }
+    stages {
+        stage('check-code-coverage') {
+            steps {
+                script {
+                    checkCodeCoverage(
+                        inputManifest: ["tests/data/opensearch-1.3.0.yml"],
+                        action: "${params.ACTION}"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
@@ -27,12 +27,12 @@
             set +x
             curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"repository\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
         , returnStdout=true})
-                        TemplateProcessor.process(release/missing-code-coverage.md, {BRANCH=1.3, CODECOV_URL=https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3}, /tmp/workspace)
+                        TemplateProcessor.process(release/missing-code-coverage.md, {BRANCH=1.3, CODECOV_URL=https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3, COMPONENT_NAME=OpenSearch}, /tmp/workspace)
                            TemplateProcessor.getRandomName()
                            checkCodeCoverage.libraryResource(release/missing-code-coverage.md)
                            checkCodeCoverage.writeFile({file=/tmp/workspace/BBBBBBBBBB.md, text=Hi, </br>
 
-This component is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>
+OpenSearch is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>
 Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>
 
 Thank you!

--- a/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
@@ -30,15 +30,15 @@
                         TemplateProcessor.process(release/missing-code-coverage.md, {BRANCH=1.3, CODECOV_URL=https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3}, /tmp/workspace)
                            TemplateProcessor.getRandomName()
                            checkCodeCoverage.libraryResource(release/missing-code-coverage.md)
-                           checkCodeCoverage.writeFile({file=/tmp/workspace/BCNWQONCDN.md, text=Hi, </br>
+                           checkCodeCoverage.writeFile({file=/tmp/workspace/BBBBBBBBBB.md, text=Hi, </br>
 
 This component is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>
 Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>
 
 Thank you!
 })
-                           checkCodeCoverage.println(Wrote file to /tmp/workspace/BCNWQONCDN.md)
+                           checkCodeCoverage.println(Wrote file to /tmp/workspace/BBBBBBBBBB.md)
                         checkCodeCoverage.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                         checkCodeCoverage.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
-                           checkCodeCoverage.sh({script=gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file /tmp/workspace/BCNWQONCDN.md, returnStdout=true})
+                           checkCodeCoverage.sh({script=gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file /tmp/workspace/BBBBBBBBBB.md, returnStdout=true})
                   checkCodeCoverage.echo(Components missing code coverage are: [OpenSearch:https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3])

--- a/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
@@ -1,0 +1,44 @@
+   CheckCodeCoverage_Jenkinsfile.run()
+      CheckCodeCoverage_Jenkinsfile.pipeline(groovy.lang.Closure)
+         CheckCodeCoverage_Jenkinsfile.echo(Executing on agent [label:none])
+         CheckCodeCoverage_Jenkinsfile.stage(check-code-coverage, groovy.lang.Closure)
+            CheckCodeCoverage_Jenkinsfile.script(groovy.lang.Closure)
+               CheckCodeCoverage_Jenkinsfile.checkCodeCoverage({inputManifest=[tests/data/opensearch-1.3.0.yml], action=notify})
+                  checkCodeCoverage.fileExists(tests/data/opensearch-1.3.0.yml)
+                  checkCodeCoverage.readYaml({file=tests/data/opensearch-1.3.0.yml})
+                  checkCodeCoverage.readYaml({file=tests/data/opensearch-1.3.0.yml})
+                  checkCodeCoverage.string({credentialsId=jenkins-health-metrics-account-number, variable=METRICS_HOST_ACCOUNT})
+                  checkCodeCoverage.string({credentialsId=jenkins-health-metrics-cluster-endpoint, variable=METRICS_HOST_URL})
+                  checkCodeCoverage.withCredentials([METRICS_HOST_ACCOUNT, METRICS_HOST_URL], groovy.lang.Closure)
+                     checkCodeCoverage.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                        ComponentRepoData.getCodeCoverage(OpenSearch, opensearch-codecov-metrics-03-2025)
+                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkCodeCoverage.println(Running query: {\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkCodeCoverage.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch-codecov-metrics-03-2025/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+        , returnStdout=true})
+                        ReleaseMetricsData.getReleaseIssue(OpenSearch)
+                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"repository\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkCodeCoverage.println(Running query: {\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"repository\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkCodeCoverage.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"repository\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+        , returnStdout=true})
+                        TemplateProcessor.process(release/missing-code-coverage.md, {BRANCH=1.3, CODECOV_URL=https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3}, /tmp/workspace)
+                           TemplateProcessor.getRandomName()
+                           checkCodeCoverage.libraryResource(release/missing-code-coverage.md)
+                           checkCodeCoverage.writeFile({file=/tmp/workspace/BCNWQONCDN.md, text=Hi, </br>
+
+This component is not reporting code-coverage for branch [1.3](https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3). </br>
+Please fix the issue by checking your CI workflow responsible for reporting code coverage. See the details on [code coverage reporting](https://github.com/opensearch-project/opensearch-plugins/blob/main/TESTING.md#code-coverage-reporting) </br>
+
+Thank you!
+})
+                           checkCodeCoverage.println(Wrote file to /tmp/workspace/BCNWQONCDN.md)
+                        checkCodeCoverage.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                        checkCodeCoverage.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                           checkCodeCoverage.sh({script=gh issue comment https://github.com/opensearch-project/OpenSearch/issues/5152 --body-file /tmp/workspace/BCNWQONCDN.md, returnStdout=true})
+                  checkCodeCoverage.echo(Components missing code coverage are: [OpenSearch:https://api.codecov.io/api/v2/github/opensearch-project/repos/OpenSearch/commits?branch=1.3])

--- a/tests/jenkins/lib-testers/CheckCodeCoverageLibTester.groovy
+++ b/tests/jenkins/lib-testers/CheckCodeCoverageLibTester.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import jenkins.tests.LibFunctionTester
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class CheckCodeCoverageLibTester extends LibFunctionTester {
+    private List inputManifest
+    private String action
+
+    public CheckCodeCoverageLibTester(inputManifest, action) {
+        this.inputManifest = inputManifest
+        this.action = action
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'checkCodeCoverage'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        assertThat(call.args.inputManifest.first(), notNullValue())
+        assertThat(call.args.action.first(), notNullValue())
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.inputManifest.first().equals(this.inputManifest)
+                && call.args.action.first().toString().equals(this.action)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {}
+}
+

--- a/tests/utils/TestOpenSearchMetricsQuery.groovy
+++ b/tests/utils/TestOpenSearchMetricsQuery.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils.tests
+
+import groovy.json.JsonSlurperClassic
+import org.junit.Before
+import org.junit.Test
+import utils.OpenSearchMetricsQuery
+import static org.junit.Assert.assertEquals
+
+class TestOpenSearchMetricsQuery {
+    def script
+    def scriptArgs
+    String response
+
+    @Before
+    void setUp() {
+        script = new Expando()
+
+        script.sh = { Map args ->
+            scriptArgs = args
+            // Mock implementation to verify the file is written correctly
+            response = """
+                    {
+                      "took": 4,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                     }"""
+            if (args.containsKey("script")) {
+                return response
+            }
+        }
+
+        script.println = { message ->
+            // Mock implementation for println
+            println(message)
+        }
+    }
+
+    @Test
+    void testOpenSearchMetricsQuery() {
+        def query = "{\\\"size\\\":1,\\\"_source\\\":[\\\"coverage\\\",\\\"branch\\\",\\\"state\\\",\\\"url\\\"],\\\"query\\\":{\\\"bool\\\":{\\\"filter\\\":[{\\\"match_phrase\\\":{\\\"repository.keyword\\\":\\\"OpenSearch\\\"}},{\\\"match_phrase\\\":{\\\"version\\\":\\\"2.19.0\\\"}}]}},\\\"sort\\\":[{\\\"current_date\\\":{\\\"order\\\":\\\"desc\\\"}}]}"
+        def expectedScript = """
+            set -e
+            set +x
+            curl -s -XGET "metricsUrl/sampleIndex/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "awsAccessKey:awsSecretKey" -H "x-amz-security-token:awsSessionToken" -H 'Content-Type: application/json' -d "${query}" | jq '.'
+            """
+        def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", "sampleIndex", this.script)
+        def result  = metricsQuery.fetchMetrics(query)
+        assertEquals(result, new JsonSlurperClassic().parseText(response))
+        assertEquals(expectedScript.trim(), scriptArgs.script.trim())
+    }
+}
+

--- a/tests/utils/TestTemplateProcessor.groovy
+++ b/tests/utils/TestTemplateProcessor.groovy
@@ -57,7 +57,26 @@ class TestTemplateProcessor {
         assertEquals(writtenFiles["Content"].toString(),"[This is a test template checking values for main and 3.0]" )
     }
 
-    @Test
+//    @Test
+//    void testProcessorException() {
+//        def bindings = [
+//                BRANCH: '',
+//                VERSION: '3.0'
+//        ]
+//        script.libraryResource = { path ->
+//            // Return a sample template content for testing
+//            throw new IOException("Resource not found, ${path}")
+//        }
+//        def templateProcessor = new TemplateProcessor(script)
+//        try {
+//            templateProcessor.process("/tmp", bindings, '/tmp/workspace')
+//            fail("Expected an exception to be thrown")
+//        } catch (Exception e) {
+//            assertEquals("Failed to process template: Resource not found, /tmp", e.getMessage())
+//        }
+//    }
+
+    @Test(expected = Exception.class )
     void testProcessorException() {
         def bindings = [
                 BRANCH: '',
@@ -68,12 +87,7 @@ class TestTemplateProcessor {
             throw new IOException("Resource not found, ${path}")
         }
         def templateProcessor = new TemplateProcessor(script)
-        try {
-            templateProcessor.process("/tmp", bindings, '/tmp/workspace')
-            fail("Expected an exception to be thrown")
-        } catch (Exception e) {
-            assertEquals("Failed to process template: Resource not found, /tmp", e.getMessage())
-        }
+        templateProcessor.process("/tmp", bindings, '/tmp/workspace')
     }
 }
 

--- a/tests/utils/TestTemplateProcessor.groovy
+++ b/tests/utils/TestTemplateProcessor.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils.tests
+
+
+import org.junit.Before
+import org.junit.Test
+import utils.TemplateProcessor
+import static org.junit.Assert.assertEquals
+
+class TestTemplateProcessor {
+    def script
+    def writtenFiles =[:]
+
+    @Before
+    void setUp() {
+        script = new Expando()
+        script.libraryResource = { path ->
+            // Return a sample template content for testing
+            return "This is a test template checking values for \$BRANCH and \$VERSION"
+        }
+        script.writeFile = { Map params ->
+            // Mock implementation to verify the file is written correctly
+            writtenFiles["Content"] = ["${params.text}"]
+            return true
+        }
+
+        script.println = { message ->
+            // Mock implementation for println
+            println(message)
+        }
+
+        script.error = { message ->
+            // Mock implementation for error
+            throw new Exception(message)
+        }
+    }
+
+    @Test
+    void testProcessor() {
+
+        def bindings = [
+                BRANCH: 'main',
+                VERSION: '3.0'
+        ]
+        def templateProcessor = new TemplateProcessor(script)
+        def result  = templateProcessor.process("release/missing-code-coverage.md", bindings, '/tmp/workspace')
+        assert result.startsWith("/tmp/workspace/")
+        assertEquals(writtenFiles["Content"].toString(),"[This is a test template checking values for main and 3.0]" )
+    }
+}
+

--- a/tests/utils/TestTemplateProcessor.groovy
+++ b/tests/utils/TestTemplateProcessor.groovy
@@ -45,14 +45,14 @@ class TestTemplateProcessor {
 
     @Test
     void testProcessor() {
-
+        Random.metaClass.nextInt = { int max -> 1 }
         def bindings = [
                 BRANCH: 'main',
                 VERSION: '3.0'
         ]
         def templateProcessor = new TemplateProcessor(script)
         def result  = templateProcessor.process("release/missing-code-coverage.md", bindings, '/tmp/workspace')
-        assert result.startsWith("/tmp/workspace/")
+        assertEquals (result, "/tmp/workspace/BBBBBBBBBB.md")
         assertEquals(writtenFiles["Content"].toString(),"[This is a test template checking values for main and 3.0]" )
     }
 }

--- a/tests/utils/TestTemplateProcessor.groovy
+++ b/tests/utils/TestTemplateProcessor.groovy
@@ -57,26 +57,7 @@ class TestTemplateProcessor {
         assertEquals(writtenFiles["Content"].toString(),"[This is a test template checking values for main and 3.0]" )
     }
 
-//    @Test
-//    void testProcessorException() {
-//        def bindings = [
-//                BRANCH: '',
-//                VERSION: '3.0'
-//        ]
-//        script.libraryResource = { path ->
-//            // Return a sample template content for testing
-//            throw new IOException("Resource not found, ${path}")
-//        }
-//        def templateProcessor = new TemplateProcessor(script)
-//        try {
-//            templateProcessor.process("/tmp", bindings, '/tmp/workspace')
-//            fail("Expected an exception to be thrown")
-//        } catch (Exception e) {
-//            assertEquals("Failed to process template: Resource not found, /tmp", e.getMessage())
-//        }
-//    }
-
-    @Test(expected = Exception.class )
+    @Test
     void testProcessorException() {
         def bindings = [
                 BRANCH: '',
@@ -87,7 +68,12 @@ class TestTemplateProcessor {
             throw new IOException("Resource not found, ${path}")
         }
         def templateProcessor = new TemplateProcessor(script)
-        templateProcessor.process("/tmp", bindings, '/tmp/workspace')
+        try {
+            templateProcessor.process("/tmp", bindings, '/tmp/workspace')
+            fail("Expected an exception to be thrown")
+        } catch (Exception e) {
+            assertEquals("Failed to process template: Resource not found, /tmp", e.getMessage())
+        }
     }
 }
 

--- a/tests/utils/TestTemplateProcessor.groovy
+++ b/tests/utils/TestTemplateProcessor.groovy
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import utils.TemplateProcessor
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThrows
 
 class TestTemplateProcessor {
     def script
@@ -54,6 +55,25 @@ class TestTemplateProcessor {
         def result  = templateProcessor.process("release/missing-code-coverage.md", bindings, '/tmp/workspace')
         assertEquals (result, "/tmp/workspace/BBBBBBBBBB.md")
         assertEquals(writtenFiles["Content"].toString(),"[This is a test template checking values for main and 3.0]" )
+    }
+
+    @Test
+    void testProcessorException() {
+        def bindings = [
+                BRANCH: '',
+                VERSION: '3.0'
+        ]
+        script.libraryResource = { path ->
+            // Return a sample template content for testing
+            throw new IOException("Resource not found, ${path}")
+        }
+        def templateProcessor = new TemplateProcessor(script)
+        try {
+            templateProcessor.process("/tmp", bindings, '/tmp/workspace')
+            fail("Expected an exception to be thrown")
+        } catch (Exception e) {
+            assertEquals("Failed to process template: Resource not found, /tmp", e.getMessage())
+        }
     }
 }
 

--- a/vars/checkCodeCoverage.groovy
+++ b/vars/checkCodeCoverage.groovy
@@ -87,6 +87,7 @@ private void validateParameters(Map args, action) {
 /**
  * Notify components regarding the missing code coverage adding a comment to the release issue.
  * @param codeCoverage: Map of args with with branch and url.
+ * @param releaseIssue: GitHub release issue URL
  */
 private void notifyReleaseOwners(Map codeCoverage, String releaseIssue) {
     try {

--- a/vars/checkCodeCoverage.groovy
+++ b/vars/checkCodeCoverage.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import jenkins.ComponentRepoData
+import jenkins.ReleaseMetricsData
+import java.time.LocalDate
+import utils.TemplateProcessor
+/**
+ * Library to check and notify missing code coverage.
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.inputManifest <required> - Array of input manifest(s). eg: ["manifests/2.0.0/opensearch-2.0.0.yml", "manifests/2.0.0/opensearch-dashboards-2.0.0.yml"]
+ * @param args.action <optional> - Action to perform. Default is 'check'. Acceptable values are 'check' and 'notify'.
+ */
+void call(Map args = [:]) {
+    String action = args.action ?: 'check'
+    // Parameter check
+    validateParameters(args, action)
+    def inputManifests = args.inputManifest
+    def inputManifestYaml = readYaml(file: args.inputManifest[0])
+    def version = inputManifestYaml.build.version
+    version = version.tokenize('-')[0] // Get only version and skip the qualifier
+    def now = LocalDate.now()
+    def monthYear = String.format("%02d-%d", now.monthValue, now.year)
+    def codeCoverageIndex = "opensearch-codecov-metrics-${monthYear}"
+    def componentsMissingCodeCoverageWithUrl = [:]
+
+    inputManifests.each { inputManifestFile ->
+        def inputManifestObj = readYaml(file: inputManifestFile)
+        withCredentials([
+                string(credentialsId: 'jenkins-health-metrics-account-number', variable: 'METRICS_HOST_ACCOUNT'),
+                string(credentialsId: 'jenkins-health-metrics-cluster-endpoint', variable: 'METRICS_HOST_URL')]) {
+            withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+                def metricsUrl = env.METRICS_HOST_URL
+                def awsAccessKey = env.AWS_ACCESS_KEY_ID
+                def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+                def awsSessionToken = env.AWS_SESSION_TOKEN
+
+                def componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
+                def releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
+                inputManifestObj.components.each { component ->
+                    String repoName = component.repository.toString().split('/')[-1].replace('.git', '')
+                    def codeCoverage = componentRepoData.getCodeCoverage(repoName, codeCoverageIndex)
+                    def releaseIssue = releaseMetricsData.getReleaseIssue(repoName)
+                    if (!codeCoverage.isEmpty() && codeCoverage.state == "no-coverage") { // Also equivalent to codeCoverage.coverage == 0
+                        componentsMissingCodeCoverageWithUrl[component.name] = codeCoverage.url
+                        if (args.action == 'notify') {
+                            notifyReleaseOwners(codeCoverage, releaseIssue)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (componentsMissingCodeCoverageWithUrl) {
+        echo("Components missing code coverage are: ${componentsMissingCodeCoverageWithUrl}")
+    } else {
+        echo('All components are reporting code coverage.')
+    }
+}
+
+/**
+ * Validates input parameters
+ */
+private void validateParameters(Map args, action) {
+    if (!args.inputManifest || args.inputManifest.isEmpty()) {
+        error "inputManifest parameter is required."
+    } else {
+        args.inputManifest.each { inputManifestFile ->
+            if (!fileExists(inputManifestFile)) {
+                error("Invalid path. Input manifest file does not exist at ${inputManifestFile}")
+            }
+        }
+    }
+
+    List<String> validActions = ['check', 'notify']
+    if (!validActions.contains(action)) {
+        error "Invalid action '${action}'. Valid values: ${validActions.join(', ')}"
+    }
+}
+
+/**
+ * Notify components regarding the missing code coverage adding a comment to the release issue.
+ * @param codeCoverage: Map of args with with branch and url.
+ */
+private void notifyReleaseOwners(Map codeCoverage, String releaseIssue) {
+    try {
+        def bindings = [
+                BRANCH: codeCoverage.branch,
+                CODECOV_URL: codeCoverage.url
+        ]
+        def ghCommentBodyContent = new TemplateProcessor(this).process("release/missing-code-coverage.md", bindings, "${WORKSPACE}")
+        addComment(releaseIssue, ghCommentBodyContent)
+    } catch (Exception e) {
+        error("Failed to process template: ${e.getMessage()}")
+    }
+}
+
+/**
+ * Add a comment on the Release issue.
+ * @param releaseIssueUrl: Component release issue URL.
+ * @param commentBodyFile: Path to the file containing GitHub comment content.
+ */
+private void addComment(String releaseIssueUrl, def commentBodyFile) {
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        sh(
+                script: "gh issue comment ${releaseIssueUrl} --body-file ${commentBodyFile}",
+                returnStdout: true
+        )
+    }
+}
+

--- a/vars/checkCodeCoverage.groovy
+++ b/vars/checkCodeCoverage.groovy
@@ -49,7 +49,7 @@ void call(Map args = [:]) {
                     if (!codeCoverage.isEmpty() && codeCoverage.state == "no-coverage") { // Also equivalent to codeCoverage.coverage == 0
                         componentsMissingCodeCoverageWithUrl[component.name] = codeCoverage.url
                         if (args.action == 'notify') {
-                            notifyReleaseOwners(codeCoverage, releaseIssue)
+                            notifyReleaseOwners(component.name, codeCoverage, releaseIssue)
                         }
                     }
                 }
@@ -89,11 +89,12 @@ private void validateParameters(Map args, action) {
  * @param codeCoverage: Map of args with with branch and url.
  * @param releaseIssue: GitHub release issue URL
  */
-private void notifyReleaseOwners(Map codeCoverage, String releaseIssue) {
+private void notifyReleaseOwners(String componentName, Map codeCoverage, String releaseIssue) {
     try {
         def bindings = [
                 BRANCH: codeCoverage.branch,
-                CODECOV_URL: codeCoverage.url
+                CODECOV_URL: codeCoverage.url,
+                COMPONENT_NAME: componentName
         ]
         def ghCommentBodyContent = new TemplateProcessor(this).process("release/missing-code-coverage.md", bindings, "${WORKSPACE}")
         addComment(releaseIssue, ghCommentBodyContent)


### PR DESCRIPTION
### Description
Add a library to check code coverage for all the components in the release. Currently this will only report components missing the code coverage. Regarding meeting the threshold or not, we will be adding in next iteration once we know everyone is on-board.
This change also add a new utility to parse the template using [GStringTemplateEngine](https://docs.groovy-lang.org/latest/html/api/groovy/text/GStringTemplateEngine.html) that would help replacing the values and also add conditions based on values within the template much easier in the future.

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/5332

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
