### PR TITLE
add sigv4, region, service to opensearch build libraries

### DIFF
--- a/vars/runBenchmarkTestScript.groovy
+++ b/vars/runBenchmarkTestScript.groovy
@@ -15,6 +15,9 @@
  * @param args.distributionVersion <optional> - Provide OpenSearch version if using distributionUrl param
  * @param args.endpoint <optional> - Endpoint to the cluster.
  * @param args.insecure <optional> - Force the security of the cluster to be disabled, default is false.
+ * @param args.sigv4 <optional> - Use AWS SigV4 authentication, default is false.
+ * @param args.region <optional> - AWS region for signing, default is us-east-1
+ * @param args.service <optional> - AWS service to sign for (es = OpenSearch Service, aoss = OpenSearch Serverless)
  * @param args.workload <required> - Name of the workload that OpenSearch Benchmark should run, default is nyc_taxis.
  * @param args.singleNode <optional> - Create single node OS cluster, default is true.
  * @param args.minDistribution <optional> - Use min distribution of OpenSearch for cluster, default is false.
@@ -99,6 +102,9 @@ void call(Map args = [:]) {
             "--benchmark-config ${WORKSPACE}/benchmark.ini",
             "--user-tag ${userTags}",
             args.insecure?.toBoolean() ? "--without-security" : "",
+            args.sigv4?.toBoolean() ? "--sigv4" : "",
+            isNullOrEmpty(args.region) ? "" : "--region ${args.region}",
+            isNullOrEmpty(args.service) ? "" : "--service ${args.service}",
             isNullOrEmpty(args.username) ? "" : "--username ${args.username}",
             isNullOrEmpty(args.password) ? "" : "--password ${args.password}",
             args.singleNode?.toBoolean() ? "--single-node" : "",


### PR DESCRIPTION
### Description
Adds sigv4, region, service args to opensearch build libraries

### Issues Resolved
[#5691](https://github.com/opensearch-project/opensearch-build/pull/5691)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
