### PR TITLE
Add command parameter to runGradleCheck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '11.5.2'
+String version = '11.6.0'
 
 task updateVersion {
     doLast {

--- a/vars/publishGradleCheckTestResults.groovy
+++ b/vars/publishGradleCheckTestResults.groovy
@@ -12,6 +12,7 @@
  * @param Map args = [:] args A map of the following parameters
  * @param args.prNumber <required> - The pull_request number that triggered the gradle-check run. If Null then use post_merge_action string.
  * @param args.prDescription <required> - The subject of the pull_request. If prNumber is null then it signifies push action on branch.
+ * @param args.command <optional> - The Gradle command that was executed (e.g. 'check', ':server:check'). Recorded in index documents to distinguish parallel job slices.
  */
 
 import hudson.tasks.test.AbstractTestResultAction
@@ -32,12 +33,13 @@ void call(Map args = [:]) {
     def prOwner = args.prOwner.toString()
     def prTitle = args.prTitle.toString()
     def gitReference = args.gitReference.toString()
+    def gradleCommand = args.command ?: null
     def currentDate = new Date()
     def formattedDate = new SimpleDateFormat("MM-yyyy").format(currentDate)
 
     def indexName = "gradle-check-${formattedDate}"
 
-    def test_docs = getFailedTestRecords(buildNumber, prNumber, invokeType, prOwner, prTitle, gitReference, buildResult, buildDuration, buildStartTime)
+    def test_docs = getFailedTestRecords(buildNumber, prNumber, invokeType, prOwner, prTitle, gitReference, buildResult, buildDuration, buildStartTime, gradleCommand)
 
     for (doc in test_docs) {
         def jsonDoc = JsonOutput.toJson(doc)
@@ -56,6 +58,10 @@ void call(Map args = [:]) {
         'build_duration': buildDuration,
         'build_start_time': buildStartTime
     ]
+
+    if (gradleCommand) {
+        buildSummaryDoc['gradle_command'] = gradleCommand
+    }
 
     populateTestCounts(buildSummaryDoc)
 
@@ -81,7 +87,7 @@ void populateTestCounts(Map buildSummaryDoc) {
     }
 }
 
-List<Map<String, String>> getFailedTestRecords(buildNumber, prNumber, invokeType, prOwner, prTitle, gitReference, buildResult, buildDuration, buildStartTime) {
+List<Map<String, String>> getFailedTestRecords(buildNumber, prNumber, invokeType, prOwner, prTitle, gitReference, buildResult, buildDuration, buildStartTime, gradleCommand) {
     def testResults = []
     AbstractTestResultAction testResultAction = currentBuild.rawBuild.getAction(AbstractTestResultAction.class)
     if (testResultAction != null) {
@@ -94,6 +100,9 @@ List<Map<String, String>> getFailedTestRecords(buildNumber, prNumber, invokeType
         if (failedTests){
             for (test in failedTests) {
                 def failDocument = ['build_number': buildNumber, 'pull_request': prNumber, 'pull_request_owner': prOwner , 'invoke_type': invokeType, 'pull_request_title': prTitle, 'git_reference': gitReference, 'test_class': test.getParent().getName(), 'test_name': test.fullName, 'test_status': 'FAILED', 'build_result': buildResult, 'test_fail_count': testsFailed, 'test_skipped_count': testsSkipped, 'test_passed_count': testsPassed, 'build_duration': buildDuration, 'build_start_time': buildStartTime]
+                if (gradleCommand) {
+                    failDocument['gradle_command'] = gradleCommand
+                }
                 testResults.add(failDocument)
             }
         } else {
@@ -191,6 +200,9 @@ void indexFailedTestData() {
                                 "type": "integer"
                             },
                             "test_status": {
+                                "type": "keyword"
+                            },
+                            "gradle_command": {
                                 "type": "keyword"
                             }
                         }

--- a/vars/runGradleCheck.groovy
+++ b/vars/runGradleCheck.groovy
@@ -13,31 +13,34 @@
  *  @param args.gitRepoUrl <required> - Github repo url generally - https://github.com/opensearch-project/OpenSearch.git  is cloned and checks tasks are executed in it.
  *  @param args.gitReference <optional> - The git commit or branch that needs to be checked in OpenSearch repo to run check tasks defaults to main.
  *  @param args.bwcCheckoutAlign <optional> - Used to set the value of bwc.checkout.align, can be either true or false
- *  @param args.module_name <optional> - Defines module scope which has check tasks running and reported against it.
+ *  @param args.scope <optional> - Defines module scope which has check tasks running and reported against it. Cannot be used with args.command.
+ *  @param args.command <optional> - Sets the Gradle command directly, bypassing scope-based selection. Cannot be used with args.scope.
  **/
 
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@main', retriever: legacySCM(scm))
     def git_repo_url = args.gitRepoUrl ?: 'null'
     def git_reference = args.gitReference ?: 'null'
-    def module_name = args.scope ?: 'null'
     def bwc_checkout_align = args.bwcCheckoutAlign ?: 'false'
     def bwc_checkout_align_param = ''
     def command
     println("Git Repo: ${git_repo_url}")
     println("Git Reference: ${git_reference}")
     println("Bwc Checkout Align: ${bwc_checkout_align}")
-    println("Module Scope: ${module_name}")
+
+    if (args.scope && args.command) {
+        error("Cannot specify both 'scope' and 'command' parameters. Use one or the other.")
+    }
 
     if (Boolean.parseBoolean(bwc_checkout_align)) {
         bwc_checkout_align_param = '-Dbwc.checkout.align=true'
     }
 
-    if (git_repo_url.equals('null') || git_reference.equals('null') || module_name.equals('null')) {
-        println("git repo url or git reference or module_name aren't specified to checkout the commit and run gradle check task, exit 1")
-        System.exit(1)
-    }
-    else {
+    if (args.command) {
+        command = args.command
+        println("Command (explicit): ${command}")
+    } else if (args.scope) {
+        println("Module Scope: ${args.scope}")
         switch (args.scope) {
             case 'server':
                 command = ':server:check -Dmoduletests.coverage=true'
@@ -49,6 +52,14 @@ void call(Map args = [:]) {
                 command = 'check -Dtests.coverage=true'
                 break
         }
+    } else {
+        error("Either 'scope' or 'command' parameter must be specified.")
+    }
+
+    if (git_repo_url.equals('null') || git_reference.equals('null')) {
+        error("git repo url or git reference aren't specified to checkout the commit and run gradle check task.")
+    }
+    else {
 
         def secret_s3 = [
             [envVar: 'amazon_s3_access_key', secretRef: 'op://opensearch-infra-secrets/gradle-check/jenkins-gradle-check-s3-aws-access-key'],


### PR DESCRIPTION
This change allows the caller, which will ultimately be the GitHub Action in OpenSearch that triggers this job, to specify the exact command used to run the tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
