### PR TITLE
Fix ingestion to remove duplicate data

### DIFF
--- a/vars/publishSmokeTestResults.groovy
+++ b/vars/publishSmokeTestResults.groovy
@@ -79,11 +79,10 @@ void call(Map args = [:]) {
                 finalJsonDoc += "{\"index\": {\"_index\": \"${indexName}\"}}\n" + "${jsonContent}\n"
             }
         }
-        writeFile file: "test-records.json", text: finalJsonDoc
-        def fileContents = readFile(file: "test-records.json").trim()
-        indexSmokeTestData(indexName, "test-records.json")
-
     }
+    writeFile file: "test-records.json", text: finalJsonDoc
+    def fileContents = readFile(file: "test-records.json").trim()
+    indexSmokeTestData(indexName, "test-records.json")
 }
 
 boolean argCheck(String str) { return (str == null || str.allWhitespace || str.isEmpty()) }


### PR DESCRIPTION
### Description
We are appending `finalJsonDoc` each time without clearing it. So the previous component json data will be indexed repetitively. We could either clearing the `finalJsonDoc` for each component but moving it out of the component loop will result only a single call to `_bulk` API when ingesting.
```
manifest.components.each { component ->
    ...
    if (component.configs) {
        component.configs.each { config ->
            ...
            finalJsonDoc += "{\"index\": ...\n" + "${jsonContent}\n"
        }
    }
}

writeFile file: "test-records.json", text: finalJsonDoc
def fileContents = readFile(file: "test-records.json").trim()
indexSmokeTestData(indexName, "test-records.json")
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
