### PR TITLE
Fix breaking changes for gradlecheck test failure issue creation

### DIFF
--- a/src/gradlecheck/FetchPostMergeFailedTestClass.groovy
+++ b/src/gradlecheck/FetchPostMergeFailedTestClass.groovy
@@ -90,8 +90,13 @@ class FetchPostMergeFailedTestClass {
     }
 
     def getPostMergeFailedTestClass(timeFrame) {
-         def jsonResponse = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script).fetchMetrics(getQuery(timeFrame))
-         def keys = jsonResponse.aggregations.test_class_keyword_agg.buckets.collect { it.key }
-         return keys
+        try {
+            def jsonResponse = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script).fetchMetrics(getQuery(timeFrame))
+            def keys = jsonResponse.aggregations.test_class_keyword_agg.buckets.collect { it.key }
+            return keys
+        } catch (Exception e) {
+            this.script.println("Error fetching Failed Test Class Details: ${e.message}")
+            return null
+        }
     }
 }

--- a/src/gradlecheck/FetchPostMergeTestGitReference.groovy
+++ b/src/gradlecheck/FetchPostMergeTestGitReference.groovy
@@ -93,8 +93,13 @@ class FetchPostMergeTestGitReference  {
     }
 
     def getPostMergeTestGitReference(testName) {
-        def jsonResponse = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script).fetchMetrics(getQuery(testName))
-        def keys = jsonResponse.aggregations.git_reference_keyword_agg.buckets.collect { it.key }
-        return keys
+        try {
+            def jsonResponse = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script).fetchMetrics(getQuery(testName))
+            def keys = jsonResponse.aggregations.git_reference_keyword_agg.buckets.collect { it.key }
+            return keys
+        } catch (Exception e) {
+            this.script.println("Error fetching Git Reference Details: ${e.message}")
+            return null
+        }
     }
 }

--- a/src/gradlecheck/FetchTestPullRequests.groovy
+++ b/src/gradlecheck/FetchTestPullRequests.groovy
@@ -99,9 +99,13 @@ class FetchTestPullRequests  {
         return query.replace('"', '\\"')
     }
     List<String> getTestPullRequests(testName) {
-        def jsonResponse = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script).fetchMetrics(getQuery(testName))
-        def keys = jsonResponse.aggregations.pull_request_keyword_agg.buckets.collect { it.key }
-        return keys
+        try {
+            def jsonResponse = new OpenSearchMetricsQuery(metricsUrl,awsAccessKey, awsSecretKey, awsSessionToken, indexName, script).fetchMetrics(getQuery(testName))
+            def keys = jsonResponse.aggregations.pull_request_keyword_agg.buckets.collect { it.key }
+            return keys
+        } catch (Exception e) {
+            this.script.println("Error fetching Pull Request Details: ${e.message}")
+            return null
+        }
     }
-
 }

--- a/tests/gradlecheck/FetchPostMergeTestGitReferenceTest.groovy
+++ b/tests/gradlecheck/FetchPostMergeTestGitReferenceTest.groovy
@@ -13,6 +13,7 @@ import gradlecheck.FetchPostMergeTestGitReference
 import org.junit.Before
 import org.junit.Test
 import groovy.json.JsonOutput
+import utils.OpenSearchMetricsQuery
 
 class FetchPostMergeTestGitReferenceTest {
 
@@ -122,4 +123,24 @@ class FetchPostMergeTestGitReferenceTest {
 
         assert result == expectedOutput
     }
+
+    @Test
+    void testGetPostMergeTestGitReferenceException() {
+        script = new Expando()
+        def testName = "ExampleTest"
+        script.println = { String message ->
+            assert message.startsWith("Error fetching Git Reference Details:")
+        }
+        fetchPostMergeTestGitReference = new FetchPostMergeTestGitReference(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, script)
+        OpenSearchMetricsQuery.metaClass.constructor = { Object[] args ->
+            return [
+                    fetchMetrics: { query ->
+                        throw new RuntimeException("Test exception")
+                    }
+            ] as OpenSearchMetricsQuery
+        }
+        def result = fetchPostMergeTestGitReference.getPostMergeTestGitReference(testName)
+        assert result == null
+    }
 }
+

--- a/vars/gradleCheckFlakyTestDetector.groovy
+++ b/vars/gradleCheckFlakyTestDetector.groovy
@@ -30,14 +30,14 @@ void call(Map args = [:]) {
             def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
             def awsSessionToken = env.AWS_SESSION_TOKEN
             def timeFrame = args.timeFrame ?: '30d'
-            def indexName = 'gradle-check-*'
+            def indexName = 'gradle-check'
             def postMergeFailedTests = new FetchPostMergeFailedTestClass(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, this).getPostMergeFailedTestClass(timeFrame)
             postMergeFailedTests.each { failedTest ->
                 def testData = []
                 def allPullRequests = []
                 def postMergeTestGitReference = new FetchPostMergeTestGitReference(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, this).getPostMergeTestGitReference(failedTest)
                 postMergeTestGitReference.each { gitReference ->
-                    def failedTestNames = new FetchPostMergeFailedTestName(metricsUrl, awsAccessKey, awsSecretKey, indexName, awsSessionToken, this).getPostMergeFailedTestName(failedTest, gitReference)
+                    def failedTestNames = new FetchPostMergeFailedTestName(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, this).getPostMergeFailedTestName(failedTest, gitReference)
                     def testNames = failedTestNames.aggregations.test_name_keyword_agg.buckets.collect { it.key }
                     def buildNumber = failedTestNames.aggregations.build_number_agg.buckets.collect { it.key }
                     def pullRequests = failedTestNames.aggregations.pull_request_agg.buckets.collect { it.key }


### PR DESCRIPTION
### Description
Fix breaking changes for gradlecheck test failure issue creation, uses alias instead of index pattern
Added error handling for the libraries consumed.
### Issues Resolved

https://build.ci.opensearch.org/blue/organizations/jenkins/gradle-check-flaky-test-detector/detail/gradle-check-flaky-test-detector/1782/pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
