### PR TITLE
Support cluster write operations and add base for release state docs

### DIFF
--- a/src/jenkins/ReleaseCriterion.groovy
+++ b/src/jenkins/ReleaseCriterion.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+/**
+ * A single per-criterion release readiness record for the opensearch_release_state index.
+ * Validates its enum-like fields on construction so a malformed criterion never reaches the cluster.
+ */
+class ReleaseCriterion {
+
+    static final List<String> VALID_TYPES = ['entrance', 'exit']
+    static final List<String> VALID_STATUSES = ['met', 'not_met', 'in_progress', 'unknown', 'not_applicable']
+    static final List<String> VALID_PRODUCTS = ['opensearch', 'opensearch-dashboards', 'both']
+    static final List<String> VALID_SOURCES = ['issue_table', 'chore_check', 'manual']
+
+    String version
+    String releaseDate
+    Integer daysToRelease
+    String product
+    String criterionType
+    String criterionName
+    String status
+    String details
+    List<String> blockingComponents
+    String source
+    String releaseIssue
+    String checkedBy
+
+    ReleaseCriterion(Map args) {
+        this.version = required(args, 'version')
+        this.criterionType = requireOneOf(args, 'criterionType', VALID_TYPES)
+        this.criterionName = required(args, 'criterionName')
+        this.status = requireOneOf(args, 'status', VALID_STATUSES)
+        this.product = optionalOneOf(args, 'product', VALID_PRODUCTS)
+        this.source = optionalOneOf(args, 'source', VALID_SOURCES)
+        this.releaseDate = args.releaseDate
+        this.daysToRelease = args.daysToRelease
+        this.details = args.details
+        this.blockingComponents = args.blockingComponents ?: []
+        this.releaseIssue = args.releaseIssue
+        this.checkedBy = args.checkedBy
+    }
+
+    /**
+     * @param timestamp ISO-8601 time the criterion was checked, injected by the writer.
+     */
+    Map toDocument(String timestamp) {
+        return [
+            doc_type           : 'criterion',
+            version            : version,
+            release_date       : releaseDate,
+            days_to_release    : daysToRelease,
+            product            : product,
+            criterion_type     : criterionType,
+            criterion_name     : criterionName,
+            status             : status,
+            details            : details,
+            blocking_components: blockingComponents,
+            source             : source,
+            release_issue      : releaseIssue,
+            checked_by         : checkedBy,
+            last_checked       : timestamp
+        ]
+    }
+
+    private static String required(Map args, String key) {
+        if (!args[key]) {
+            throw new IllegalArgumentException("ReleaseCriterion: '${key}' is required.")
+        }
+        return args[key]
+    }
+
+    private static String requireOneOf(Map args, String key, List<String> allowed) {
+        String value = required(args, key)
+        if (!allowed.contains(value)) {
+            throw new IllegalArgumentException("ReleaseCriterion: '${key}' must be one of ${allowed}, got '${value}'.")
+        }
+        return value
+    }
+
+    private static String optionalOneOf(Map args, String key, List<String> allowed) {
+        String value = args[key]
+        if (value != null && !allowed.contains(value)) {
+            throw new IllegalArgumentException("ReleaseCriterion: '${key}' must be one of ${allowed}, got '${value}'.")
+        }
+        return value
+    }
+}

--- a/src/jenkins/ReleaseCriterion.groovy
+++ b/src/jenkins/ReleaseCriterion.groovy
@@ -9,6 +9,8 @@
 
 package jenkins
 
+import utils.ArgumentValidator
+
 /**
  * A single per-criterion release readiness record for the opensearch_release_state index.
  * Validates its enum-like fields on construction so a malformed criterion never reaches the cluster.
@@ -34,12 +36,13 @@ class ReleaseCriterion {
     String checkedBy
 
     ReleaseCriterion(Map args) {
-        this.version = required(args, 'version')
-        this.criterionType = requireOneOf(args, 'criterionType', VALID_TYPES)
-        this.criterionName = required(args, 'criterionName')
-        this.status = requireOneOf(args, 'status', VALID_STATUSES)
-        this.product = optionalOneOf(args, 'product', VALID_PRODUCTS)
-        this.source = optionalOneOf(args, 'source', VALID_SOURCES)
+        String context = this.class.simpleName
+        this.version = ArgumentValidator.required(args, 'version', context)
+        this.criterionType = ArgumentValidator.requireOneOf(args, 'criterionType', VALID_TYPES, context)
+        this.criterionName = ArgumentValidator.required(args, 'criterionName', context)
+        this.status = ArgumentValidator.requireOneOf(args, 'status', VALID_STATUSES, context)
+        this.product = ArgumentValidator.optionalOneOf(args, 'product', VALID_PRODUCTS, context)
+        this.source = ArgumentValidator.optionalOneOf(args, 'source', VALID_SOURCES, context)
         this.releaseDate = args.releaseDate
         this.daysToRelease = args.daysToRelease
         this.details = args.details
@@ -68,28 +71,5 @@ class ReleaseCriterion {
             checked_by         : checkedBy,
             last_checked       : timestamp
         ]
-    }
-
-    private static String required(Map args, String key) {
-        if (!args[key]) {
-            throw new IllegalArgumentException("ReleaseCriterion: '${key}' is required.")
-        }
-        return args[key]
-    }
-
-    private static String requireOneOf(Map args, String key, List<String> allowed) {
-        String value = required(args, key)
-        if (!allowed.contains(value)) {
-            throw new IllegalArgumentException("ReleaseCriterion: '${key}' must be one of ${allowed}, got '${value}'.")
-        }
-        return value
-    }
-
-    private static String optionalOneOf(Map args, String key, List<String> allowed) {
-        String value = args[key]
-        if (value != null && !allowed.contains(value)) {
-            throw new IllegalArgumentException("ReleaseCriterion: '${key}' must be one of ${allowed}, got '${value}'.")
-        }
-        return value
     }
 }

--- a/src/jenkins/ReleaseDecision.groovy
+++ b/src/jenkins/ReleaseDecision.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+/**
+ * A Go/No-Go decision record for the opensearch_release_state index.
+ * Validates its enum-like fields on construction so a malformed decision never reaches the cluster.
+ */
+class ReleaseDecision {
+
+    static final List<String> VALID_DECISIONS = ['go', 'no-go', 'hold']
+    static final List<String> VALID_RECOMMENDATIONS = ['red', 'yellow', 'green']
+
+    String version
+    String decidedBy
+    String decision
+    String oscarRecommendation
+    Boolean agreedWithOscar
+    Map criteriaSnapshot
+    String releaseIssue
+    String notes
+
+    ReleaseDecision(Map args) {
+        this.version = required(args, 'version')
+        this.decidedBy = required(args, 'decidedBy')
+        this.decision = requireOneOf(args, 'decision', VALID_DECISIONS)
+        this.oscarRecommendation = optionalOneOf(args, 'oscarRecommendation', VALID_RECOMMENDATIONS)
+        this.agreedWithOscar = args.agreedWithOscar
+        this.criteriaSnapshot = args.criteriaSnapshot ?: [:]
+        this.releaseIssue = args.releaseIssue
+        this.notes = args.notes
+    }
+
+    /**
+     * @param timestamp ISO-8601 time the decision was recorded, injected by the writer.
+     */
+    Map toDocument(String timestamp) {
+        return [
+            doc_type            : 'decision',
+            version             : version,
+            decided_at          : timestamp,
+            decided_by          : decidedBy,
+            decision            : decision,
+            oscar_recommendation: oscarRecommendation,
+            agreed_with_oscar   : agreedWithOscar,
+            criteria_snapshot   : criteriaSnapshot,
+            release_issue       : releaseIssue,
+            notes               : notes
+        ]
+    }
+
+    private static String required(Map args, String key) {
+        if (!args[key]) {
+            throw new IllegalArgumentException("ReleaseDecision: '${key}' is required.")
+        }
+        return args[key]
+    }
+
+    private static String requireOneOf(Map args, String key, List<String> allowed) {
+        String value = required(args, key)
+        if (!allowed.contains(value)) {
+            throw new IllegalArgumentException("ReleaseDecision: '${key}' must be one of ${allowed}, got '${value}'.")
+        }
+        return value
+    }
+
+    private static String optionalOneOf(Map args, String key, List<String> allowed) {
+        String value = args[key]
+        if (value != null && !allowed.contains(value)) {
+            throw new IllegalArgumentException("ReleaseDecision: '${key}' must be one of ${allowed}, got '${value}'.")
+        }
+        return value
+    }
+}

--- a/src/jenkins/ReleaseDecision.groovy
+++ b/src/jenkins/ReleaseDecision.groovy
@@ -9,6 +9,8 @@
 
 package jenkins
 
+import utils.ArgumentValidator
+
 /**
  * A Go/No-Go decision record for the opensearch_release_state index.
  * Validates its enum-like fields on construction so a malformed decision never reaches the cluster.
@@ -28,10 +30,11 @@ class ReleaseDecision {
     String notes
 
     ReleaseDecision(Map args) {
-        this.version = required(args, 'version')
-        this.decidedBy = required(args, 'decidedBy')
-        this.decision = requireOneOf(args, 'decision', VALID_DECISIONS)
-        this.oscarRecommendation = optionalOneOf(args, 'oscarRecommendation', VALID_RECOMMENDATIONS)
+        String context = this.class.simpleName
+        this.version = ArgumentValidator.required(args, 'version', context)
+        this.decidedBy = ArgumentValidator.required(args, 'decidedBy', context)
+        this.decision = ArgumentValidator.requireOneOf(args, 'decision', VALID_DECISIONS, context)
+        this.oscarRecommendation = ArgumentValidator.optionalOneOf(args, 'oscarRecommendation', VALID_RECOMMENDATIONS, context)
         this.agreedWithOscar = args.agreedWithOscar
         this.criteriaSnapshot = args.criteriaSnapshot ?: [:]
         this.releaseIssue = args.releaseIssue
@@ -54,28 +57,5 @@ class ReleaseDecision {
             release_issue       : releaseIssue,
             notes               : notes
         ]
-    }
-
-    private static String required(Map args, String key) {
-        if (!args[key]) {
-            throw new IllegalArgumentException("ReleaseDecision: '${key}' is required.")
-        }
-        return args[key]
-    }
-
-    private static String requireOneOf(Map args, String key, List<String> allowed) {
-        String value = required(args, key)
-        if (!allowed.contains(value)) {
-            throw new IllegalArgumentException("ReleaseDecision: '${key}' must be one of ${allowed}, got '${value}'.")
-        }
-        return value
-    }
-
-    private static String optionalOneOf(Map args, String key, List<String> allowed) {
-        String value = args[key]
-        if (value != null && !allowed.contains(value)) {
-            throw new IllegalArgumentException("ReleaseDecision: '${key}' must be one of ${allowed}, got '${value}'.")
-        }
-        return value
     }
 }

--- a/src/jenkins/ReleaseSchedule.groovy
+++ b/src/jenkins/ReleaseSchedule.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+/**
+ * A release schedule record for the opensearch_release_schedule index (one per version).
+ * Validates its enum-like fields on construction so a malformed schedule never reaches the cluster.
+ */
+class ReleaseSchedule {
+
+    static final List<String> VALID_STATUSES = ['active', 'released', 'cancelled']
+
+    String version
+    String rcDate
+    String releaseDate
+    String releaseIssue
+    String releaseManager
+    String status
+    String registeredBy
+
+    ReleaseSchedule(Map args) {
+        this.version = required(args, 'version')
+        this.status = args.status ?: 'active'
+        if (!VALID_STATUSES.contains(this.status)) {
+            throw new IllegalArgumentException("ReleaseSchedule: 'status' must be one of ${VALID_STATUSES}, got '${this.status}'.")
+        }
+        this.rcDate = args.rcDate
+        this.releaseDate = args.releaseDate
+        this.releaseIssue = args.releaseIssue
+        this.releaseManager = args.releaseManager
+        this.registeredBy = args.registeredBy
+    }
+
+    /**
+     * @param timestamp ISO-8601 time the schedule was registered, injected by the writer.
+     */
+    Map toDocument(String timestamp) {
+        return [
+            version        : version,
+            rc_date        : rcDate,
+            release_date   : releaseDate,
+            release_issue  : releaseIssue,
+            release_manager: releaseManager,
+            status         : status,
+            registered_at  : timestamp,
+            registered_by  : registeredBy
+        ]
+    }
+
+    private static String required(Map args, String key) {
+        if (!args[key]) {
+            throw new IllegalArgumentException("ReleaseSchedule: '${key}' is required.")
+        }
+        return args[key]
+    }
+}

--- a/src/jenkins/ReleaseSchedule.groovy
+++ b/src/jenkins/ReleaseSchedule.groovy
@@ -9,13 +9,15 @@
 
 package jenkins
 
+import utils.ArgumentValidator
+
 /**
  * A release schedule record for the opensearch_release_schedule index (one per version).
  * Validates its enum-like fields on construction so a malformed schedule never reaches the cluster.
  */
 class ReleaseSchedule {
 
-    static final List<String> VALID_STATUSES = ['active', 'released', 'cancelled']
+    static final List<String> VALID_STATUSES = ['inactive', 'active', 'released', 'cancelled']
 
     String version
     String rcDate
@@ -26,11 +28,11 @@ class ReleaseSchedule {
     String registeredBy
 
     ReleaseSchedule(Map args) {
-        this.version = required(args, 'version')
-        this.status = args.status ?: 'active'
-        if (!VALID_STATUSES.contains(this.status)) {
-            throw new IllegalArgumentException("ReleaseSchedule: 'status' must be one of ${VALID_STATUSES}, got '${this.status}'.")
-        }
+        String context = this.class.simpleName
+        this.version = ArgumentValidator.required(args, 'version', context)
+        // status defaults to 'inactive' when absent, then must be one of the allowed values.
+        // A release stays 'inactive' until ~1 month before its RC date, when it is flipped to 'active'.
+        this.status = ArgumentValidator.requireOneOf([status: args.status ?: 'inactive'], 'status', VALID_STATUSES, context)
         this.rcDate = args.rcDate
         this.releaseDate = args.releaseDate
         this.releaseIssue = args.releaseIssue
@@ -52,12 +54,5 @@ class ReleaseSchedule {
             registered_at  : timestamp,
             registered_by  : registeredBy
         ]
-    }
-
-    private static String required(Map args, String key) {
-        if (!args[key]) {
-            throw new IllegalArgumentException("ReleaseSchedule: '${key}' is required.")
-        }
-        return args[key]
     }
 }

--- a/src/jenkins/ReleaseStateData.groovy
+++ b/src/jenkins/ReleaseStateData.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+import java.text.SimpleDateFormat
+import utils.OpenSearchMetricsQuery
+
+/**
+ * Indexes release state documents on the OpenSearch metrics cluster.
+ *
+ * Writes to two indices:
+ *  - opensearch_release_schedule: one schedule doc per release version
+ *  - opensearch_release_state: per-criterion state docs and Go/No-Go decision docs
+ *
+ * Documents are typed (ReleaseSchedule, ReleaseCriterion, ReleaseDecision) and validated on
+ * construction. This class stamps the write timestamp and appends the document (a new document
+ * is created on each write), preserving history so dashboards can chart change over time.
+ */
+class ReleaseStateData {
+
+    String metricsUrl
+    String awsAccessKey
+    String awsSecretKey
+    String awsSessionToken
+    def script
+    OpenSearchMetricsQuery metricsQuery
+
+    ReleaseStateData(String metricsUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, def script) {
+        this.metricsUrl = metricsUrl
+        this.awsAccessKey = awsAccessKey
+        this.awsSecretKey = awsSecretKey
+        this.awsSessionToken = awsSessionToken
+        this.script = script
+        this.metricsQuery = new OpenSearchMetricsQuery(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, script)
+    }
+
+    void registerSchedule(ReleaseSchedule schedule) {
+        metricsQuery.indexDocument(ReleaseStateIndex.SCHEDULE_INDEX, schedule.toDocument(nowIso()))
+    }
+
+    void indexCriterion(ReleaseCriterion criterion) {
+        metricsQuery.indexDocument(ReleaseStateIndex.STATE_INDEX, criterion.toDocument(nowIso()))
+    }
+
+    void indexDecision(ReleaseDecision decision) {
+        metricsQuery.indexDocument(ReleaseStateIndex.STATE_INDEX, decision.toDocument(nowIso()))
+    }
+
+    /**
+     * Current UTC timestamp in ISO-8601 format (e.g. 2026-08-01T17:00:00Z), which OpenSearch
+     * parses via the default strict_date_optional_time format.
+     */
+    private String nowIso() {
+        def formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        formatter.setTimeZone(TimeZone.getTimeZone('UTC'))
+        return formatter.format(new Date())
+    }
+}

--- a/src/utils/ArgumentValidator.groovy
+++ b/src/utils/ArgumentValidator.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils
+
+/**
+ * Generic validation helpers for named-argument (Map) inputs.
+ *
+ * Intended for any class or var that accepts a Map of arguments and needs to fail fast on
+ * missing required fields or values outside an allowed set. The optional 'context' label is
+ * included in error messages to identify the caller (e.g. the class name).
+ */
+class ArgumentValidator {
+
+    /**
+     * Returns args[key], throwing IllegalArgumentException if it is null or empty.
+     */
+    static Object required(Map args, String key, String context = 'ArgumentValidator') {
+        def value = args[key]
+        if (!value) {
+            throw new IllegalArgumentException("${context}: '${key}' is required.")
+        }
+        return value
+    }
+
+    /**
+     * Returns a required args[key], throwing if it is missing or not in the allowed list.
+     */
+    static Object requireOneOf(Map args, String key, List allowed, String context = 'ArgumentValidator') {
+        def value = required(args, key, context)
+        if (!allowed.contains(value)) {
+            throw new IllegalArgumentException("${context}: '${key}' must be one of ${allowed}, got '${value}'.")
+        }
+        return value
+    }
+
+    /**
+     * Returns args[key] if present, throwing only when a non-null value is not in the allowed list.
+     * Returns null when the key is absent.
+     */
+    static Object optionalOneOf(Map args, String key, List allowed, String context = 'ArgumentValidator') {
+        def value = args[key]
+        if (value != null && !allowed.contains(value)) {
+            throw new IllegalArgumentException("${context}: '${key}' must be one of ${allowed}, got '${value}'.")
+        }
+        return value
+    }
+}

--- a/src/utils/OpenSearchMetricsQuery.groovy
+++ b/src/utils/OpenSearchMetricsQuery.groovy
@@ -73,14 +73,7 @@ class OpenSearchMetricsQuery {
      * @param mapping a Map representing the index body (e.g. [mappings: [properties: [...]]])
      */
     void createIndex(String targetIndex, Map mapping) {
-        String body = JsonOutput.toJson(mapping)
-        String httpCode = script.sh(
-            script: """
-                set +x
-                curl -s -o /dev/null -w '%{http_code}' -XPUT "${metricsUrl}/${targetIndex}" ${curlAuthArgs()} -H 'Content-Type: application/json' -d '${body}'
-            """,
-            returnStdout: true
-        ).trim()
+        String httpCode = sendJson('PUT', "${metricsUrl}/${targetIndex}", mapping)
         if (httpCode != '200' && httpCode != '201') {
             throw new RuntimeException("Failed to create index ${targetIndex}. HTTP status: ${httpCode}")
         }
@@ -93,16 +86,36 @@ class OpenSearchMetricsQuery {
      * @param document a Map representing the document body
      */
     void indexDocument(String targetIndex, Map document) {
-        String body = JsonOutput.toJson(document)
-        String httpCode = script.sh(
-            script: """
-                set +x
-                curl -s -o /dev/null -w '%{http_code}' -XPOST "${metricsUrl}/${targetIndex}/_doc" ${curlAuthArgs()} -H 'Content-Type: application/json' -d '${body}'
-            """,
-            returnStdout: true
-        ).trim()
+        String httpCode = sendJson('POST', "${metricsUrl}/${targetIndex}/_doc", document)
         if (httpCode != '200' && httpCode != '201') {
             throw new RuntimeException("Failed to index document into ${targetIndex}. HTTP status: ${httpCode}")
+        }
+    }
+
+    /**
+     * Sends a JSON body to the cluster and returns the HTTP status code.
+     *
+     * The body is written to a temp file and passed via `curl -d @file` rather than inlined into
+     * the shell command, so free-text fields containing quotes or shell metacharacters cannot break
+     * the command or inject shell (the body never touches the shell parser).
+     *
+     * @param method HTTP method (PUT, POST, ...)
+     * @param url full request URL
+     * @param body a Map serialized to JSON as the request body
+     */
+    private String sendJson(String method, String url, Map body) {
+        String bodyFile = "os-metrics-request-${UUID.randomUUID().toString()}.json"
+        script.writeFile(file: bodyFile, text: JsonOutput.toJson(body))
+        try {
+            return script.sh(
+                script: """
+                    set +x
+                    curl -s -o /dev/null -w '%{http_code}' -X${method} "${url}" ${curlAuthArgs()} -H 'Content-Type: application/json' -d @${bodyFile}
+                """,
+                returnStdout: true
+            ).trim()
+        } finally {
+            script.sh(script: "rm -f ${bodyFile}", returnStatus: true)
         }
     }
 

--- a/src/utils/OpenSearchMetricsQuery.groovy
+++ b/src/utils/OpenSearchMetricsQuery.groovy
@@ -87,6 +87,26 @@ class OpenSearchMetricsQuery {
     }
 
     /**
+     * Indexes a single document into the given index (append; a new document is created each call).
+     * Throws if the cluster does not return 200 or 201.
+     * @param targetIndex the index to write to
+     * @param document a Map representing the document body
+     */
+    void indexDocument(String targetIndex, Map document) {
+        String body = JsonOutput.toJson(document)
+        String httpCode = script.sh(
+            script: """
+                set +x
+                curl -s -o /dev/null -w '%{http_code}' -XPOST "${metricsUrl}/${targetIndex}/_doc" ${curlAuthArgs()} -H 'Content-Type: application/json' -d '${body}'
+            """,
+            returnStdout: true
+        ).trim()
+        if (httpCode != '200' && httpCode != '201') {
+            throw new RuntimeException("Failed to index document into ${targetIndex}. HTTP status: ${httpCode}")
+        }
+    }
+
+    /**
      * Common SigV4 authentication arguments shared by every cluster request.
      * Keeping this private ensures credentials and the signing region are defined once.
      */

--- a/tests/jenkins/TestReleaseStateData.groovy
+++ b/tests/jenkins/TestReleaseStateData.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import org.junit.Before
+import org.junit.Test
+import groovy.json.JsonSlurper
+import jenkins.ReleaseStateData
+import jenkins.ReleaseStateIndex
+import jenkins.ReleaseCriterion
+import jenkins.ReleaseDecision
+import jenkins.ReleaseSchedule
+
+class TestReleaseStateData {
+    private final String metricsUrl = 'http://example.com'
+    private final String awsAccessKey = 'testAccessKey'
+    private final String awsSecretKey = 'testSecretKey'
+    private final String awsSessionToken = 'testSessionToken'
+
+    private ReleaseStateData releaseStateData
+    private def script
+    // Captures each POSTed doc as [index: <targetIndex>, doc: <parsed body>]
+    private List<Map> indexedDocs
+    private String responseCode
+
+    @Before
+    void setUp() {
+        indexedDocs = []
+        responseCode = '201'
+        script = new Expando()
+        script.sh = { Map args ->
+            String s = args.script
+            if (s.contains('-XPOST')) {
+                indexedDocs.add([index: extractIndex(s), doc: extractBody(s)])
+            }
+            return responseCode
+        }
+        releaseStateData = new ReleaseStateData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, script)
+    }
+
+    private String extractIndex(String shScript) {
+        def matcher = (shScript =~ /${metricsUrl}\/([^\/]+)\/_doc/)
+        return matcher ? matcher[0][1] : null
+    }
+
+    private Map extractBody(String shScript) {
+        def matcher = (shScript =~ /-d '(\{.*\})'/)
+        return matcher ? new JsonSlurper().parseText(matcher[0][1]) : [:]
+    }
+
+    @Test
+    void testRegisterScheduleRoutesToScheduleIndexAndStampsTimestamp() {
+        releaseStateData.registerSchedule(new ReleaseSchedule([version: '3.8.0']))
+        assert indexedDocs[0].index == ReleaseStateIndex.SCHEDULE_INDEX
+        // registered_at is stamped by ReleaseStateData, not the caller
+        assert indexedDocs[0].doc.registered_at ==~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/
+    }
+
+    @Test
+    void testIndexCriterionRoutesToStateIndexAndStampsTimestamp() {
+        releaseStateData.indexCriterion(new ReleaseCriterion([
+                version      : '3.8.0',
+                criterionType: 'entrance',
+                criterionName: 'documentation_PRs_up',
+                status       : 'not_met'
+        ]))
+        assert indexedDocs[0].index == ReleaseStateIndex.STATE_INDEX
+        assert indexedDocs[0].doc.doc_type == 'criterion'
+        assert indexedDocs[0].doc.last_checked ==~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/
+    }
+
+    @Test
+    void testIndexDecisionRoutesToStateIndexAndStampsTimestamp() {
+        releaseStateData.indexDecision(new ReleaseDecision([
+                version  : '3.8.0',
+                decidedBy: 'test-rm',
+                decision : 'go'
+        ]))
+        assert indexedDocs[0].index == ReleaseStateIndex.STATE_INDEX
+        assert indexedDocs[0].doc.doc_type == 'decision'
+        assert indexedDocs[0].doc.decided_at ==~ /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/
+    }
+
+    @Test
+    void testIndexCriterionThrowsWhenClusterReturnsError() {
+        responseCode = '404'
+        try {
+            releaseStateData.indexCriterion(new ReleaseCriterion([
+                    version: '3.8.0', criterionType: 'entrance', criterionName: 'x', status: 'unknown'
+            ]))
+            assert false : 'Expected RuntimeException when cluster returns a non-2xx status'
+        } catch (RuntimeException e) {
+            assert e.message.contains('Failed to index document')
+        }
+    }
+}

--- a/tests/jenkins/TestReleaseStateData.groovy
+++ b/tests/jenkins/TestReleaseStateData.groovy
@@ -30,15 +30,21 @@ class TestReleaseStateData {
     private List<Map> indexedDocs
     private String responseCode
 
+    // Holds the body written by the most recent writeFile call, to pair with the following POST.
+    private String pendingBody
+
     @Before
     void setUp() {
         indexedDocs = []
+        pendingBody = null
         responseCode = '201'
         script = new Expando()
+        // The body is written to a temp file first, then the POST curl references it.
+        script.writeFile = { Map args -> pendingBody = args.text }
         script.sh = { Map args ->
             String s = args.script
             if (s.contains('-XPOST')) {
-                indexedDocs.add([index: extractIndex(s), doc: extractBody(s)])
+                indexedDocs.add([index: extractIndex(s), doc: new JsonSlurper().parseText(pendingBody)])
             }
             return responseCode
         }
@@ -48,11 +54,6 @@ class TestReleaseStateData {
     private String extractIndex(String shScript) {
         def matcher = (shScript =~ /${metricsUrl}\/([^\/]+)\/_doc/)
         return matcher ? matcher[0][1] : null
-    }
-
-    private Map extractBody(String shScript) {
-        def matcher = (shScript =~ /-d '(\{.*\})'/)
-        return matcher ? new JsonSlurper().parseText(matcher[0][1]) : [:]
     }
 
     @Test

--- a/tests/jenkins/TestReleaseStateDocuments.groovy
+++ b/tests/jenkins/TestReleaseStateDocuments.groovy
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import org.junit.Test
+import jenkins.ReleaseCriterion
+import jenkins.ReleaseDecision
+import jenkins.ReleaseSchedule
+
+/**
+ * Validation and serialization tests for the typed release state documents.
+ */
+class TestReleaseStateDocuments {
+
+    private static final String TS = '2026-08-01T17:00:00Z'
+
+    // ---- ReleaseCriterion ----
+
+    @Test
+    void testCriterionToDocumentMapsSnakeCaseAndDiscriminator() {
+        def doc = new ReleaseCriterion([
+                version           : '3.8.0',
+                criterionType     : 'entrance',
+                criterionName     : 'documentation_PRs_up',
+                status            : 'not_met',
+                product           : 'opensearch',
+                source            : 'chore_check',
+                daysToRelease     : 9,
+                blockingComponents: ['issue-1']
+        ]).toDocument(TS)
+
+        assert doc.doc_type == 'criterion'
+        assert doc.criterion_type == 'entrance'
+        assert doc.criterion_name == 'documentation_PRs_up'
+        assert doc.days_to_release == 9
+        assert doc.blocking_components == ['issue-1']
+        assert doc.last_checked == TS
+    }
+
+    @Test
+    void testCriterionDefaultsBlockingComponentsToEmptyList() {
+        def doc = new ReleaseCriterion([
+                version: '3.8.0', criterionType: 'entrance', criterionName: 'x', status: 'unknown'
+        ]).toDocument(TS)
+        assert doc.blocking_components == []
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testCriterionRejectsMissingRequiredField() {
+        // criterionName missing
+        new ReleaseCriterion([version: '3.8.0', criterionType: 'entrance', status: 'met'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testCriterionRejectsInvalidStatus() {
+        new ReleaseCriterion([version: '3.8.0', criterionType: 'entrance', criterionName: 'x', status: 'maybe'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testCriterionRejectsInvalidType() {
+        new ReleaseCriterion([version: '3.8.0', criterionType: 'sideways', criterionName: 'x', status: 'met'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testCriterionRejectsInvalidProduct() {
+        new ReleaseCriterion([version: '3.8.0', criterionType: 'entrance', criterionName: 'x', status: 'met', product: 'logstash'])
+    }
+
+    // ---- ReleaseDecision ----
+
+    @Test
+    void testDecisionToDocumentMapsSnakeCaseAndDiscriminator() {
+        def doc = new ReleaseDecision([
+                version            : '3.8.0',
+                decidedBy          : 'test-rm',
+                decision           : 'go',
+                oscarRecommendation: 'yellow',
+                agreedWithOscar    : false
+        ]).toDocument(TS)
+
+        assert doc.doc_type == 'decision'
+        assert doc.decided_by == 'test-rm'
+        assert doc.oscar_recommendation == 'yellow'
+        assert doc.agreed_with_oscar == false
+        assert doc.decided_at == TS
+    }
+
+    @Test
+    void testDecisionDefaultsCriteriaSnapshotToEmptyMap() {
+        def doc = new ReleaseDecision([version: '3.8.0', decidedBy: 'rm', decision: 'hold']).toDocument(TS)
+        assert doc.criteria_snapshot == [:]
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testDecisionRejectsInvalidDecision() {
+        new ReleaseDecision([version: '3.8.0', decidedBy: 'rm', decision: 'maybe'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testDecisionRejectsInvalidRecommendation() {
+        new ReleaseDecision([version: '3.8.0', decidedBy: 'rm', decision: 'go', oscarRecommendation: 'purple'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testDecisionRejectsMissingDecidedBy() {
+        new ReleaseDecision([version: '3.8.0', decision: 'go'])
+    }
+
+    // ---- ReleaseSchedule ----
+
+    @Test
+    void testScheduleToDocumentMapsSnakeCaseAndDefaultsStatus() {
+        def doc = new ReleaseSchedule([
+                version       : '3.8.0',
+                rcDate        : '2026-08-01',
+                releaseDate   : '2026-08-12',
+                releaseManager: 'test-rm',
+                registeredBy  : 'release-schedule-job #5'
+        ]).toDocument(TS)
+
+        assert doc.version == '3.8.0'
+        assert doc.rc_date == '2026-08-01'
+        assert doc.release_date == '2026-08-12'
+        assert doc.release_manager == 'test-rm'
+        assert doc.registered_by == 'release-schedule-job #5'
+        assert doc.status == 'active'
+        assert doc.registered_at == TS
+    }
+
+    @Test
+    void testScheduleHonorsExplicitStatus() {
+        def doc = new ReleaseSchedule([version: '3.8.0', status: 'released']).toDocument(TS)
+        assert doc.status == 'released'
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testScheduleRejectsInvalidStatus() {
+        new ReleaseSchedule([version: '3.8.0', status: 'paused'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testScheduleRejectsMissingVersion() {
+        new ReleaseSchedule([rcDate: '2026-08-01'])
+    }
+}

--- a/tests/jenkins/TestReleaseStateDocuments.groovy
+++ b/tests/jenkins/TestReleaseStateDocuments.groovy
@@ -116,7 +116,7 @@ class TestReleaseStateDocuments {
     // ---- ReleaseSchedule ----
 
     @Test
-    void testScheduleToDocumentMapsSnakeCaseAndDefaultsStatus() {
+    void testScheduleToDocumentMapsSnakeCaseAndDefaultsStatusToInactive() {
         def doc = new ReleaseSchedule([
                 version       : '3.8.0',
                 rcDate        : '2026-08-01',
@@ -130,14 +130,15 @@ class TestReleaseStateDocuments {
         assert doc.release_date == '2026-08-12'
         assert doc.release_manager == 'test-rm'
         assert doc.registered_by == 'release-schedule-job #5'
-        assert doc.status == 'active'
+        // A newly registered release is inactive until ~1 month before its RC date.
+        assert doc.status == 'inactive'
         assert doc.registered_at == TS
     }
 
     @Test
     void testScheduleHonorsExplicitStatus() {
-        def doc = new ReleaseSchedule([version: '3.8.0', status: 'released']).toDocument(TS)
-        assert doc.status == 'released'
+        assert new ReleaseSchedule([version: '3.8.0', status: 'active']).toDocument(TS).status == 'active'
+        assert new ReleaseSchedule([version: '3.8.0', status: 'released']).toDocument(TS).status == 'released'
     }
 
     @Test(expected = IllegalArgumentException)

--- a/tests/jenkins/TestReleaseStateIndex.groovy
+++ b/tests/jenkins/TestReleaseStateIndex.groovy
@@ -32,6 +32,8 @@ class TestReleaseStateIndex {
         shScripts = []
         script = new Expando()
         script.echo = { String message -> echoedMessages.add(message) }
+        // createIndex writes the mapping to a temp file before issuing the PUT.
+        script.writeFile = { Map args -> }
         releaseStateIndex = new ReleaseStateIndex(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, script)
     }
 
@@ -39,6 +41,7 @@ class TestReleaseStateIndex {
      * Stubs script.sh to return HTTP codes keyed by curl verb:
      *  - HEAD (-I)   -> existsCode  (index existence check)
      *  - PUT (-XPUT) -> createCode  (index creation)
+     * The temp-file cleanup 'rm' call is ignored.
      */
     private void stubClusterResponses(String existsCode, String createCode) {
         script.sh = { Map args ->

--- a/tests/utils/TestArgumentValidator.groovy
+++ b/tests/utils/TestArgumentValidator.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils.tests
+
+import org.junit.Test
+import utils.ArgumentValidator
+
+class TestArgumentValidator {
+
+    // ---- required ----
+
+    @Test
+    void testRequiredReturnsValueWhenPresent() {
+        assert ArgumentValidator.required([name: 'oscar'], 'name') == 'oscar'
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testRequiredThrowsWhenMissing() {
+        ArgumentValidator.required([:], 'name')
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testRequiredThrowsWhenEmpty() {
+        ArgumentValidator.required([name: ''], 'name')
+    }
+
+    @Test
+    void testRequiredIncludesContextInMessage() {
+        try {
+            ArgumentValidator.required([:], 'name', 'MyClass')
+            assert false : 'Expected IllegalArgumentException'
+        } catch (IllegalArgumentException e) {
+            assert e.message == "MyClass: 'name' is required."
+        }
+    }
+
+    // ---- requireOneOf ----
+
+    @Test
+    void testRequireOneOfReturnsValueWhenAllowed() {
+        assert ArgumentValidator.requireOneOf([status: 'active'], 'status', ['active', 'inactive']) == 'active'
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testRequireOneOfThrowsWhenNotAllowed() {
+        ArgumentValidator.requireOneOf([status: 'paused'], 'status', ['active', 'inactive'])
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testRequireOneOfThrowsWhenMissing() {
+        ArgumentValidator.requireOneOf([:], 'status', ['active'])
+    }
+
+    // ---- optionalOneOf ----
+
+    @Test
+    void testOptionalOneOfReturnsNullWhenAbsent() {
+        assert ArgumentValidator.optionalOneOf([:], 'product', ['opensearch']) == null
+    }
+
+    @Test
+    void testOptionalOneOfReturnsValueWhenAllowed() {
+        assert ArgumentValidator.optionalOneOf([product: 'opensearch'], 'product', ['opensearch', 'both']) == 'opensearch'
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void testOptionalOneOfThrowsWhenPresentButNotAllowed() {
+        ArgumentValidator.optionalOneOf([product: 'logstash'], 'product', ['opensearch', 'both'])
+    }
+}

--- a/tests/utils/TestOpenSearchMetricsQuery.groovy
+++ b/tests/utils/TestOpenSearchMetricsQuery.groovy
@@ -22,6 +22,10 @@ class TestOpenSearchMetricsQuery {
     def script
     def scriptArgs
     String response
+    // Captures the JSON body written to the temp file by sendJson()
+    String writtenBody
+    // Captures the curl sh script specifically (sendJson also issues an 'rm' cleanup call)
+    String curlScript
 
     @Before
     void setUp() {
@@ -45,6 +49,9 @@ class TestOpenSearchMetricsQuery {
                 return response
             }
         }
+
+        // Captures the request body that sendJson writes before issuing the curl.
+        script.writeFile = { Map args -> writtenBody = args.text }
 
         script.println = { message ->
             // Mock implementation for println
@@ -89,23 +96,28 @@ class TestOpenSearchMetricsQuery {
     }
 
     @Test
-    void testCreateIndexSendsMappingAsJson() {
+    void testCreateIndexSendsMappingAsJsonViaFile() {
+        // The curl call returns the status; the cleanup 'rm' call returns anything.
         script.sh = { Map args ->
-            scriptArgs = args
-            return '200'
+            if (args.script.contains('curl')) {
+                curlScript = args.script
+                return '200'
+            }
+            return 0
         }
         def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
         metricsQuery.createIndex("sampleIndex", [mappings: [properties: [version: [type: 'keyword']]]])
-        assertTrue(scriptArgs.script.contains('-XPUT "metricsUrl/sampleIndex"'))
-        // Map is serialized to JSON in the request body
-        assertTrue(scriptArgs.script.contains('{"mappings":{"properties":{"version":{"type":"keyword"}}}}'))
+        // PUT to the index, body passed via file (-d @...), and the mapping serialized into that file.
+        assertTrue(curlScript.contains('-XPUT "metricsUrl/sampleIndex"'))
+        assertTrue(curlScript.contains('-d @'))
+        assertEquals('{"mappings":{"properties":{"version":{"type":"keyword"}}}}', writtenBody)
     }
 
     @Test
     void testCreateIndexThrowsOnNon200() {
         script.sh = { Map args ->
             scriptArgs = args
-            return '400'
+            return args.script.contains('curl') ? '400' : 0
         }
         def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
         try {
@@ -114,6 +126,50 @@ class TestOpenSearchMetricsQuery {
         } catch (RuntimeException e) {
             assertTrue(e.message.contains("Failed to create index sampleIndex"))
             assertTrue(e.message.contains("400"))
+        }
+    }
+
+    @Test
+    void testIndexDocumentSendsBodyAsJsonViaFile() {
+        script.sh = { Map args ->
+            if (args.script.contains('curl')) {
+                curlScript = args.script
+                return '201'
+            }
+            return 0
+        }
+        def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        metricsQuery.indexDocument("sampleIndex", [doc_type: 'criterion', version: '3.8.0'])
+        assertTrue(curlScript.contains('-XPOST "metricsUrl/sampleIndex/_doc"'))
+        assertTrue(curlScript.contains('-d @'))
+        assertEquals('{"doc_type":"criterion","version":"3.8.0"}', writtenBody)
+    }
+
+    @Test
+    void testIndexDocumentEscapesFieldsWithQuotes() {
+        // A field containing a single quote must not corrupt the request: it goes through
+        // writeFile verbatim (no shell interpolation), proving the injection fix.
+        script.sh = { Map args ->
+            scriptArgs = args
+            return args.script.contains('curl') ? '201' : 0
+        }
+        def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        metricsQuery.indexDocument("sampleIndex", [details: "5 issues don't have PR linked"])
+        assertEquals('{"details":"5 issues don\'t have PR linked"}', writtenBody)
+    }
+
+    @Test
+    void testIndexDocumentThrowsOnErrorStatus() {
+        script.sh = { Map args ->
+            scriptArgs = args
+            return args.script.contains('curl') ? '404' : 0
+        }
+        def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        try {
+            metricsQuery.indexDocument("sampleIndex", [version: '3.8.0'])
+            fail("Expected RuntimeException when cluster returns a non-2xx status")
+        } catch (RuntimeException e) {
+            assertTrue(e.message.contains("Failed to index document into sampleIndex"))
         }
     }
 }


### PR DESCRIPTION
### Description
Introduces validated document models (ReleaseSchedule, ReleaseCriterion, ReleaseDecision) for the release state machine, each enforcing required and enum-like fields so malformed docs fail fast. 
Also adds `indexDocument` write method to OpenSearchMetricsQuery

### Issues Resolved
Part of https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
