### PR TITLE
Add maven2 mirror when downloading nexus-staging-maven-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.3.0'
+String version = '13.3.1'
 
 task updateVersion {
     doLast {

--- a/resources/publish/stage-maven-release.sh
+++ b/resources/publish/stage-maven-release.sh
@@ -99,6 +99,14 @@ function create_maven_settings() {
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                             http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>opensearch-maven-mirror</id>
+      <name>OpenSearch CI Maven Mirror</name>
+      <url>https://ci.opensearch.org/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>central</id>


### PR DESCRIPTION
### Description
Add maven2 mirror when downloading nexus-staging-maven-plugin

### Issues Resolved
https://github.com/opensearch-project/spring-data-opensearch/issues/745

Local test with some dummy env vars:

`[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository (default-cli) on project standalone-pom: Execution default-cli of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository failed: 401 - Unauthorized -> [Help 1][6:10 PM]Downloaded from opensearch-maven-mirror: https://ci.opensearch.org/maven2/ch/qos/logback/logback-classic/1.2.11/logback-classic-1.2.11.jar (232 kB at 136 kB/s)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
