### PR TITLE
Add library to check documentation PR status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '9.0.2'
+String version = '9.1.0'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestCheckDocumentationPRs.groovy
+++ b/tests/jenkins/TestCheckDocumentationPRs.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import jenkins.tests.BuildPipelineTest
+import jenkins.tests.CheckDocumentationPullRequestsLibTester
+import org.junit.Before
+import org.junit.Test
+
+
+class TestCheckDocumentationPullRequests extends BuildPipelineTest {
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        helper.registerAllowedMethod('withCredentials', [Map])
+        addParam('VERSION', '3.0.0-beta1')
+    }
+
+    @Test
+    void testGitCommand() {
+        helper.addShMock("""gh pr list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-label:\\"6 - Done but waiting to merge\\"" --json url --jq '.[].url'""") { script ->
+            return [stdout: "https://github.com/opensearch-project/documentation-website/pull/123", exitValue: 0]
+        }
+        this.registerLibTester(new CheckDocumentationPullRequestsLibTester('3.0.0-beta1'))
+        super.testPipeline('tests/jenkins/jobs/CheckDocumentationPRs_Jenkinsfile')
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('checkDocumentationPullRequests.sh({script=gh pr list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-label:\\"6 - Done but waiting to merge\\"" --json url --jq \'.[].url\', returnStdout=true})')
+        assertCallStack().contains('checkDocumentationPullRequests.echo(Documentation pull requests pending to be merged: \n' +
+                'https://github.com/opensearch-project/documentation-website/pull/123)')
+    }
+
+    @Test
+    void testNoPrPending() {
+        helper.addShMock("""gh pr list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-label:\\"6 - Done but waiting to merge\\"" --json url --jq '.[].url'""") { script ->
+            return [stdout: "", exitValue: 0]
+        }
+        this.registerLibTester(new CheckDocumentationPullRequestsLibTester('3.0.0-beta1'))
+        runScript('tests/jenkins/jobs/CheckDocumentationPRs_Jenkinsfile')
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('checkDocumentationPullRequests.sh({script=gh pr list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-label:\\"6 - Done but waiting to merge\\"" --json url --jq \'.[].url\', returnStdout=true})')
+        assertCallStack().contains('No open pull requests found!')
+    }
+}

--- a/tests/jenkins/jobs/CheckDocumentationPRs_Jenkinsfile
+++ b/tests/jenkins/jobs/CheckDocumentationPRs_Jenkinsfile
@@ -1,0 +1,30 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+*/
+
+pipeline {
+    agent none
+    parameters {
+        string(
+            name: 'VERSION',
+            description: 'Release version',
+            trim: true
+        )
+    }
+    stages {
+        stage('check-doc-prs') {
+            steps {
+                script {
+                    checkDocumentationPullRequests(
+                        version: "${params.VERSION}"
+                        )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/CheckDocumentationPRs_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CheckDocumentationPRs_Jenkinsfile.txt
@@ -1,0 +1,11 @@
+   CheckDocumentationPRs_Jenkinsfile.run()
+      CheckDocumentationPRs_Jenkinsfile.pipeline(groovy.lang.Closure)
+         CheckDocumentationPRs_Jenkinsfile.echo(Executing on agent [label:none])
+         CheckDocumentationPRs_Jenkinsfile.stage(check-doc-prs, groovy.lang.Closure)
+            CheckDocumentationPRs_Jenkinsfile.script(groovy.lang.Closure)
+               CheckDocumentationPRs_Jenkinsfile.checkDocumentationPullRequests({version=3.0.0-beta1})
+                  checkDocumentationPullRequests.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                  checkDocumentationPullRequests.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                     checkDocumentationPullRequests.sh({script=gh pr list --repo opensearch-project/documentation-website --state open --label v3.0.0 -S "-label:\"6 - Done but waiting to merge\"" --json url --jq '.[].url', returnStdout=true})
+                     checkDocumentationPullRequests.echo(Documentation pull requests pending to be merged: 
+https://github.com/opensearch-project/documentation-website/pull/123)

--- a/tests/jenkins/lib-testers/CheckDocumentationPullRequestsLibTester.groovy
+++ b/tests/jenkins/lib-testers/CheckDocumentationPullRequestsLibTester.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class CheckDocumentationPullRequestsLibTester extends LibFunctionTester {
+    private String version
+
+    public CheckDocumentationPullRequestsLibTester(version) {
+        this.version = version
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'checkDocumentationPullRequests'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        assertThat(call.args.version.first(), notNullValue())
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.version.first().toString().equals(this.version)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {}
+}
+

--- a/vars/checkDocumentationPullRequests.groovy
+++ b/vars/checkDocumentationPullRequests.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/**
+ * Library to check documentation pull requests per release.
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.version <required> - Release version to track the documentation PRs for.
+ */
+void call(Map args = [:]) {
+    // Validate Parameters
+    validateParameters(args)
+    def versionTokenize = args.version.tokenize('-')
+    // Qualifiers are not a part of the labels in GitHub. Ignoring it.
+    def version = versionTokenize[0]
+
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        def openPRs = sh(
+                script: "gh pr list --repo opensearch-project/documentation-website --state open --label v${version} -S \"-label:\\\"6 - Done but waiting to merge\\\"\" --json url --jq '.[].url'",
+                returnStdout: true
+        )
+        if (openPRs) {
+            echo("Documentation pull requests pending to be merged: \n${openPRs}")
+        } else {
+            echo("No open pull requests found!")
+        }
+    }
+}
+
+/**
+ * Validates input parameters
+ */
+private void validateParameters(Map args) {
+    if (!args.version) {
+        error ('Version is required parameter.')
+    }
+}


### PR DESCRIPTION
### Description
One of the [exit criterias](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#exit-criteria-to-close-release-window) that we are tracking today is
`Documentation has been fully reviewed and signed off by the documentation community.`
This PR adds a mechanism to track the same via automation. Thanks to @kolchfa-aws for helping with the GH query that doc team uses to track the status


### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/5432

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
