### PR TITLE
Bump maven plugin version and refactor maven publication script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '10.2.0'
+String version = '10.2.1'
 
 task updateVersion {
     doLast {

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -165,6 +165,7 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+        exit 1
     else
         echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
     fi
@@ -173,6 +174,6 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     echo "Done."
     echo "==========================================="
 else 
-    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
+    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH might be set false or unable to retrieve DEPLOYED_STAGING_REPO_ID."
     echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
 fi

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -111,20 +111,21 @@ EOF
 }
 
 create_maven_settings
-
 echo "AUTO_PUBLISH variable is set to: '$AUTO_PUBLISH'"
 echo "==========================================="
 echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
 deployment=$(mvn --settings="${mvn_settings}" \
-  org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
+  org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
+  -DstagingProfileId="${STAGING_PROFILE_ID}")
+
+echo $deployment
 
 if echo "$deployment" | grep "BUILD SUCCESS"; then
   DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
@@ -155,15 +156,14 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
         \"description\": \"Releasing ${DEPLOYED_STAGING_REPO_ID}\"}
       }"
       
-    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
+    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d "{\"data\": ${JSON_DATA}}")
-    
+
     if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
-        echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
         echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -175,6 +175,7 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+        exit 1
     else
         echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
     fi
@@ -183,7 +184,7 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     echo "Done."
     echo "==========================================="
 else 
-    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
+    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH might be set false or unable to retrieve DEPLOYED_STAGING_REPO_ID."
     echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
 fi
 })

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -121,20 +121,21 @@ EOF
 }
 
 create_maven_settings
-
 echo "AUTO_PUBLISH variable is set to: '$AUTO_PUBLISH'"
 echo "==========================================="
 echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
 deployment=$(mvn --settings="${mvn_settings}" \
-  org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
+  org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
+  -DstagingProfileId="${STAGING_PROFILE_ID}")
+
+echo $deployment
 
 if echo "$deployment" | grep "BUILD SUCCESS"; then
   DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
@@ -165,15 +166,14 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
         \"description\": \"Releasing ${DEPLOYED_STAGING_REPO_ID}\"}
       }"
       
-    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
+    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d "{\"data\": ${JSON_DATA}}")
-    
+
     if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
-        echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
         echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
@@ -185,7 +185,8 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
 else 
     echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
     echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
-fi})
+fi
+})
                      loadCustomScript.sh(chmod a+x ./stage-maven-release.sh)
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing/manifest.yml, type=maven, platform=linux, sigtype=.asc, email=release@opensearch.org})
                      signArtifacts.fileExists(workspace/sign.sh)

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -121,20 +121,21 @@ EOF
 }
 
 create_maven_settings
-
 echo "AUTO_PUBLISH variable is set to: '$AUTO_PUBLISH'"
 echo "==========================================="
 echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
 deployment=$(mvn --settings="${mvn_settings}" \
-  org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
+  org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}" | tee /dev/stderr)
+  -DstagingProfileId="${STAGING_PROFILE_ID}")
+
+echo $deployment
 
 if echo "$deployment" | grep "BUILD SUCCESS"; then
   DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
@@ -165,15 +166,14 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
         \"description\": \"Releasing ${DEPLOYED_STAGING_REPO_ID}\"}
       }"
       
-    RESPONSE_CODE=$(curl -o /tmp/out.txt -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
+    RESPONSE_CODE=$(curl -w "%{http_code}\n" -X POST "${PROMOTION_URL}" \
       -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
       -H "Content-Type: application/json" \
       -H "Accept: application/json" \
       -d "{\"data\": ${JSON_DATA}}")
-    
+
     if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
-        echo "Response: $(cat /tmp/out.txt)"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
     else
         echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
@@ -185,7 +185,8 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
 else 
     echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
     echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
-fi})
+fi
+})
                      loadCustomScript.sh(chmod a+x ./stage-maven-release.sh)
                   publishToMaven.signArtifacts({artifactPath=/path/to/signing, type=maven, platform=linux, sigtype=.asc, email=release@opensearch.org})
                      signArtifacts.fileExists(workspace/sign.sh)

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -175,6 +175,7 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     if [[ ${RESPONSE_CODE} != 200 ]]; then
         echo "Failed to close and release staging repository ${DEPLOYED_STAGING_REPO_ID}. Response code: ${RESPONSE_CODE}"
         echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
+        exit 1
     else
         echo "Staging repository ${DEPLOYED_STAGING_REPO_ID} released successfully."
     fi
@@ -183,7 +184,7 @@ if [ "$AUTO_PUBLISH" = true ] && [ -n "$DEPLOYED_STAGING_REPO_ID" ] ; then
     echo "Done."
     echo "==========================================="
 else 
-    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH is set to false or DEPLOYED_STAGING_REPO_ID is empty."
+    echo "Skipping auto-release of staging repository ${DEPLOYED_STAGING_REPO_ID} as AUTO_PUBLISH might be set false or unable to retrieve DEPLOYED_STAGING_REPO_ID."
     echo "Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing ."
 fi
 })


### PR DESCRIPTION
### Description
- Bumps the maven plugin version to 1.7.0 which as per the maven central support team is more stable and should not throw IO errors like before.
- Removes `tee` command that was causing auto-publish to reset and caching all stdout

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5548

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
