### PR TITLE
Add null check and fix test cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.4.0'
+String version = '8.4.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestCheckCodeCoverage.groovy
+++ b/tests/jenkins/TestCheckCodeCoverage.groovy
@@ -13,6 +13,7 @@ import jenkins.tests.CheckCodeCoverageLibTester
 import jenkins.tests.CheckReleaseNotesLibTester
 import org.junit.Before
 import org.junit.Test
+import java.time.LocalDate
 import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.allOf
@@ -20,6 +21,10 @@ import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.MatcherAssert.assertThat
 
 class TestCheckCodeCoverage extends BuildPipelineTest {
+        def now = LocalDate.now()
+        def monthYear = String.format("%02d-%d", now.monthValue, now.year)
+        def codeCoverageIndex = "opensearch-codecov-metrics-${monthYear}"
+
     @Override
     @Before
     void setUp() {
@@ -54,7 +59,7 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
                     "max_score": null,
                     "hits": [
                       {
-                        "_index": "opensearch-codecov-metrics-03-2025",
+                        "_index": "${codeCoverageIndex}",
                         "_id": "5e8f90ec-983d-362c-8828-ecff1731f301",
                         "_score": null,
                         "_source": {
@@ -105,7 +110,7 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
                       }
                     }
 '''
-        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-codecov-metrics-03-2025/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
             return [stdout: coverageResponse, exitValue: 0]
         }
         helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch_release_metrics/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}},{\\"match_phrase\\":{\\"repository\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
@@ -150,7 +155,7 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
                     "max_score": null,
                     "hits": [
                       {
-                        "_index": "opensearch-codecov-metrics-03-2025",
+                        "_index": "${codeCoverageIndex}",
                         "_id": "5e8f90ec-983d-362c-8828-ecff1731f301",
                         "_score": null,
                         "_source": {
@@ -167,7 +172,7 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
                   }
                 }
                     '''
-        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch-codecov-metrics-03-2025/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
             return [stdout: coverageResponse, exitValue: 0]
         }
         this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'check'))

--- a/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile.txt
@@ -11,13 +11,13 @@
                   checkCodeCoverage.string({credentialsId=jenkins-health-metrics-cluster-endpoint, variable=METRICS_HOST_URL})
                   checkCodeCoverage.withCredentials([METRICS_HOST_ACCOUNT, METRICS_HOST_URL], groovy.lang.Closure)
                      checkCodeCoverage.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                        ComponentRepoData.getCodeCoverage(OpenSearch, opensearch-codecov-metrics-03-2025)
+                        ComponentRepoData.getCodeCoverage(OpenSearch, opensearch-codecov-metrics-04-2025)
                            OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
                               checkCodeCoverage.println(Running query: {\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
                               checkCodeCoverage.sh({script=
             set -e
             set +x
-            curl -s -XGET "sample.url/opensearch-codecov-metrics-03-2025/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+            curl -s -XGET "sample.url/opensearch-codecov-metrics-04-2025/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":[\"coverage\",\"branch\",\"state\",\"url\"],\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"repository.keyword\":\"OpenSearch\"}},{\"match_phrase\":{\"version\":\"1.3.0\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
         , returnStdout=true})
                         ReleaseMetricsData.getReleaseIssue(OpenSearch)
                            OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"repository\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})

--- a/vars/checkCodeCoverage.groovy
+++ b/vars/checkCodeCoverage.groovy
@@ -46,7 +46,7 @@ void call(Map args = [:]) {
                     String repoName = component.repository.toString().split('/')[-1].replace('.git', '')
                     def codeCoverage = componentRepoData.getCodeCoverage(repoName, codeCoverageIndex)
                     def releaseIssue = releaseMetricsData.getReleaseIssue(repoName)
-                    if (!codeCoverage.isEmpty() && codeCoverage.state == "no-coverage") { // Also equivalent to codeCoverage.coverage == 0
+                    if (codeCoverage != null && !codeCoverage.isEmpty() && codeCoverage.state == "no-coverage") { // Also equivalent to codeCoverage.coverage == 0
                         componentsMissingCodeCoverageWithUrl[component.name] = codeCoverage.url
                         if (args.action == 'notify') {
                             notifyReleaseOwners(component.name, codeCoverage, releaseIssue)

--- a/vars/checkRequestAssignReleaseOwners.groovy
+++ b/vars/checkRequestAssignReleaseOwners.groovy
@@ -75,7 +75,6 @@ private void validateParameters(Map args) {
     }
 
     String action = args.action
-    println("Action is: ${action}")
     List<String> validActions = ['check', 'assign', 'request']
     if (!validActions.contains(action)) {
         error "Invalid action '${action}'. Valid values: ${validActions.join(', ')}"


### PR DESCRIPTION
### Description
Codecoverage library fails is the returned value is `null` which is possible. This PR adds the null check. 
Fixes tests until aliases are added in metrics project. 

Currently unable to see alias for maintainer-inactivity (cc: @prudhvigodithi @Divyaasm ) 
```
{
  "maintainer-inactivity-04-2025": {
    "aliases": {}
  }
}
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
