### PR TITLE
Add an option to skip core plugin validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '12.0.1'
+String version = '12.0.2'
 
 task updateVersion {
     doLast {

--- a/vars/validateArtifacts.groovy
+++ b/vars/validateArtifacts.groovy
@@ -24,6 +24,7 @@ Note: These parameters are mutually exclusive. Provide either of 'version' or  '
 @param Map[artifact_type] <Optional> - Select the artifact type among [staging and production].
 @param Map[allow_http] <Optional> - Supports validation of artifacts in which security plugin is absent.architecture.
 @param Map[docker_args] <Optional> - Select either of [using-staging-artifact-only', 'validate-digest-only] for docker validation.
+@param Map[skip_core_plugins] <Optional> - Skip native/core plugin validation.
 */
 void call(Map args = [:]) {
     if (!fileExists("$WORKSPACE/validation.sh")) {
@@ -45,6 +46,7 @@ void call(Map args = [:]) {
         args.artifact_type ? "--artifact-type ${args.artifact_type}" : "",
         args.allow_http ? '--allow-http' : "",
         args.docker_args ? "--${args.docker_args}" : "",
+        args.skip_core_plugins ? '--skip-core-plugins' : "",
     ].join(' ').trim()
 
     if (isUnix()) {


### PR DESCRIPTION
### Description
Add an option to skip core plugin validation. Related PR https://github.com/opensearch-project/opensearch-build/pull/6225

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
