### PR TITLE
Fix release issue query to exactly match the repo name

### DIFF
--- a/src/jenkins/ReleaseMetricsData.groovy
+++ b/src/jenkins/ReleaseMetricsData.groovy
@@ -79,7 +79,7 @@ class ReleaseMetricsData {
         return query.replace('"', '\\"')
     }
 
-    String getReleaseIssueQuery(String repository, String changedMatchPhraseKey = "repository") {
+    String getReleaseIssueQuery(String repository, String changedMatchPhraseKey = "repository.keyword") {
         def queryMap = [
                 size   : 1,
                 _source: "release_issue",

--- a/tests/jenkins/TestReleaseMetricsData.groovy
+++ b/tests/jenkins/TestReleaseMetricsData.groovy
@@ -130,7 +130,7 @@ class TestReleaseMetricsData {
                                         ],
                                         [
                                                 match_phrase: [
-                                                        repository: "opensearch-build"
+                                                        "repository.keyword": "opensearch-build"
                                                 ]
                                         ]
                                 ]


### PR DESCRIPTION
### Description
This changes fixes the query for retrieving release issue to exactly match the repo name. 
Currently, the below query returns observailibility dashboards issues instead of backend observability issue
```
GET opensearch_release_metrics/_search
{"size":1,"query":{"bool":{"filter":[{"match_phrase":{"version":"3.0.0"}},{"match_phrase":{"repository":"observability"}}]}},"sort":[{"current_date":{"order":"desc"}}]}
``` 


### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/643#issuecomment-2802881956

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
