### PR TITLE
Update trivy report to ignore summary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '9.6.1'
+String version = '9.6.2'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/jobs/ScanDockerImage_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/ScanDockerImage_Jenkinsfile.txt
@@ -9,6 +9,6 @@
         trivy clean --all
         docker rmi `docker images -f "dangling=true" -q` || echo
         docker rmi opensearchstaging/opensearch:2.0.0 || echo
-        trivy image --format table --output scan_docker_image.txt opensearchstaging/opensearch:2.0.0
+        trivy image --format table --table-mode detailed --output scan_docker_image.txt opensearchstaging/opensearch:2.0.0
         trivy image --format json --output scan_docker_image.json opensearchstaging/opensearch:2.0.0
     )

--- a/vars/scanDockerImage.groovy
+++ b/vars/scanDockerImage.groovy
@@ -13,7 +13,7 @@ void call(Map args = [:]) {
         trivy clean --all
         docker rmi `docker images -f "dangling=true" -q` || echo
         docker rmi ${args.imageFullName} || echo
-        trivy image --format table --output ${args.imageResultFile}.txt ${args.imageFullName}
+        trivy image --format table --table-mode detailed --output ${args.imageResultFile}.txt ${args.imageFullName}
         trivy image --format json --output ${args.imageResultFile}.json ${args.imageFullName}
     """
 


### PR DESCRIPTION
### Description

Update trivy report to ignore summary

In trivy https://github.com/aquasecurity/trivy/pull/8177 the summary of the table report has been expended with a lot of details which exceed the github comment length.

### Issues Resolved
https://build.ci.opensearch.org/job/docker-scan/4945/artifact/scan_docker_image.txt

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
