### PR TITLE
Fix indexing for integration test results

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '12.0.0'
+String version = '12.0.1'
 
 task updateVersion {
     doLast {

--- a/vars/publishIntegTestResults.groovy
+++ b/vars/publishIntegTestResults.groovy
@@ -132,9 +132,11 @@ def processFailedTests(failedTests, componentName, componentRepo, componentRepoU
             failedTests.collect { failedTest ->
                 def match = failedTest.split("#")
                 if (match) {
+                    def testClass = match[0].trim()
+                    def testName = match.length > 1 ? match[1].trim() : testClass
                     def testResultJsonContent = generateFailedTestJson(componentName, componentRepo, componentRepoUrl, version, qualifier, integTestBuildNumber,
                         integTestBuildUrl, distributionBuildNumber, distributionBuildUrl, buildStartTime, rc, rcNumber,
-                        platform, architecture, distribution, componentCategory, securityType, match[0].trim(), match[1].trim())
+                        platform, architecture, distribution, componentCategory, securityType, testClass, testName)
                     finalFailedTestsJsonDoc += "{\"index\": {\"_index\": \"${testFailuresindexName}\"}}\n${testResultJsonContent}\n"
                 }
             }


### PR DESCRIPTION
### Description
Fix indexing for integration test results

### Issues Resolved
Fixes indexing errors seen in https://build.ci.opensearch.org/view/Test/job/integ-test/11206/console
```
ERROR: Execution failed
java.lang.ArrayIndexOutOfBoundsException
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
