### PR TITLE
Refactor standalone release workflows to use prerelease and add notifications

### DIFF
--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -19,23 +19,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
       - name: Run gradle task
         id: gradle
         run: |
           ./gradlew updateVersion
-      - name: GitHub App token
-        id: github_app_token
-        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06 # v1.6.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
-          base: '12.x'
+          push-to-fork: opensearch-ci-bot/opensearch-build-libraries
+          token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          base: '13.x'
           committer: opensearch-ci-bot <opensearch-infra@amazon.com>
           author: opensearch-ci-bot <opensearch-infra@amazon.com>
           commit-message: |

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '12.1.0'
+String version = '13.0.0'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
+++ b/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
@@ -60,6 +60,8 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
         helper.registerAllowedMethod("GenericTrigger", [Map.class], null)
         binding.setVariable('tag', '1.0.0')
         binding.setVariable('release_url', 'https://api.github.com/repos/Codertocat/Hello-World/releases/17372790')
+        binding.setVariable('release_html_url', 'https://github.com/Codertocat/Hello-World/releases/tag/1.0.0')
+        binding.setVariable('repository', 'https://github.com/Codertocat/Hello-World')
         binding.setVariable('assets_url', 'https://api.github.com/repos/owner/name/releases/1234/assets')
         helper.registerAllowedMethod('readJSON', [Map], { Map parameters ->
             return new JsonSlurper().parseText(json)
@@ -70,7 +72,17 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
         })
         binding.setVariable('GITHUB_USER', "GITHUB_USER")
         binding.setVariable('GITHUB_TOKEN', "GITHUB_TOKEN")
+        binding.setVariable('JOB_NAME', 'dummy_release_job')
+        binding.setVariable('BUILD_NUMBER', '100')
+        binding.setVariable('BUILD_URL', 'https://build.ci.opensearch.org/job/dummy_release_job/100/')
+        binding.setVariable('WEBHOOK_URL', 'https://webhook.example.com')
+        binding.setVariable('currentBuild', [currentResult: 'SUCCESS'])
         super.setUp()
+        binding.setVariable('env', [
+                'JOB_NAME'    : 'dummy_release_job',
+                'BUILD_NUMBER': '100',
+                'BUILD_URL'   : 'https://build.ci.opensearch.org/job/dummy_release_job/100/'
+        ])
     }
 
 
@@ -102,17 +114,17 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
             c -> c.contains('generic')
         }
         assertThat(cmd.size(), equalTo(1))
-        assertThat(cmd, hasItem('{genericVariables=[{key=ref, value=$.release.tag_name}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isDraft, value=$.release.draft}, {key=release_url, value=$.release.url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$isDraft $action, regexpFilterExpression=^true created$}'))
+        assertThat(cmd, hasItem('{genericVariables=[{key=ref, value=$.release.tag_name}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isPreRelease, value=$.release.prerelease}, {key=release_url, value=$.release.url}, {key=release_html_url, value=$.release.html_url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$isPreRelease $action, regexpFilterExpression=^true published$}'))
     }
 
     @Test
-    void 'validate release is published'(){
+    void 'validate github issue is created'(){
         runScript("tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile")
         def cmd = getCommands('sh').findAll{
-            c -> c.contains('curl')
+            c -> c.contains('gh issue create')
         }
-        assertThat(cmd, hasItem("curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/Codertocat/Hello-World/releases/17372790 -d '{\"tag_name\":\"1.0.0\",\"draft\":false,\"prerelease\":false}'"))
-
+        assertThat(cmd.size(), equalTo(1))
+        assertThat(cmd, hasItem("""gh issue create --title \"[Release - Action Required] Publish release for tag 1.0.0\" --body \"The release workflow for tag `1.0.0` completed successfully.\n\nBuild: https://build.ci.opensearch.org/job/dummy_release_job/100/\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0\n\ncc: bbb\nccc\" --repo https://github.com/Codertocat/Hello-World"""))
     }
 
    @Test
@@ -121,8 +133,8 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
         def cmd = getCommands('sh').findAll{
             c -> c.contains('curl')
         }
-        assertThat(cmd, hasItem("curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"))
-        assertThat(cmd, hasItem("{script=curl -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/name/releases/1234/assets, returnStdout=true}"))
+        assertThat(cmd, hasItem("curl -s --fail -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"))
+        assertThat(cmd, hasItem("{script=curl -s --fail -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/name/releases/1234/assets, returnStdout=true}"))
     }
 
     @Test
@@ -143,7 +155,7 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
             c -> c.contains('generic')
         }
         assertThat(cmd.size(), equalTo(1))
-        assertThat(cmd, hasItem('{genericVariables=[{key=ref, value=.ref}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isDraft, value=$.release.draft}, {key=release_url, value=$.release.url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$ref, regexpFilterExpression=^refs/tags/.*}'))
+        assertThat(cmd, hasItem('{genericVariables=[{key=ref, value=.ref}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isPreRelease, value=$.release.prerelease}, {key=release_url, value=$.release.url}, {key=release_html_url, value=$.release.html_url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$ref, regexpFilterExpression=^refs/tags/.*}'))
     }
 
     @Test
@@ -156,12 +168,12 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
     }
 
     @Test
-    void 'validate release is not published'(){
+    void 'validate github issue is created for tag trigger'(){
         runScript("tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile")
         def cmd = getCommands('sh').findAll{
-            c -> c.contains('curl')
+            c -> c.contains('gh issue create')
         }
-        assertThat(cmd.size(), equalTo(0))
+        assertThat(cmd.size(), equalTo(1))
     }
 
     def getCommands(String method) {

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.txt
@@ -3,12 +3,34 @@
          standardReleasePipelineWithGenericTrigger.pipeline(groovy.lang.Closure)
             standardReleasePipelineWithGenericTrigger.timeout({time=1, unit=HOURS})
             standardReleasePipelineWithGenericTrigger.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:release-centos7-clients-v4, reuseNode:false, stages:[:], args:-e JAVA_HOME=/opt/java/openjdk-11, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])
-            standardReleasePipelineWithGenericTrigger.GenericTrigger({genericVariables=[{key=ref, value=.ref}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isDraft, value=$.release.draft}, {key=release_url, value=$.release.url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$ref, regexpFilterExpression=^refs/tags/.*})
+            standardReleasePipelineWithGenericTrigger.GenericTrigger({genericVariables=[{key=ref, value=.ref}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isPreRelease, value=$.release.prerelease}, {key=release_url, value=$.release.url}, {key=release_html_url, value=$.release.html_url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$ref, regexpFilterExpression=^refs/tags/.*})
             standardReleasePipelineWithGenericTrigger.echo(Skipping stage Download artifacts)
             standardReleasePipelineWithGenericTrigger.stage(Release, groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                   StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.echo(fakePublishToNpm [tag:1.0.0])
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
+               standardReleasePipelineWithGenericTrigger.publishNotification({icon=:white_check_mark:, message=Release 1.0.0 completed successfully, extra=REPOSITORY: https://github.com/Codertocat/Hello-World
+TAG: 1.0.0, credentialsId=opensearch-release-notification-webhook})
+                  publishNotification.withSecrets({secrets=[{envVar=WEBHOOK_URL, secretRef=op://opensearch-release-secrets/webhook/opensearch-release-notification-webhook}]}, groovy.lang.Closure)
+                     publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
+JOB_NAME=dummy_release_job
+BUILD_NUMBER=[100]
+MESSAGE=Release 1.0.0 completed successfully
+BUILD_URL: https://build.ci.opensearch.org/job/dummy_release_job/100/
+REPOSITORY: https://github.com/Codertocat/Hello-World
+TAG: 1.0.0"}' "https://webhook.example.com")
                standardReleasePipelineWithGenericTrigger.postCleanup()
                   postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
+               standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
+                  standardReleasePipelineWithGenericTrigger.sh({script=gh api repos/Codertocat/Hello-World/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d | grep -oP '@[\w/-]+' | sort -u | tr '\n' ' ' || echo '', returnStdout=true})
+                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag `1.0.0` completed successfully.
+
+Build: https://build.ci.opensearch.org/job/dummy_release_job/100/
+
+Please publish the release on GitHub by converting the pre-release to a full release.
+
+Release: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0
+
+cc: bbb
+ccc" --repo https://github.com/Codertocat/Hello-World)

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
@@ -3,23 +3,43 @@
          standardReleasePipelineWithGenericTrigger.pipeline(groovy.lang.Closure)
             standardReleasePipelineWithGenericTrigger.timeout({time=1, unit=HOURS})
             standardReleasePipelineWithGenericTrigger.echo(Executing on agent [docker:[image:centos:7, reuseNode:false, stages:[:], args:-e JAVA_HOME=/opt/java/openjdk-17, alwaysPull:true, containerPerStageRoot:false, label:AL2-X64]])
-            standardReleasePipelineWithGenericTrigger.GenericTrigger({genericVariables=[{key=ref, value=$.release.tag_name}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isDraft, value=$.release.draft}, {key=release_url, value=$.release.url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$isDraft $action, regexpFilterExpression=^true created$})
+            standardReleasePipelineWithGenericTrigger.GenericTrigger({genericVariables=[{key=ref, value=$.release.tag_name}, {key=repository, value=$.repository.html_url}, {key=action, value=$.action}, {key=isPreRelease, value=$.release.prerelease}, {key=release_url, value=$.release.url}, {key=release_html_url, value=$.release.html_url}, {key=assets_url, value=$.release.assets_url}], tokenCredentialId=opensearch-ci-webhook-trigger-token, causeString=A tag was cut on opensearch-ci repo, printContributedVariables=false, printPostContent=false, regexpFilterText=$isPreRelease $action, regexpFilterExpression=^true published$})
             standardReleasePipelineWithGenericTrigger.stage(Download artifacts, groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                   standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
-                     standardReleasePipelineWithGenericTrigger.sh({script=curl -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/name/releases/1234/assets, returnStdout=true})
+                     standardReleasePipelineWithGenericTrigger.sh({script=curl -s --fail -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/name/releases/1234/assets, returnStdout=true})
                      standardReleasePipelineWithGenericTrigger.readJSON({text=
 bbb
 ccc
 })
                      standardReleasePipelineWithGenericTrigger.echo(Downloading artifacts from https://api.github.com/repos/owner/reponame/releases/assets/123456)
-                     standardReleasePipelineWithGenericTrigger.sh(curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 -o artifacts.tar.gz && tar -xvf artifacts.tar.gz)
+                     standardReleasePipelineWithGenericTrigger.sh(curl -s --fail -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/owner/reponame/releases/assets/123456 -o artifacts.tar.gz && tar -xvf artifacts.tar.gz)
             standardReleasePipelineWithGenericTrigger.stage(Release, groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                   StandardReleasePipelineWithGenericTriggers_Jenkinsfile.echo(fakePublishToMaven [mavenArtifactsPath:/maven, autoPublish:true])
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
+               standardReleasePipelineWithGenericTrigger.publishNotification({icon=:white_check_mark:, message=Release 1.0.0 completed successfully, extra=REPOSITORY: https://github.com/Codertocat/Hello-World
+TAG: 1.0.0, credentialsId=opensearch-release-notification-webhook})
+                  publishNotification.withSecrets({secrets=[{envVar=WEBHOOK_URL, secretRef=op://opensearch-release-secrets/webhook/opensearch-release-notification-webhook}]}, groovy.lang.Closure)
+                     publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
+JOB_NAME=dummy_release_job
+BUILD_NUMBER=[100]
+MESSAGE=Release 1.0.0 completed successfully
+BUILD_URL: https://build.ci.opensearch.org/job/dummy_release_job/100/
+REPOSITORY: https://github.com/Codertocat/Hello-World
+TAG: 1.0.0"}' "https://webhook.example.com")
                standardReleasePipelineWithGenericTrigger.postCleanup()
                   postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
-                  standardReleasePipelineWithGenericTrigger.sh(curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer GITHUB_TOKEN' https://api.github.com/repos/Codertocat/Hello-World/releases/17372790 -d '{"tag_name":"1.0.0","draft":false,"prerelease":false}')
+                  standardReleasePipelineWithGenericTrigger.sh({script=gh api repos/Codertocat/Hello-World/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d | grep -oP '@[\w/-]+' | sort -u | tr '\n' ' ' || echo '', returnStdout=true})
+                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag `1.0.0` completed successfully.
+
+Build: https://build.ci.opensearch.org/job/dummy_release_job/100/
+
+Please publish the release on GitHub by converting the pre-release to a full release.
+
+Release: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0
+
+cc: bbb
+ccc" --repo https://github.com/Codertocat/Hello-World)

--- a/tests/jenkins/lib-testers/PublishNotificationLibTester.groovy
+++ b/tests/jenkins/lib-testers/PublishNotificationLibTester.groovy
@@ -52,6 +52,11 @@ class PublishNotificationLibTester extends LibFunctionTester {
         binding.setVariable('BUILD_NUMBER', '123')
         binding.setVariable('BUILD_URL', 'htth://BUILD_URL_dummy.com')
         binding.setVariable('WEBHOOK_URL', 'htth://WEBHOOK_URL_dummy.com')
+        binding.setVariable('env', [
+                'JOB_NAME'    : 'dummy_job',
+                'BUILD_NUMBER': '123',
+                'BUILD_URL'   : 'htth://BUILD_URL_dummy.com'
+        ])
         helper.registerAllowedMethod("withCredentials", [Map])
     }
 }

--- a/vars/publishNotification.groovy
+++ b/vars/publishNotification.groovy
@@ -7,15 +7,18 @@
  * compatible open source license.
  */
 void call(Map args = [:]) {
-    text = ([
+    def parts = [
         "${args.icon}",
-        "JOB_NAME=${JOB_NAME}",
-        "BUILD_NUMBER=[${BUILD_NUMBER}]",
+        "JOB_NAME=${env.JOB_NAME}",
+        "BUILD_NUMBER=[${env.BUILD_NUMBER}]",
         "MESSAGE=${args.message}",
-        "BUILD_URL: ${BUILD_URL}",
-        "MANIFEST: ${args.manifest}",
-        args.extra
-    ] - null).join("\n")
+        "BUILD_URL: ${env.BUILD_URL}",
+    ]
+    if (args.manifest) {
+        parts.add("MANIFEST: ${args.manifest}")
+    }
+    parts.add(args.extra)
+    text = (parts - null).join("\n")
 
     def secret_webhook = [
         [envVar: 'WEBHOOK_URL', secretRef: "op://opensearch-release-secrets/webhook/${args.credentialsId}"]

--- a/vars/standardReleasePipelineWithGenericTrigger.groovy
+++ b/vars/standardReleasePipelineWithGenericTrigger.groovy
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-/** A standard release pipeline for OpenSearch projects including generic triggers. A tag or a draft release can be used as a trigger using this library. The defaults are all set to trigger via a draft release. If the release is successful, the release can be published by using right params.
+/** A standard release pipeline for OpenSearch projects including generic triggers. A tag or a pre-release can be used as a trigger using this library. The defaults are all set to trigger via a pre-release. If the release is successful, a GitHub issue is created for maintainers to publish the release.
 @param Map arguments = [:] arguments A map of the following parameters
 @param body <Required> - A closure containing release steps to be executed in release stage.
 @param arguments.tokenIdCredential <Required> - Credential id containing token for trigger authentication
@@ -15,11 +15,10 @@
 @param arguments.overrideDockerImage <Optional> - Docker image to override the default ('opensearchstaging/ci-runner:release-centos7-clients-v1')
 @param arguments.jsonValue <Optional> - Json value retrieved from payload of the webhook. Defaults to '$.release.tag_name'
 @param arguments.causeString <Optional> - String mentioning why the workflow was triggered. Defaults to 'A tag was cut on GitHub repository causing this workflow to run'
-@param arguments.regexpFilterText <Optional> - Variable to apply regular expression on. Defaults to '$isDraft'
-@param arguments.regexpFilterExpression <Optional> - Regular expression to test on the evaluated text specified. Defaults to ''
-@param arguments.publishRelease <Optional> - If set to true the release that triggered the job will be published on GitHub.
+@param arguments.regexpFilterText <Optional> - Variable to apply regular expression on. Defaults to '$isPreRelease $action'
+@param arguments.regexpFilterExpression <Optional> - Regular expression to test on the evaluated text specified. Defaults to '^true published$'
 @param arguments.downloadReleaseAsset <Optional> - If set to true, the assets attached to the release that triggered the job will be downloaded. Defaults to false.
-@param arguments.downloadReleaseAssetName <Optional> - Name of the tar.gz file attached to the draft release and containing artifacts to release. Defaults to 'artifacts.tar.gz'.
+@param arguments.downloadReleaseAssetName <Optional> - Name of the tar.gz file attached to the pre-release and containing artifacts to release. Defaults to 'artifacts.tar.gz'.
 */
 
 void call(Map arguments = [:], Closure body) {
@@ -47,16 +46,17 @@ void call(Map arguments = [:], Closure body) {
                     [key: 'ref', value: (arguments.jsonValue ?: '$.release.tag_name')],
                     [key: 'repository', value: '$.repository.html_url'],
                     [key: 'action', value: '$.action'],
-                    [key: 'isDraft', value: '$.release.draft'],
+                    [key: 'isPreRelease', value: '$.release.prerelease'],
                     [key: 'release_url', value: '$.release.url'],
+                    [key: 'release_html_url', value: '$.release.html_url'],
                     [key: 'assets_url', value: '$.release.assets_url']
                 ],
                 tokenCredentialId: arguments.tokenIdCredential,
                 causeString: arguments.causeString ?: 'A tag was cut on GitHub repository causing this workflow to run',
                 printContributedVariables: false,
                 printPostContent: false,
-                regexpFilterText: (arguments.regexpFilterText ?: '$isDraft $action'),
-                regexpFilterExpression: (arguments.regexpFilterExpression ?: '^true created$')
+                regexpFilterText: (arguments.regexpFilterText ?: '$isPreRelease $action'),
+                regexpFilterExpression: (arguments.regexpFilterExpression ?: '^true published$')
             )
         }
         environment {
@@ -73,21 +73,28 @@ void call(Map arguments = [:], Closure body) {
                 steps {
                     script {
                         if (arguments.downloadReleaseAsset && "$assets_url" != '') {
-                            withSecrets(secrets: secret_github_bot){
+                        withSecrets(secrets: secret_github_bot){
+                                def assetName = arguments.downloadReleaseAssetName ?: 'artifacts.tar.gz'
+                                String assetUrl = null
+
                                 String assets = sh(
-                                    script: "curl -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assets_url}",
+                                    script: "curl -s --fail -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assets_url}",
                                     returnStdout: true
                                 )
-                                String assetUrl = null
                                 def parsedJson = readJSON text: assets
-                                def assetName = arguments.downloadReleaseAssetName ?: 'artifacts.tar.gz'
                                 parsedJson.each { item ->
-                                    if(item.name == assetName) {
+                                    if (item.name == assetName) {
                                         assetUrl = item.url
-                                        }
                                     }
-                                echo "Downloading artifacts from $assetUrl"
-                                sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"
+                                }
+
+                                if (assetUrl == null) {
+                                    def availableAssets = parsedJson.collect { it.name }.join(', ')
+                                    error("Asset '${assetName}' not found in release assets. Available assets: [${availableAssets}]. Assets URL: ${assets_url}")
+                                }
+
+                                echo "Downloading artifacts from ${assetUrl}"
+                                sh "curl -s --fail -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"
                             }
                         }
                     }
@@ -104,15 +111,36 @@ void call(Map arguments = [:], Closure body) {
         post {
             success {
                 script {
-                    if (arguments.publishRelease && release_url != null) {
+                    withSecrets(secrets: secret_github_bot){
+                        def codeOwners = sh(
+                            script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
+                            returnStdout: true
+                        ).trim()
+                        def issueBody = "The release workflow for tag `${tag}` completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: ${release_html_url}\n\ncc: ${codeOwners}"
+                        sh """gh issue create --title \"[Release - Action Required] Publish release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
+                    }
+                }
+            }
+            failure {
+                script {
                         withSecrets(secrets: secret_github_bot){
-                            sh "curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${release_url} -d '{\"tag_name\":\"${tag}\",\"draft\":false,\"prerelease\":false}'"
-                        }
+                        def codeOwners = sh(
+                            script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
+                            returnStdout: true
+                        ).trim()
+                        def issueBody = "The release workflow for tag `${tag}` failed.\n\nPlease investigate the failure and retry the release.\n\nRelease: ${release_html_url}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
+                        sh """gh issue create --title \"[RELEASE] Failed: release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
                     }
                 }
             }
             always {
                 script {
+                    publishNotification(
+                        icon: currentBuild.currentResult == 'SUCCESS' ? ':white_check_mark:' : ':x:',
+                        message: currentBuild.currentResult == 'SUCCESS' ? "Release ${tag} completed successfully" : "Release ${tag} failed",
+                        extra: "REPOSITORY: ${repository}\nTAG: ${tag}",
+                        credentialsId: 'opensearch-release-notification-webhook'
+                    )
                     postCleanup()
                 }
             }


### PR DESCRIPTION

### Description
Since bot access has been removed for all repositories, the release workflows are unable to read the draft release. This PR fixes that. It now triggers only for pre-release. Would need additional changes in all repositories to switch from draft release creation to pre-release release. 
Also adds notification mechanism to both slack and GitHub
Maintainers now need to manually publish the pre-release to actual release on GitHub as bot does not have access anymore. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
