### PR TITLE
Add workload param while fetching contender benchmark id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '9.0.0'
+String version = '9.0.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CompareBenchmarkRun_Jenkinsfile.txt
@@ -65,6 +65,11 @@
                       "term": {
                         "user-tags.pull_request_number": "12345"
                       }
+                    },
+                    {
+                      "term": {
+                        "workload": \"big5\"
+                      }
                     }
                   ]
                 }

--- a/vars/getCompareBenchmarkIds.groovy
+++ b/vars/getCompareBenchmarkIds.groovy
@@ -24,7 +24,7 @@ Map<String, String> call(Map args = [:]) {
         return null
     }
     String baselineId = getBaselineTestExecutionId(args.baselineClusterConfig, args.distributionVersion, args.workload)
-    String contenderId = getContenderTestExecutionId(args.pullRequestNumber)
+    String contenderId = getContenderTestExecutionId(args.pullRequestNumber, args.workload)
     return ['baseline': baselineId, 'contender': contenderId]
 }
 
@@ -81,7 +81,7 @@ String getBaselineTestExecutionId(baselineClusterConfig, distributionVersion, wo
     }
 }
 
-String getContenderTestExecutionId(pullRequestNumber) {
+String getContenderTestExecutionId(pullRequestNumber, workload) {
     withCredentials([string(credentialsId: 'benchmark-metrics-datastore-user', variable: 'DATASTORE_USER'),
                      string(credentialsId: 'benchmark-metrics-datastore-password', variable: 'DATASTORE_PASSWORD'),
                      string(credentialsId: 'benchmark-metrics-datastore-nlb-endpoint', variable: 'DATASTORE_ENDPOINT')]) {
@@ -94,6 +94,11 @@ String getContenderTestExecutionId(pullRequestNumber) {
                     {
                       "term": {
                         "user-tags.pull_request_number": \"${pullRequestNumber}\"
+                      }
+                    },
+                    {
+                      "term": {
+                        "workload": \\"${workload}\\"
                       }
                     }
                   ]


### PR DESCRIPTION
### Description
Add workload param while fetching contender benchmark id. This will resolve the bug when running multiple benchmarks on a pull request and it just fetches the latest id irrespective of the workload type. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
