### PR TITLE
Fix maven publishing method for auto-publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '10.1.1'
+String version = '10.2.0'
 
 task updateVersion {
     doLast {

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -160,17 +160,21 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
-    RESPONSE_CODE=$(curl -s -w "%{http_code}\n" -X POST \
+    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d "{\"data\": ${JSON_DATA}}" \
-      "${PROMOTION_URL}" -o "${workdir}/out.txt")
+      "${PROMOTION_URL}")
+
+    echo "Response code: ${RESPONSE_CODE}"
     
     if [[ ${RESPONSE_CODE} -ne 200 ]]; then
-        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${REPONSE_CODE}"
-        echo "Response: $(cat ${workdir}/out.txt)"
+        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+    else
+        echo "Staging repository ${staging_repo_id} closed and released successfully."
     fi
 
     echo "==========================================="

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -144,37 +144,36 @@ echo "==========================================="
 echo "Done."
 echo "==========================================="
 
-# If AUTO_PUBLISH is set to true below commands will be executed See https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md
-# for command reference.
+# When using `org.sonatype.plugins:nexus-staging-maven-plugin` rc-close or rc-release we get below error:
+# `Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string`
+# Sending raw POST request to close ad release the staging repository instead.
+# Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
+
 if [ "$AUTO_PUBLISH" = true ] ; then
     export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
 
     echo "==========================================="
-    echo "Closing Staging Repository ${staging_repo_id}."
+    echo "Closing and Releasing Staging Repository ${staging_repo_id}."
     echo "==========================================="
 
-    mvn --settings="${mvn_settings}" \
-      org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-close \
-      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-      -DserverId=central \
-      -DautoReleaseAfterClose=true \
-      -DstagingProfileId="${STAGING_PROFILE_ID}" \
-      -DstagingRepositoryId="${staging_repo_id}"
-
-    echo "==========================================="
-    echo "Done."
-    echo "==========================================="
-
-    echo "==========================================="
-    echo "Release Staging Repository ${staging_repo_id}."
-    echo "==========================================="
-
-    mvn --settings="${mvn_settings}" \
-      org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-release \
-      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-      -DserverId=central \
-      -DstagingProfileId="${STAGING_PROFILE_ID}" \
-      -DstagingRepositoryId="${staging_repo_id}"
+    PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
+    JSON_DATA="{
+        \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
+        \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+      }"
+    
+    RESPONSE_CODE=$(curl -s -w "%{http_code}\n" -X POST \
+      -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -d "{\"data\": ${JSON_DATA}}" \
+      "${PROMOTION_URL}" -o "${workdir}/out.txt")
+    
+    if [[ ${RESPONSE_CODE} -ne 200 ]]; then
+        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${REPONSE_CODE}"
+        echo "Response: $(cat ${workdir}/out.txt)"
+        echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+    fi
 
     echo "==========================================="
     echo "Done."

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -161,7 +161,7 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
-    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \
+    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -160,17 +160,14 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"autoDropAfterRelease\": true, 
         \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
-    
-    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST \
+      
+    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
-      -d "{\"data\": ${JSON_DATA}}" \
-      "${PROMOTION_URL}")
-
-    echo "Response code: ${RESPONSE_CODE}"
+      -d "{\"data\": ${JSON_DATA}}")
     
-    if [[ ${RESPONSE_CODE} -ne 200 ]]; then
+    if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -150,8 +150,6 @@ echo "==========================================="
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
 if [ "$AUTO_PUBLISH" = true ] ; then
-    export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
-
     echo "==========================================="
     echo "Closing and Releasing Staging Repository ${staging_repo_id}."
     echo "==========================================="

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -37,6 +37,7 @@ usage() {
   exit 1
 }
 AUTO_PUBLISH=false
+DEPLOYED_STAGING_REPO_ID=""
 
 while getopts "ha:d:" option; do
   case $option in
@@ -126,10 +127,10 @@ deployment=$(mvn --settings="${mvn_settings}" \
   -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
 
 if echo "$deployment" | grep "BUILD SUCCESS"; then
-  deployed_staging_repo_id=$(echo $deployment | grep "Closing staging repository with ID" | grep -o "\"[^\"]*\"" | tr -d '"')
-  echo "Successfully staged and validated artifacts. Staging repository ID: ${deployed_staging_repo_id}"
+  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
+  echo "Successfully staged and validated artifacts. Staging repository ID: ${DEPLOYED_STAGING_REPO_ID}"
 else
-  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing ."
+  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing."
   exit 1
 fi
 
@@ -142,16 +143,16 @@ echo "==========================================="
 # Sending raw POST request to release the staging repository instead.
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
-if [ "$AUTO_PUBLISH" = true ] ; then
+if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     echo "==========================================="
-    echo "Releasing Staging Repository ${deployed_staging_repo_id}."
+    echo "Releasing Staging Repository ${DEPLOYED_STAGING_REPO_ID}."
     echo "==========================================="
 
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
-        \"stagedRepositoryIds\": [\"${deployed_staging_repo_id}\"], 
+        \"stagedRepositoryIds\": [\"${DEPLOYED_STAGING_REPO_ID}\"], 
         \"autoDropAfterRelease\": true, 
-        \"description\": \"Releasing ${deployed_staging_repo_id}\"}
+        \"description\": \"Releasing ${DEPLOYED_STAGING_REPO_ID}\"}
       }"
       
     RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
@@ -161,14 +162,17 @@ if [ "$AUTO_PUBLISH" = true ] ; then
       -d "{\"data\": ${JSON_DATA}}")
     
     if [[ ${RESPONSE_CODE} != 200 ]]; then
-        echo "Failed to close and release staging repository ${deployed_staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
-        echo "Staging repository ${deployed_staging_repo_id} released successfully."
+        echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
     fi
 
     echo "==========================================="
     echo "Done."
     echo "==========================================="
+else 
+    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
+    echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
 fi

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -33,8 +33,6 @@ usage() {
   echo "Required environment variables:"
   echo "SONATYPE_USERNAME - username with publish rights to a sonatype repository"
   echo "SONATYPE_PASSWORD - publishing token for sonatype"
-  echo "JOB_NAME - Job Name which triggered this script for tracking purposes"
-  echo "BUILD_ID - Build ID from CI so we can trace where the artifacts were built"
   echo "STAGING_PROFILE_ID - Sonatype Staging profile ID"
   exit 1
 }
@@ -65,7 +63,7 @@ if [ "$AUTO_PUBLISH" != "true" ] && [ "$AUTO_PUBLISH" != "false" ]; then
   exit 1
 fi
 
-required_env_vars=(ARTIFACT_DIRECTORY SONATYPE_USERNAME SONATYPE_PASSWORD JOB_NAME BUILD_ID STAGING_PROFILE_ID)
+required_env_vars=(ARTIFACT_DIRECTORY SONATYPE_USERNAME SONATYPE_PASSWORD STAGING_PROFILE_ID)
 for var in "${required_env_vars[@]}"; do
   if [ -z "${!var}" ]; then
     echo "Error: $var is required"
@@ -111,34 +109,29 @@ function create_maven_settings() {
 EOF
 }
 
-function create_staging_repository() {
-  echo "Creating staging repository."
-  staging_repo_id=$(mvn --settings="${mvn_settings}" \
-    org.sonatype.plugins:nexus-staging-maven-plugin:rc-open \
-    -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-    -DserverId=central \
-    -DstagingProfileId="${STAGING_PROFILE_ID}" \
-    -DstagingDescription="Staging artifacts for ${JOB_NAME}-${BUILD_ID}" \
-    -DopenedRepositoryMessageFormat="opensearch-staging-repo-id=%s" |
-    grep -E -o 'opensearch-staging-repo-id=.*$' | cut -d'=' -f2)
-  echo "Opened staging repository ID $staging_repo_id"
-}
-
 create_maven_settings
-create_staging_repository
+
 echo "AUTO_PUBLISH variable is set to: '$AUTO_PUBLISH'"
 echo "==========================================="
-echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository ${staging_repo_id}."
+echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
-mvn --settings="${mvn_settings}" \
+deployment=$(mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}"
+  -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
+
+if echo "$deployment" | grep "BUILD SUCCESS"; then
+  deployed_staging_repo_id=$(echo $deployment | grep "Closing staging repository with ID" | grep -o "\"[^\"]*\"" | tr -d '"')
+  echo "Successfully staged and validated artifacts. Staging repository ID: ${deployed_staging_repo_id}"
+else
+  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing ."
+  exit 1
+fi
 
 echo "==========================================="
 echo "Done."
@@ -146,19 +139,19 @@ echo "==========================================="
 
 # When using `org.sonatype.plugins:nexus-staging-maven-plugin` rc-close or rc-release we get below error:
 # `Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string`
-# Sending raw POST request to close ad release the staging repository instead.
+# Sending raw POST request to release the staging repository instead.
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
 if [ "$AUTO_PUBLISH" = true ] ; then
     echo "==========================================="
-    echo "Closing and Releasing Staging Repository ${staging_repo_id}."
+    echo "Releasing Staging Repository ${deployed_staging_repo_id}."
     echo "==========================================="
 
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
-        \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
+        \"stagedRepositoryIds\": [\"${deployed_staging_repo_id}\"], 
         \"autoDropAfterRelease\": true, 
-        \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+        \"description\": \"Releasing ${deployed_staging_repo_id}\"}
       }"
       
     RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
@@ -168,11 +161,11 @@ if [ "$AUTO_PUBLISH" = true ] ; then
       -d "{\"data\": ${JSON_DATA}}")
     
     if [[ ${RESPONSE_CODE} != 200 ]]; then
-        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Failed to close and release staging repository ${deployed_staging_repo_id}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
-        echo "Staging repository ${staging_repo_id} closed and released successfully."
+        echo "Staging repository ${deployed_staging_repo_id} released successfully."
     fi
 
     echo "==========================================="

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -157,7 +157,8 @@ if [ "$AUTO_PUBLISH" = true ] ; then
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
         \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
-        \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+        \"autoDropAfterRelease\": true, 
+        \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
     RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -154,43 +154,41 @@ echo "==========================================="
 echo "Done."
 echo "==========================================="
 
-# If AUTO_PUBLISH is set to true below commands will be executed See https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md
-# for command reference.
+# When using `org.sonatype.plugins:nexus-staging-maven-plugin` rc-close or rc-release we get below error:
+# `Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string`
+# Sending raw POST request to close ad release the staging repository instead.
+# Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
+
 if [ "$AUTO_PUBLISH" = true ] ; then
     export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
 
     echo "==========================================="
-    echo "Closing Staging Repository ${staging_repo_id}."
+    echo "Closing and Releasing Staging Repository ${staging_repo_id}."
     echo "==========================================="
 
-    mvn --settings="${mvn_settings}" \
-      org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-close \
-      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-      -DserverId=central \
-      -DautoReleaseAfterClose=true \
-      -DstagingProfileId="${STAGING_PROFILE_ID}" \
-      -DstagingRepositoryId="${staging_repo_id}"
-
-    echo "==========================================="
-    echo "Done."
-    echo "==========================================="
-
-    echo "==========================================="
-    echo "Release Staging Repository ${staging_repo_id}."
-    echo "==========================================="
-
-    mvn --settings="${mvn_settings}" \
-      org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-release \
-      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-      -DserverId=central \
-      -DstagingProfileId="${STAGING_PROFILE_ID}" \
-      -DstagingRepositoryId="${staging_repo_id}"
+    PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
+    JSON_DATA="{
+        \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
+        \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+      }"
+    
+    RESPONSE_CODE=$(curl -s -w "%{http_code}\n" -X POST \
+      -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -d "{\"data\": ${JSON_DATA}}" \
+      "${PROMOTION_URL}" -o "${workdir}/out.txt")
+    
+    if [[ ${RESPONSE_CODE} -ne 200 ]]; then
+        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${REPONSE_CODE}"
+        echo "Response: $(cat ${workdir}/out.txt)"
+        echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+    fi
 
     echo "==========================================="
     echo "Done."
     echo "==========================================="
-fi
-})
+fi})
                      loadCustomScript.sh(chmod a+x ./stage-maven-release.sh)
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing/manifest.yml, type=maven, platform=linux, sigtype=.asc, email=release@opensearch.org})
                      signArtifacts.fileExists(workspace/sign.sh)

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -170,17 +170,21 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
-    RESPONSE_CODE=$(curl -s -w "%{http_code}\n" -X POST \
+    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d "{\"data\": ${JSON_DATA}}" \
-      "${PROMOTION_URL}" -o "${workdir}/out.txt")
+      "${PROMOTION_URL}")
+
+    echo "Response code: ${RESPONSE_CODE}"
     
     if [[ ${RESPONSE_CODE} -ne 200 ]]; then
-        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${REPONSE_CODE}"
-        echo "Response: $(cat ${workdir}/out.txt)"
+        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+    else
+        echo "Staging repository ${staging_repo_id} closed and released successfully."
     fi
 
     echo "==========================================="

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -43,8 +43,6 @@ usage() {
   echo "Required environment variables:"
   echo "SONATYPE_USERNAME - username with publish rights to a sonatype repository"
   echo "SONATYPE_PASSWORD - publishing token for sonatype"
-  echo "JOB_NAME - Job Name which triggered this script for tracking purposes"
-  echo "BUILD_ID - Build ID from CI so we can trace where the artifacts were built"
   echo "STAGING_PROFILE_ID - Sonatype Staging profile ID"
   exit 1
 }
@@ -75,7 +73,7 @@ if [ "$AUTO_PUBLISH" != "true" ] && [ "$AUTO_PUBLISH" != "false" ]; then
   exit 1
 fi
 
-required_env_vars=(ARTIFACT_DIRECTORY SONATYPE_USERNAME SONATYPE_PASSWORD JOB_NAME BUILD_ID STAGING_PROFILE_ID)
+required_env_vars=(ARTIFACT_DIRECTORY SONATYPE_USERNAME SONATYPE_PASSWORD STAGING_PROFILE_ID)
 for var in "${required_env_vars[@]}"; do
   if [ -z "${!var}" ]; then
     echo "Error: $var is required"
@@ -121,34 +119,29 @@ function create_maven_settings() {
 EOF
 }
 
-function create_staging_repository() {
-  echo "Creating staging repository."
-  staging_repo_id=$(mvn --settings="${mvn_settings}" \
-    org.sonatype.plugins:nexus-staging-maven-plugin:rc-open \
-    -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-    -DserverId=central \
-    -DstagingProfileId="${STAGING_PROFILE_ID}" \
-    -DstagingDescription="Staging artifacts for ${JOB_NAME}-${BUILD_ID}" \
-    -DopenedRepositoryMessageFormat="opensearch-staging-repo-id=%s" |
-    grep -E -o 'opensearch-staging-repo-id=.*$' | cut -d'=' -f2)
-  echo "Opened staging repository ID $staging_repo_id"
-}
-
 create_maven_settings
-create_staging_repository
+
 echo "AUTO_PUBLISH variable is set to: '$AUTO_PUBLISH'"
 echo "==========================================="
-echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository ${staging_repo_id}."
+echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
-mvn --settings="${mvn_settings}" \
+deployment=$(mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}"
+  -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
+
+if echo "$deployment" | grep "BUILD SUCCESS"; then
+  deployed_staging_repo_id=$(echo $deployment | grep "Closing staging repository with ID" | grep -o "\"[^\"]*\"" | tr -d '"')
+  echo "Successfully staged and validated artifacts. Staging repository ID: ${deployed_staging_repo_id}"
+else
+  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing ."
+  exit 1
+fi
 
 echo "==========================================="
 echo "Done."
@@ -156,19 +149,19 @@ echo "==========================================="
 
 # When using `org.sonatype.plugins:nexus-staging-maven-plugin` rc-close or rc-release we get below error:
 # `Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string`
-# Sending raw POST request to close ad release the staging repository instead.
+# Sending raw POST request to release the staging repository instead.
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
 if [ "$AUTO_PUBLISH" = true ] ; then
     echo "==========================================="
-    echo "Closing and Releasing Staging Repository ${staging_repo_id}."
+    echo "Releasing Staging Repository ${deployed_staging_repo_id}."
     echo "==========================================="
 
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
-        \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
+        \"stagedRepositoryIds\": [\"${deployed_staging_repo_id}\"], 
         \"autoDropAfterRelease\": true, 
-        \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+        \"description\": \"Releasing ${deployed_staging_repo_id}\"}
       }"
       
     RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
@@ -178,11 +171,11 @@ if [ "$AUTO_PUBLISH" = true ] ; then
       -d "{\"data\": ${JSON_DATA}}")
     
     if [[ ${RESPONSE_CODE} != 200 ]]; then
-        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Failed to close and release staging repository ${deployed_staging_repo_id}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
-        echo "Staging repository ${staging_repo_id} closed and released successfully."
+        echo "Staging repository ${deployed_staging_repo_id} released successfully."
     fi
 
     echo "==========================================="

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -160,8 +160,6 @@ echo "==========================================="
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
 if [ "$AUTO_PUBLISH" = true ] ; then
-    export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
-
     echo "==========================================="
     echo "Closing and Releasing Staging Repository ${staging_repo_id}."
     echo "==========================================="

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -170,17 +170,14 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"autoDropAfterRelease\": true, 
         \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
-    
-    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST \
+      
+    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
-      -d "{\"data\": ${JSON_DATA}}" \
-      "${PROMOTION_URL}")
-
-    echo "Response code: ${RESPONSE_CODE}"
+      -d "{\"data\": ${JSON_DATA}}")
     
-    if [[ ${RESPONSE_CODE} -ne 200 ]]; then
+    if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -171,7 +171,7 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
-    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \
+    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -167,7 +167,8 @@ if [ "$AUTO_PUBLISH" = true ] ; then
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
         \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
-        \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+        \"autoDropAfterRelease\": true, 
+        \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
     RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -47,6 +47,7 @@ usage() {
   exit 1
 }
 AUTO_PUBLISH=false
+DEPLOYED_STAGING_REPO_ID=""
 
 while getopts "ha:d:" option; do
   case $option in
@@ -136,10 +137,10 @@ deployment=$(mvn --settings="${mvn_settings}" \
   -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
 
 if echo "$deployment" | grep "BUILD SUCCESS"; then
-  deployed_staging_repo_id=$(echo $deployment | grep "Closing staging repository with ID" | grep -o "\"[^\"]*\"" | tr -d '"')
-  echo "Successfully staged and validated artifacts. Staging repository ID: ${deployed_staging_repo_id}"
+  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
+  echo "Successfully staged and validated artifacts. Staging repository ID: ${DEPLOYED_STAGING_REPO_ID}"
 else
-  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing ."
+  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing."
   exit 1
 fi
 
@@ -152,16 +153,16 @@ echo "==========================================="
 # Sending raw POST request to release the staging repository instead.
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
-if [ "$AUTO_PUBLISH" = true ] ; then
+if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     echo "==========================================="
-    echo "Releasing Staging Repository ${deployed_staging_repo_id}."
+    echo "Releasing Staging Repository ${DEPLOYED_STAGING_REPO_ID}."
     echo "==========================================="
 
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
-        \"stagedRepositoryIds\": [\"${deployed_staging_repo_id}\"], 
+        \"stagedRepositoryIds\": [\"${DEPLOYED_STAGING_REPO_ID}\"], 
         \"autoDropAfterRelease\": true, 
-        \"description\": \"Releasing ${deployed_staging_repo_id}\"}
+        \"description\": \"Releasing ${DEPLOYED_STAGING_REPO_ID}\"}
       }"
       
     RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
@@ -171,16 +172,19 @@ if [ "$AUTO_PUBLISH" = true ] ; then
       -d "{\"data\": ${JSON_DATA}}")
     
     if [[ ${RESPONSE_CODE} != 200 ]]; then
-        echo "Failed to close and release staging repository ${deployed_staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
-        echo "Staging repository ${deployed_staging_repo_id} released successfully."
+        echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
     fi
 
     echo "==========================================="
     echo "Done."
     echo "==========================================="
+else 
+    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
+    echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
 fi})
                      loadCustomScript.sh(chmod a+x ./stage-maven-release.sh)
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing/manifest.yml, type=maven, platform=linux, sigtype=.asc, email=release@opensearch.org})

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -170,17 +170,21 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
-    RESPONSE_CODE=$(curl -s -w "%{http_code}\n" -X POST \
+    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d "{\"data\": ${JSON_DATA}}" \
-      "${PROMOTION_URL}" -o "${workdir}/out.txt")
+      "${PROMOTION_URL}")
+
+    echo "Response code: ${RESPONSE_CODE}"
     
     if [[ ${RESPONSE_CODE} -ne 200 ]]; then
-        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${REPONSE_CODE}"
-        echo "Response: $(cat ${workdir}/out.txt)"
+        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+    else
+        echo "Staging repository ${staging_repo_id} closed and released successfully."
     fi
 
     echo "==========================================="

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -43,8 +43,6 @@ usage() {
   echo "Required environment variables:"
   echo "SONATYPE_USERNAME - username with publish rights to a sonatype repository"
   echo "SONATYPE_PASSWORD - publishing token for sonatype"
-  echo "JOB_NAME - Job Name which triggered this script for tracking purposes"
-  echo "BUILD_ID - Build ID from CI so we can trace where the artifacts were built"
   echo "STAGING_PROFILE_ID - Sonatype Staging profile ID"
   exit 1
 }
@@ -75,7 +73,7 @@ if [ "$AUTO_PUBLISH" != "true" ] && [ "$AUTO_PUBLISH" != "false" ]; then
   exit 1
 fi
 
-required_env_vars=(ARTIFACT_DIRECTORY SONATYPE_USERNAME SONATYPE_PASSWORD JOB_NAME BUILD_ID STAGING_PROFILE_ID)
+required_env_vars=(ARTIFACT_DIRECTORY SONATYPE_USERNAME SONATYPE_PASSWORD STAGING_PROFILE_ID)
 for var in "${required_env_vars[@]}"; do
   if [ -z "${!var}" ]; then
     echo "Error: $var is required"
@@ -121,34 +119,29 @@ function create_maven_settings() {
 EOF
 }
 
-function create_staging_repository() {
-  echo "Creating staging repository."
-  staging_repo_id=$(mvn --settings="${mvn_settings}" \
-    org.sonatype.plugins:nexus-staging-maven-plugin:rc-open \
-    -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-    -DserverId=central \
-    -DstagingProfileId="${STAGING_PROFILE_ID}" \
-    -DstagingDescription="Staging artifacts for ${JOB_NAME}-${BUILD_ID}" \
-    -DopenedRepositoryMessageFormat="opensearch-staging-repo-id=%s" |
-    grep -E -o 'opensearch-staging-repo-id=.*$' | cut -d'=' -f2)
-  echo "Opened staging repository ID $staging_repo_id"
-}
-
 create_maven_settings
-create_staging_repository
+
 echo "AUTO_PUBLISH variable is set to: '$AUTO_PUBLISH'"
 echo "==========================================="
-echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository ${staging_repo_id}."
+echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
-mvn --settings="${mvn_settings}" \
+deployment=$(mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}"
+  -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
+
+if echo "$deployment" | grep "BUILD SUCCESS"; then
+  deployed_staging_repo_id=$(echo $deployment | grep "Closing staging repository with ID" | grep -o "\"[^\"]*\"" | tr -d '"')
+  echo "Successfully staged and validated artifacts. Staging repository ID: ${deployed_staging_repo_id}"
+else
+  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing ."
+  exit 1
+fi
 
 echo "==========================================="
 echo "Done."
@@ -156,19 +149,19 @@ echo "==========================================="
 
 # When using `org.sonatype.plugins:nexus-staging-maven-plugin` rc-close or rc-release we get below error:
 # `Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string`
-# Sending raw POST request to close ad release the staging repository instead.
+# Sending raw POST request to release the staging repository instead.
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
 if [ "$AUTO_PUBLISH" = true ] ; then
     echo "==========================================="
-    echo "Closing and Releasing Staging Repository ${staging_repo_id}."
+    echo "Releasing Staging Repository ${deployed_staging_repo_id}."
     echo "==========================================="
 
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
-        \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
+        \"stagedRepositoryIds\": [\"${deployed_staging_repo_id}\"], 
         \"autoDropAfterRelease\": true, 
-        \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+        \"description\": \"Releasing ${deployed_staging_repo_id}\"}
       }"
       
     RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
@@ -178,11 +171,11 @@ if [ "$AUTO_PUBLISH" = true ] ; then
       -d "{\"data\": ${JSON_DATA}}")
     
     if [[ ${RESPONSE_CODE} != 200 ]]; then
-        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Failed to close and release staging repository ${deployed_staging_repo_id}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
-        echo "Staging repository ${staging_repo_id} closed and released successfully."
+        echo "Staging repository ${deployed_staging_repo_id} released successfully."
     fi
 
     echo "==========================================="

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -160,8 +160,6 @@ echo "==========================================="
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
 if [ "$AUTO_PUBLISH" = true ] ; then
-    export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
-
     echo "==========================================="
     echo "Closing and Releasing Staging Repository ${staging_repo_id}."
     echo "==========================================="

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -154,43 +154,41 @@ echo "==========================================="
 echo "Done."
 echo "==========================================="
 
-# If AUTO_PUBLISH is set to true below commands will be executed See https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md
-# for command reference.
+# When using `org.sonatype.plugins:nexus-staging-maven-plugin` rc-close or rc-release we get below error:
+# `Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string`
+# Sending raw POST request to close ad release the staging repository instead.
+# Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
+
 if [ "$AUTO_PUBLISH" = true ] ; then
     export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
 
     echo "==========================================="
-    echo "Closing Staging Repository ${staging_repo_id}."
+    echo "Closing and Releasing Staging Repository ${staging_repo_id}."
     echo "==========================================="
 
-    mvn --settings="${mvn_settings}" \
-      org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-close \
-      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-      -DserverId=central \
-      -DautoReleaseAfterClose=true \
-      -DstagingProfileId="${STAGING_PROFILE_ID}" \
-      -DstagingRepositoryId="${staging_repo_id}"
-
-    echo "==========================================="
-    echo "Done."
-    echo "==========================================="
-
-    echo "==========================================="
-    echo "Release Staging Repository ${staging_repo_id}."
-    echo "==========================================="
-
-    mvn --settings="${mvn_settings}" \
-      org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-release \
-      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
-      -DserverId=central \
-      -DstagingProfileId="${STAGING_PROFILE_ID}" \
-      -DstagingRepositoryId="${staging_repo_id}"
+    PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
+    JSON_DATA="{
+        \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
+        \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+      }"
+    
+    RESPONSE_CODE=$(curl -s -w "%{http_code}\n" -X POST \
+      -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -d "{\"data\": ${JSON_DATA}}" \
+      "${PROMOTION_URL}" -o "${workdir}/out.txt")
+    
+    if [[ ${RESPONSE_CODE} -ne 200 ]]; then
+        echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${REPONSE_CODE}"
+        echo "Response: $(cat ${workdir}/out.txt)"
+        echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+    fi
 
     echo "==========================================="
     echo "Done."
     echo "==========================================="
-fi
-})
+fi})
                      loadCustomScript.sh(chmod a+x ./stage-maven-release.sh)
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing, type=maven, platform=linux, sigtype=.asc, email=release@opensearch.org})
                      signArtifacts.fileExists(workspace/sign.sh)

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -47,6 +47,7 @@ usage() {
   exit 1
 }
 AUTO_PUBLISH=false
+DEPLOYED_STAGING_REPO_ID=""
 
 while getopts "ha:d:" option; do
   case $option in
@@ -136,10 +137,10 @@ deployment=$(mvn --settings="${mvn_settings}" \
   -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
 
 if echo "$deployment" | grep "BUILD SUCCESS"; then
-  deployed_staging_repo_id=$(echo $deployment | grep "Closing staging repository with ID" | grep -o "\"[^\"]*\"" | tr -d '"')
-  echo "Successfully staged and validated artifacts. Staging repository ID: ${deployed_staging_repo_id}"
+  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
+  echo "Successfully staged and validated artifacts. Staging repository ID: ${DEPLOYED_STAGING_REPO_ID}"
 else
-  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing ."
+  echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing."
   exit 1
 fi
 
@@ -152,16 +153,16 @@ echo "==========================================="
 # Sending raw POST request to release the staging repository instead.
 # Ref: https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
 
-if [ "$AUTO_PUBLISH" = true ] ; then
+if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     echo "==========================================="
-    echo "Releasing Staging Repository ${deployed_staging_repo_id}."
+    echo "Releasing Staging Repository ${DEPLOYED_STAGING_REPO_ID}."
     echo "==========================================="
 
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
-        \"stagedRepositoryIds\": [\"${deployed_staging_repo_id}\"], 
+        \"stagedRepositoryIds\": [\"${DEPLOYED_STAGING_REPO_ID}\"], 
         \"autoDropAfterRelease\": true, 
-        \"description\": \"Releasing ${deployed_staging_repo_id}\"}
+        \"description\": \"Releasing ${DEPLOYED_STAGING_REPO_ID}\"}
       }"
       
     RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
@@ -171,16 +172,19 @@ if [ "$AUTO_PUBLISH" = true ] ; then
       -d "{\"data\": ${JSON_DATA}}")
     
     if [[ ${RESPONSE_CODE} != 200 ]]; then
-        echo "Failed to close and release staging repository ${deployed_staging_repo_id}. Response code: ${RESPONSE_CODE}"
+        echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
-        echo "Staging repository ${deployed_staging_repo_id} released successfully."
+        echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
     fi
 
     echo "==========================================="
     echo "Done."
     echo "==========================================="
+else 
+    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
+    echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
 fi})
                      loadCustomScript.sh(chmod a+x ./stage-maven-release.sh)
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing, type=maven, platform=linux, sigtype=.asc, email=release@opensearch.org})

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -170,17 +170,14 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"autoDropAfterRelease\": true, 
         \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
-    
-    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST \
+      
+    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
-      -d "{\"data\": ${JSON_DATA}}" \
-      "${PROMOTION_URL}")
-
-    echo "Response code: ${RESPONSE_CODE}"
+      -d "{\"data\": ${JSON_DATA}}")
     
-    if [[ ${RESPONSE_CODE} -ne 200 ]]; then
+    if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${staging_repo_id}. Response code: ${RESPONSE_CODE}"
         echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -171,7 +171,7 @@ if [ "$AUTO_PUBLISH" = true ] ; then
         \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
-    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \
+    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -167,7 +167,8 @@ if [ "$AUTO_PUBLISH" = true ] ; then
     PROMOTION_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote"
     JSON_DATA="{
         \"stagedRepositoryIds\": [\"${staging_repo_id}\"], 
-        \"autoDropAfterRelease\": true, \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
+        \"autoDropAfterRelease\": true, 
+        \"description\": \"Releasing ${staging_repo_id}, ${JOB_NAME}-${BUILD_ID}\"}
       }"
     
     RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST \


### PR DESCRIPTION
### Description
Maven publishing plugin throws errros for `rc-release` and `rc-close` tasks.
```
Failed to process request: Got unexpected XML element when reading stagedRepositoryIds: Got unexpected element StartElement(a, {"": "", "xml": "http://www.w3.org/XML/1998/namespace", "xmlns": "http://www.w3.org/2000/xmlns/"}, [class -> string-array]), expected one of: string
```

In order to fix this, looks like using POST action directly on the API works. 
https://github.com/cdklabs/publib/pull/1667/files#diff-36ff5f7d55e47535ad5f6a8236eaecc92dba5cc2223d39b09f870d090c47327eR396
Successful run: https://github.com/projen/projen/actions/runs/16224043485/job/45812290720

This change replicates same behavior in shell. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5548

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
