### PR TITLE
bug fix in incremental build logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '9.5.0'
+String version = '9.5.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/jobs/BuildShManifestIncremental_Jenkinsfile
+++ b/tests/jenkins/jobs/BuildShManifestIncremental_Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                         distribution: "tar",
                         platform: "linux",
                         architecture: "x64",
-                        incremental: true,
+                        incremental: 'true',
                         previousBuildId: "latest"
                     )
                 }

--- a/vars/buildManifest.groovy
+++ b/vars/buildManifest.groovy
@@ -19,7 +19,7 @@
  @param args.incremental <optional> - Boolean value to enable incremental build.
  */
 void call(Map args = [:]) {
-    boolean incremental_enabled = args.incremental != null && args.incremental
+    boolean incremental_enabled = args.incremental != null && Boolean.parseBoolean(args.incremental)
 
     def lib = library(identifier: 'jenkins@main', retriever: legacySCM(scm))
     def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: args.inputManifest))


### PR DESCRIPTION
### Description
There's a bug in incremental build logic where `boolean incremental_enabled = args.incremental != null && args.incremental` evaluates to `true` even when `args.incremental` is passed as `false`. This is because the data type of args.incremental is string, so it args.incremental evaluates to `true` even when false is passed. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
