### PR TITLE
Sort builds in chronological order in autocut flaky test reports

### DIFF
--- a/src/gradlecheck/FetchPostMergeTestGitReference.groovy
+++ b/src/gradlecheck/FetchPostMergeTestGitReference.groovy
@@ -82,7 +82,17 @@ class FetchPostMergeTestGitReference  {
                         git_reference_keyword_agg: [
                                 terms: [
                                         field: "git_reference.keyword",
-                                        size: 500
+                                        size: 500,
+                                        order: [
+                                                sort_build_number: "desc"
+                                        ]
+                                ],
+                                aggs: [
+                                        sort_build_number: [
+                                                max: [
+                                                        field: "build_number",
+                                                ]
+                                        ]
                                 ]
                         ]
                 ]

--- a/tests/gradlecheck/FetchPostMergeTestGitReferenceTest.groovy
+++ b/tests/gradlecheck/FetchPostMergeTestGitReferenceTest.groovy
@@ -103,7 +103,17 @@ class FetchPostMergeTestGitReferenceTest {
                         git_reference_keyword_agg: [
                                 terms: [
                                         field: "git_reference.keyword",
-                                        size: 500
+                                        size: 500,
+                                        order: [
+                                                sort_build_number: "desc"
+                                        ]
+                                ],
+                                aggs: [
+                                        sort_build_number: [
+                                                max: [
+                                                        field: "build_number",
+                                                ]
+                                        ]
                                 ]
                         ]
                 ]

--- a/vars/gradleCheckFlakyTestDetector.groovy
+++ b/vars/gradleCheckFlakyTestDetector.groovy
@@ -24,7 +24,7 @@ void call(Map args = [:]) {
             string(credentialsId: 'jenkins-health-metrics-account-number', variable: 'METRICS_HOST_ACCOUNT'),
             string(credentialsId: 'jenkins-health-metrics-cluster-endpoint', variable: 'METRICS_HOST_URL')
     ]) {
-        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 1500, roleSessionName: 'jenkins-session') {
             def metricsUrl = env.METRICS_HOST_URL
             def awsAccessKey = env.AWS_ACCESS_KEY_ID
             def awsSecretKey = env.AWS_SECRET_ACCESS_KEY

--- a/vars/gradleCheckFlakyTestDetector.groovy
+++ b/vars/gradleCheckFlakyTestDetector.groovy
@@ -24,7 +24,7 @@ void call(Map args = [:]) {
             string(credentialsId: 'jenkins-health-metrics-account-number', variable: 'METRICS_HOST_ACCOUNT'),
             string(credentialsId: 'jenkins-health-metrics-cluster-endpoint', variable: 'METRICS_HOST_URL')
     ]) {
-        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 1500, roleSessionName: 'jenkins-session') {
+        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 2400, roleSessionName: 'jenkins-session') {
             def metricsUrl = env.METRICS_HOST_URL
             def awsAccessKey = env.AWS_ACCESS_KEY_ID
             def awsSecretKey = env.AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
### Description
Sort the linked PR w.r.t build number in issues reporting gradle test failure 
Increase the timeout in session token to fetch the metrics query details.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/18894
https://build.ci.opensearch.org/job/gradle-check-flaky-test-detector/1976/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
