### PR TITLE
Index build summary record for every gradle-check run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '11.5.0'
+String version = '11.5.1'
 
 task updateVersion {
     doLast {

--- a/vars/publishGradleCheckTestResults.groovy
+++ b/vars/publishGradleCheckTestResults.groovy
@@ -39,17 +39,42 @@ void call(Map args = [:]) {
 
     def test_docs = getFailedTestRecords(buildNumber, prNumber, invokeType, prOwner, prTitle, gitReference, buildResult, buildDuration, buildStartTime)
 
-    if (test_docs) {
-        for (doc in test_docs) {
-            def jsonDoc = JsonOutput.toJson(doc)
-            finalJsonDoc += "{\"index\": {\"_index\": \"${indexName}\"}}\n" + "${jsonDoc}\n"
-        }
-        writeFile file: "failed-test-records.json", text: finalJsonDoc
-
-        def fileContents = readFile(file: "failed-test-records.json").trim()
-        println("File Content is:\n${fileContents}")
-        indexFailedTestData()
+    for (doc in test_docs) {
+        def jsonDoc = JsonOutput.toJson(doc)
+        finalJsonDoc += "{\"index\": {\"_index\": \"${indexName}\"}}\n" + "${jsonDoc}\n"
     }
+
+    def buildSummaryDoc = [
+        'build_number': buildNumber,
+        'pull_request': prNumber,
+        'pull_request_owner': prOwner,
+        'invoke_type': invokeType,
+        'pull_request_title': prTitle,
+        'git_reference': gitReference,
+        'test_status': 'BUILD_SUMMARY',
+        'build_result': buildResult,
+        'build_duration': buildDuration,
+        'build_start_time': buildStartTime
+    ]
+
+    AbstractTestResultAction testResultAction = currentBuild.rawBuild.getAction(AbstractTestResultAction.class)
+    if (testResultAction != null) {
+        def testsTotal = testResultAction.totalCount
+        def testsFailed = testResultAction.failCount
+        def testsSkipped = testResultAction.skipCount
+        buildSummaryDoc['test_fail_count'] = testsFailed
+        buildSummaryDoc['test_skipped_count'] = testsSkipped
+        buildSummaryDoc['test_passed_count'] = testsTotal - testsFailed - testsSkipped
+    }
+
+    def summaryJson = JsonOutput.toJson(buildSummaryDoc)
+    finalJsonDoc += "{\"index\": {\"_index\": \"${indexName}\"}}\n" + "${summaryJson}\n"
+
+    writeFile file: "failed-test-records.json", text: finalJsonDoc
+
+    def fileContents = readFile(file: "failed-test-records.json").trim()
+    println("File Content is:\n${fileContents}")
+    indexFailedTestData()
 }
 
 List<Map<String, String>> getFailedTestRecords(buildNumber, prNumber, invokeType, prOwner, prTitle, gitReference, buildResult, buildDuration, buildStartTime) {


### PR DESCRIPTION
Previously, publishGradleCheckTestResults only indexed records when test failures were present, meaning successful builds left no trace in the metrics cluster. This adds a BUILD_SUMMARY record that is indexed on every run, capturing build result, duration, and aggregate test counts. Failed runs still produce individual failure records alongside the summary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
