### PR TITLE
Use dynamic type instead of strong type

### DIFF
--- a/src/jenkins/ComponentBuildStatus.groovy
+++ b/src/jenkins/ComponentBuildStatus.groovy
@@ -25,7 +25,7 @@ class ComponentBuildStatus {
     String buildStartTimeFrom
     String buildStartTimeTo
     def script
-    OpenSearchMetricsQuery openSearchMetricsQuery
+    def openSearchMetricsQuery
 
     ComponentBuildStatus(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String indexName, String product, String version, String qualifier, String distributionBuildNumber, String buildStartTimeFrom, String buildStartTimeTo, def script) {
         this.metricsUrl = metricsUrl

--- a/src/jenkins/ComponentIntegTestStatus.groovy
+++ b/src/jenkins/ComponentIntegTestStatus.groovy
@@ -23,7 +23,7 @@ class ComponentIntegTestStatus {
     String qualifier
     String distributionBuildNumber
     def script
-    OpenSearchMetricsQuery openSearchMetricsQuery
+    def openSearchMetricsQuery
 
     ComponentIntegTestStatus(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, String indexName, String product, String version, String qualifier, String distributionBuildNumber, def script) {
         this.metricsUrl = metricsUrl


### PR DESCRIPTION
### Description
The strong type is causing  type gradle to hang as well. Tested this using my fork. This PR should fix the classes loading while loading the lib in jenkins tests.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
