### PR TITLE
Authenticate Jenkins calls for RC details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '8.4.1'
+String version = '8.4.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestAddRcDetailsComment.groovy
+++ b/tests/jenkins/TestAddRcDetailsComment.groovy
@@ -222,19 +222,19 @@ class TestAddRcDetailsComment extends BuildPipelineTest {
             return [stdout: osdRcDistributionNumberResponse, exitValue: 0]
         }
 
-        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch/runs/10787/nodes/" | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href'""") { script ->
+        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch/runs/10787/nodes/" --user GITHUB_USER:GITHUB_TOKEN | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href'""") { script ->
             return [stdout: '/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/', exitValue: 0]
         }
 
-        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/" | jq -r '._links.artifacts.href'""") { script ->
+        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/" --user GITHUB_USER:GITHUB_TOKEN | jq -r '._links.artifacts.href'""") { script ->
             return [stdout: '/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/artifacts/', exitValue: 0]
         }
 
-        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/artifacts/" | jq -r '.[] | select(.name | endswith(".txt")) | .url'""") { script ->
+        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/artifacts/" --user GITHUB_USER:GITHUB_TOKEN | jq -r '.[] | select(.name | endswith(".txt")) | .url'""") { script ->
             return [stdout: '/job/docker-scan/4439/artifact/scan_docker_image.txt', exitValue: 0]
         }
 
-        helper.addShMock('curl -s -XGET "https://build.ci.opensearch.org/job/docker-scan/4439/artifact/scan_docker_image.txt"') { script ->
+        helper.addShMock('curl -s -XGET "https://build.ci.opensearch.org/job/docker-scan/4439/artifact/scan_docker_image.txt" --user GITHUB_USER:GITHUB_TOKEN') { script ->
             return [stdout: 'Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0))', exitValue: 0]
         }
         Random.metaClass.nextInt = { int max -> 1 }

--- a/tests/jenkins/TestAddRcDetailsComment.groovy
+++ b/tests/jenkins/TestAddRcDetailsComment.groovy
@@ -259,6 +259,21 @@ class TestAddRcDetailsComment extends BuildPipelineTest {
         assertThat(fileContent, containsString("Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)"))
     }
 
+    @Test
+    void testCommentContentError() {
+        helper.addShMock("""curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch/runs/10787/nodes/" --user GITHUB_USER:GITHUB_TOKEN | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href'""") { script ->
+            return [stdout: 'Parsing error', exitValue: 1]
+        }      
+        this.registerLibTester(new AddRcDetailsCommentLibTester('2.19.0'))
+        runScript('tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile')
+        def fileContent = getCommands('writeFile', 'OpenSearch')[0]
+        assertThat(fileContent, containsString("{file=/tmp/workspace/BBBBBBBBBB.md, text=## See OpenSearch RC 5 and OpenSearch-Dashboards RC 5 details"))
+        assertThat(fileContent, containsString("OpenSearch 10787 and OpenSearch-Dashboards 8260 is ready for your test."))
+        assertThat(fileContent, containsString("image: opensearchstaging/opensearch:2.19.0.1078"))
+        assertThat(fileContent, containsString("image: opensearchstaging/opensearch-dashboards:2.19.0.8260"))
+        assertThat(fileContent, containsString("[Unable to get docker scan results for OpenSearch, RC build number: 10787]"))
+    }    
+
     def getCommands(method, text) {
         def shCommands = helper.callStack.findAll { call ->
             call.methodName == method

--- a/tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile.txt
+++ b/tests/jenkins/jobs/AddRcDetailsComment.jenkinsFile.txt
@@ -48,17 +48,23 @@
             set +x
             curl -s -XGET "sample.url/opensearch-distribution-build-results/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"_source\":\"distribution_build_number\",\"sort\":[{\"distribution_build_number\":{\"order\":\"desc\"}}],\"size\":1,\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"component\":\"OpenSearch-Dashboards\"}},{\"match_phrase\":{\"rc\":\"true\"}},{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"rc_number\":\"5\"}}]}}}" | jq '.'
         , returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch/runs/10787/nodes/" | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href', returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/" | jq -r '._links.artifacts.href', returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/artifacts/" | jq -r '.[] | select(.name | endswith(".txt")) | .url', returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/job/docker-scan/4439/artifact/scan_docker_image.txt", returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch-dashboards/runs/8260/nodes/" | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href', returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.orgbbb
-ccc" | jq -r '._links.artifacts.href', returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.orgbbb
-ccc" | jq -r '.[] | select(.name | endswith(".txt")) | .url', returnStdout=true})
-                  addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.orgbbb
-ccc", returnStdout=true})
+                  addRcDetailsComment.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                  addRcDetailsComment.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                     addRcDetailsComment.println(Getting docker scan results)
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch/runs/10787/nodes/" --user GITHUB_USER:GITHUB_TOKEN | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href', returnStdout=true})
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/" --user GITHUB_USER:GITHUB_TOKEN | jq -r '._links.artifacts.href', returnStdout=true})
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/docker-scan/runs/4439/artifacts/" --user GITHUB_USER:GITHUB_TOKEN | jq -r '.[] | select(.name | endswith(".txt")) | .url', returnStdout=true})
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/job/docker-scan/4439/artifact/scan_docker_image.txt" --user GITHUB_USER:GITHUB_TOKEN, returnStdout=true})
+                  addRcDetailsComment.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+                  addRcDetailsComment.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                     addRcDetailsComment.println(Getting docker scan results)
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/distribution-build-opensearch-dashboards/runs/8260/nodes/" --user GITHUB_USER:GITHUB_TOKEN | jq '.[] | select(.actions[].description? | contains("docker-scan")) | .actions[] | select(.description | contains("docker-scan")) | ._links.self.href', returnStdout=true})
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.orgbbb
+ccc" --user GITHUB_USER:GITHUB_TOKEN | jq -r '._links.artifacts.href', returnStdout=true})
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.orgbbb
+ccc" --user GITHUB_USER:GITHUB_TOKEN | jq -r '.[] | select(.name | endswith(".txt")) | .url', returnStdout=true})
+                     addRcDetailsComment.sh({script=curl -s -XGET "https://build.ci.opensearch.orgbbb
+ccc" --user GITHUB_USER:GITHUB_TOKEN, returnStdout=true})
                   TemplateProcessor.process(release/rc-details-template.md, {VERSION=2.19.0, OPENSEARCH_RC_NUMBER=5, OPENSEARCH_DASHBOARDS_RC_NUMBER=5, OPENSEARCH_RC_BUILD_NUMBER=10787, OPENSEARCH_DASHBOARDS_RC_BUILD_NUMBER=8260, OPENSEARCH_DOCKER_SCAN_RESULTS=Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)), OPENSEARCH_DASHBOARDS_DOCKER_SCAN_RESULTS=
 bbb
 ccc

--- a/vars/addRcDetailsComment.groovy
+++ b/vars/addRcDetailsComment.groovy
@@ -77,36 +77,48 @@ void call(Map args = [:]) {
 }
 
 def getDockerScanResult(String component, def distributionRcBuildNumber) {
-    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
-    println('Getting docker scan results')
-    String buildJobName = ''
-    String JENKINS_BASE_URL = 'https://build.ci.opensearch.org'
-    String BLUE_OCEAN_URL = 'blue/rest/organizations/jenkins/pipelines'
-    if(component == 'OpenSearch') {
-        buildJobName = 'distribution-build-opensearch'
-    } else if(component == 'OpenSearch-Dashboards') {
-        buildJobName = 'distribution-build-opensearch-dashboards'
-    } else {
-        error("Invalid component name: ${component}. Valid values: OpenSearch, OpenSearch-Dashboards")
-    }
-    String dockerScanUrl = sh (
-            script: "curl -s -XGET \"${JENKINS_BASE_URL}/${BLUE_OCEAN_URL}/${buildJobName}/runs/${distributionRcBuildNumber}/nodes/\" --user GITHUB_USER:GITHUB_TOKEN | jq '.[] | select(.actions[].description? | contains(\"docker-scan\")) | .actions[] | select(.description | contains(\"docker-scan\")) | ._links.self.href'",
-            returnStdout: true
-    ).trim()
-    String artifactsUrl = sh(
-            script: "curl -s -XGET \"${JENKINS_BASE_URL}${dockerScanUrl}\" --user GITHUB_USER:GITHUB_TOKEN | jq -r '._links.artifacts.href'",
-            returnStdout: true
-    ).trim()
-    String dockerTxtScanUrl = sh(
-            script: "curl -s -XGET \"${JENKINS_BASE_URL}${artifactsUrl}\" --user GITHUB_USER:GITHUB_TOKEN | jq -r '.[] | select(.name | endswith(\".txt\")) | .url'",
-            returnStdout: true
-    ).trim()
-    String fullDockerTxtScanUrl = "${JENKINS_BASE_URL}${dockerTxtScanUrl}"
-    // Do not trim as it messes the text table.
-    String dockerScanResult = sh(
-            script: "curl -s -XGET \"${fullDockerTxtScanUrl}\" --user GITHUB_USER:GITHUB_TOKEN",
-            returnStdout: true
-    )
-    return [dockerScanUrl: fullDockerTxtScanUrl, dockerScanResult: dockerScanResult]
+    try {
+        withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+            println('Getting docker scan results')
+            String buildJobName = ''
+            String JENKINS_BASE_URL = 'https://build.ci.opensearch.org'
+            String BLUE_OCEAN_URL = 'blue/rest/organizations/jenkins/pipelines'
+
+            if (component == 'OpenSearch') {
+                buildJobName = 'distribution-build-opensearch'
+            } else if (component == 'OpenSearch-Dashboards') {
+                buildJobName = 'distribution-build-opensearch-dashboards'
+            } else {
+                error("Invalid component name: ${component}. Valid values: OpenSearch, OpenSearch-Dashboards")
+            }
+
+            String dockerScanUrl = sh(
+                script: "curl -s -XGET \"${JENKINS_BASE_URL}/${BLUE_OCEAN_URL}/${buildJobName}/runs/${distributionRcBuildNumber}/nodes/\" --user ${GITHUB_USER}:${GITHUB_TOKEN} | jq '.[] | select(.actions[].description? | contains(\"docker-scan\")) | .actions[] | select(.description | contains(\"docker-scan\")) | ._links.self.href'",
+                returnStdout: true
+            ).trim()
+
+            String artifactsUrl = sh(
+                script: "curl -s -XGET \"${JENKINS_BASE_URL}${dockerScanUrl}\" --user ${GITHUB_USER}:${GITHUB_TOKEN} | jq -r '._links.artifacts.href'",
+                returnStdout: true
+            ).trim()
+
+            String dockerTxtScanUrl = sh(
+                script: "curl -s -XGET \"${JENKINS_BASE_URL}${artifactsUrl}\" --user ${GITHUB_USER}:${GITHUB_TOKEN} | jq -r '.[] | select(.name | endswith(\".txt\")) | .url'",
+                returnStdout: true
+            ).trim()
+
+            String fullDockerTxtScanUrl = "${JENKINS_BASE_URL}${dockerTxtScanUrl}"
+
+            // Do not trim as it messes the text table.
+            String dockerScanResult = sh(
+                script: "curl -s -XGET \"${fullDockerTxtScanUrl}\" --user ${GITHUB_USER}:${GITHUB_TOKEN}",
+                returnStdout: true
+            )
+
+            return [dockerScanUrl: fullDockerTxtScanUrl, dockerScanResult: dockerScanResult]
         }
+    } catch (Exception e) {
+        println("Error while getting docker scan results: ${e.message}")
+        return [[dockerScanUrl: "https://build.ci.opensearch.org/job/docker-scan/", dockerScanResult: "Unable to get docker scan results for ${component}, RC build number: ${distributionRcBuildNumber}"]]
+    }
 }


### PR DESCRIPTION
### Description
The recent RC details chore failed due to authentication changes on jenkins. This PR adds the auth for the same 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
