### PR TITLE
Replace backtick with single quote in generic trigger lib to avoid cmd substitution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.3.1'
+String version = '13.3.0'
 
 task updateVersion {
     doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.3.0'
+String version = '13.3.1'
 
 task updateVersion {
     doLast {

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -116,19 +116,21 @@ echo "==========================================="
 echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
-deployment=$(mvn --settings="${mvn_settings}" \
+deployment_log="${workdir}/deployment.log"
+
+mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}")
+  -DstagingProfileId="${STAGING_PROFILE_ID}" > "${deployment_log}" 2>&1 || echo "Maven command failed with exit code: $?"
 
-echo $deployment
+cat "${deployment_log}"
 
-if echo "$deployment" | grep "BUILD SUCCESS"; then
-  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
+if grep -q "BUILD SUCCESS" "${deployment_log}"; then
+  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" "${deployment_log}" | grep -o "\"[^\"]*\"" | tr -d '"')
   echo "Successfully staged and validated artifacts. Staging repository ID: ${DEPLOYED_STAGING_REPO_ID}"
 else
   echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing."

--- a/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
+++ b/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
@@ -123,7 +123,7 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
             c -> c.contains('gh issue create')
         }
         assertThat(cmd.size(), equalTo(1))
-        assertThat(cmd, hasItem("""gh issue create --title \"[Release - Action Required] Publish release for tag 1.0.0\" --body \"The release workflow for tag '1.0.0' completed successfully.\n\nBuild: https://build.ci.opensearch.org/job/dummy_release_job/100/\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0\n\ncc: bbb\nccc\" --repo https://github.com/Codertocat/Hello-World"""))
+        assertThat(cmd, hasItem("""gh issue create --title \"[Release - Action Required] Publish release for tag 1.0.0\" --body \"The release workflow for tag 1.0.0 completed successfully.\n\nBuild: https://build.ci.opensearch.org/job/dummy_release_job/100/\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0\n\ncc: bbb\nccc\" --repo https://github.com/Codertocat/Hello-World"""))
     }
 
    @Test

--- a/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
+++ b/tests/jenkins/TestStandardReleasePipelineWithGenericTriggers.groovy
@@ -123,7 +123,7 @@ class TestStandardReleasePipelineWithGenericTriggers extends BuildPipelineTest {
             c -> c.contains('gh issue create')
         }
         assertThat(cmd.size(), equalTo(1))
-        assertThat(cmd, hasItem("""gh issue create --title \"[Release - Action Required] Publish release for tag 1.0.0\" --body \"The release workflow for tag `1.0.0` completed successfully.\n\nBuild: https://build.ci.opensearch.org/job/dummy_release_job/100/\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0\n\ncc: bbb\nccc\" --repo https://github.com/Codertocat/Hello-World"""))
+        assertThat(cmd, hasItem("""gh issue create --title \"[Release - Action Required] Publish release for tag 1.0.0\" --body \"The release workflow for tag '1.0.0' completed successfully.\n\nBuild: https://build.ci.opensearch.org/job/dummy_release_job/100/\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: https://github.com/Codertocat/Hello-World/releases/tag/1.0.0\n\ncc: bbb\nccc\" --repo https://github.com/Codertocat/Hello-World"""))
     }
 
    @Test

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.txt
@@ -24,7 +24,7 @@ TAG: 1.0.0"}' "https://webhook.example.com")
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   standardReleasePipelineWithGenericTrigger.sh({script=gh api repos/Codertocat/Hello-World/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d | grep -oP '@[\w/-]+' | sort -u | tr '\n' ' ' || echo '', returnStdout=true})
-                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag `1.0.0` completed successfully.
+                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag '1.0.0' completed successfully.
 
 Build: https://build.ci.opensearch.org/job/dummy_release_job/100/
 

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggersTag_Jenkinsfile.txt
@@ -24,7 +24,7 @@ TAG: 1.0.0"}' "https://webhook.example.com")
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   standardReleasePipelineWithGenericTrigger.sh({script=gh api repos/Codertocat/Hello-World/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d | grep -oP '@[\w/-]+' | sort -u | tr '\n' ' ' || echo '', returnStdout=true})
-                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag '1.0.0' completed successfully.
+                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag 1.0.0 completed successfully.
 
 Build: https://build.ci.opensearch.org/job/dummy_release_job/100/
 

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
@@ -33,7 +33,7 @@ TAG: 1.0.0"}' "https://webhook.example.com")
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   standardReleasePipelineWithGenericTrigger.sh({script=gh api repos/Codertocat/Hello-World/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d | grep -oP '@[\w/-]+' | sort -u | tr '\n' ' ' || echo '', returnStdout=true})
-                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag `1.0.0` completed successfully.
+                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag '1.0.0' completed successfully.
 
 Build: https://build.ci.opensearch.org/job/dummy_release_job/100/
 

--- a/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/StandardReleasePipelineWithGenericTriggers_Jenkinsfile.txt
@@ -33,7 +33,7 @@ TAG: 1.0.0"}' "https://webhook.example.com")
             standardReleasePipelineWithGenericTrigger.script(groovy.lang.Closure)
                standardReleasePipelineWithGenericTrigger.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   standardReleasePipelineWithGenericTrigger.sh({script=gh api repos/Codertocat/Hello-World/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\n' | base64 -d | grep -oP '@[\w/-]+' | sort -u | tr '\n' ' ' || echo '', returnStdout=true})
-                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag '1.0.0' completed successfully.
+                  standardReleasePipelineWithGenericTrigger.sh(gh issue create --title "[Release - Action Required] Publish release for tag 1.0.0" --body "The release workflow for tag 1.0.0 completed successfully.
 
 Build: https://build.ci.opensearch.org/job/dummy_release_job/100/
 

--- a/vars/standardReleasePipelineWithGenericTrigger.groovy
+++ b/vars/standardReleasePipelineWithGenericTrigger.groovy
@@ -115,7 +115,7 @@ void call(Map arguments = [:], Closure body) {
                             script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
                             returnStdout: true
                         ).trim()
-                        def issueBody = "The release workflow for tag `${tag}` completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners}"
+                        def issueBody = "The release workflow for tag '${tag}' completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners}"
                         sh """gh issue create --title \"[Release - Action Required] Publish release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
                     }
                 }
@@ -127,7 +127,7 @@ void call(Map arguments = [:], Closure body) {
                             script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
                             returnStdout: true
                         ).trim()
-                        def issueBody = "The release workflow for tag `${tag}` failed.\n\nPlease investigate the failure and retry the release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
+                        def issueBody = "The release workflow for tag '${tag}' failed.\n\nPlease investigate the failure and retry the release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
                         sh """gh issue create --title \"[RELEASE] Failed: release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
                     }
                 }

--- a/vars/standardReleasePipelineWithGenericTrigger.groovy
+++ b/vars/standardReleasePipelineWithGenericTrigger.groovy
@@ -115,7 +115,7 @@ void call(Map arguments = [:], Closure body) {
                             script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
                             returnStdout: true
                         ).trim()
-                        def issueBody = "The release workflow for tag '${tag}' completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners}"
+                        def issueBody = "The release workflow for tag ${tag} completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners}"
                         sh """gh issue create --title \"[Release - Action Required] Publish release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
                     }
                 }
@@ -127,7 +127,7 @@ void call(Map arguments = [:], Closure body) {
                             script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
                             returnStdout: true
                         ).trim()
-                        def issueBody = "The release workflow for tag '${tag}' failed.\n\nPlease investigate the failure and retry the release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
+                        def issueBody = "The release workflow for tag ${tag} failed.\n\nPlease investigate the failure and retry the release.\n\nRelease: ${repository}/releases/tag/${tag}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
                         sh """gh issue create --title \"[RELEASE] Failed: release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
                     }
                 }


### PR DESCRIPTION


### Description
Replace backtick with single quote in generic trigger lib to avoid cmd substitution

### Issues Resolved
https://github.com/opensearch-project/spring-data-opensearch/issues/745

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
