### PR TITLE
Add release schedule parser and register it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.3.1'
+String version = '13.4.0'
 
 task updateVersion {
     doLast {

--- a/src/jenkins/ReleaseIndices.groovy
+++ b/src/jenkins/ReleaseIndices.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+/**
+ * Names of the release state indices on the OpenSearch metrics cluster.
+ *
+ * Kept as a small constants-only holder so that classes needing the index names
+ * (ReleaseStateIndex, ReleaseStateData) can share them without referencing each other's
+ * static fields. Cross-class static-constant references between full classes can trigger a
+ * re-entrant GroovyClassLoader recompile deadlock under the Jenkins pipeline unit runtime;
+ * a dependency-free holder avoids that.
+ */
+class ReleaseIndices {
+    public static final String SCHEDULE = 'opensearch_release_schedule'
+    public static final String STATE = 'opensearch_release_state'
+}

--- a/src/jenkins/ReleaseSchedule.groovy
+++ b/src/jenkins/ReleaseSchedule.groovy
@@ -34,10 +34,11 @@ class ReleaseSchedule {
     ReleaseSchedule(Map args) {
         String context = this.class.simpleName
         this.version = ArgumentValidator.required(args, 'version', context)
-        // An explicit status is honored (manual override, e.g. released/cancelled/forced active).
-        // Otherwise the status is derived from the RC date: 'active' within the activation window,
-        // 'inactive' before it. Re-running registration recomputes this as the RC date approaches.
-        String resolvedStatus = args.status ?: deriveStatus(args.rcDate)
+        // An explicit status is honored (manual override, e.g. cancelled/forced active).
+        // Otherwise the status is derived from the dates: 'inactive' until the activation window,
+        // 'active' within ACTIVATION_WINDOW_DAYS of the RC date, and 'released' once the release
+        // date has passed. Re-running registration recomputes this as the dates approach.
+        String resolvedStatus = args.status ?: deriveStatus(args.rcDate, args.releaseDate)
         this.status = ArgumentValidator.requireOneOf([status: resolvedStatus], 'status', VALID_STATUSES, context)
         this.rcDate = args.rcDate
         this.releaseDate = args.releaseDate
@@ -55,25 +56,37 @@ class ReleaseSchedule {
     }
 
     /**
-     * Derives the schedule status from the RC date relative to today:
-     *  - 'active' when today is within ACTIVATION_WINDOW_DAYS of the RC date (or the RC date has passed)
-     *  - 'inactive' when the RC date is further out, or is absent/unparseable (safe default)
+     * Derives the schedule status from the RC and release dates relative to today:
+     *  - 'released' once the release date has passed
+     *  - 'active' when today is within ACTIVATION_WINDOW_DAYS of the RC date (up to the release date)
+     *  - 'inactive' when the RC date is further out, or the RC date is absent/unparseable (safe default)
      *
      * @param rcDate RC date in yyyy-MM-dd, or null
+     * @param releaseDate release date in yyyy-MM-dd, or null
      * @param today reference date; defaults to LocalDate.now(). Overridable for testing.
      */
-    static String deriveStatus(String rcDate, LocalDate today = LocalDate.now()) {
-        if (!rcDate) {
-            return 'inactive'
+    static String deriveStatus(String rcDate, String releaseDate, LocalDate today = LocalDate.now()) {
+        LocalDate release = parseOrNull(releaseDate)
+        if (release != null && today.isAfter(release)) {
+            return 'released'
         }
-        LocalDate rc
-        try {
-            rc = LocalDate.parse(rcDate)
-        } catch (Exception ignored) {
+        LocalDate rc = parseOrNull(rcDate)
+        if (rc == null) {
             return 'inactive'
         }
         long daysUntilRc = ChronoUnit.DAYS.between(today, rc)
         return (daysUntilRc <= ACTIVATION_WINDOW_DAYS) ? 'active' : 'inactive'
+    }
+
+    private static LocalDate parseOrNull(String date) {
+        if (!date) {
+            return null
+        }
+        try {
+            return LocalDate.parse(date)
+        } catch (Exception ignored) {
+            return null
+        }
     }
 
     /**

--- a/src/jenkins/ReleaseSchedule.groovy
+++ b/src/jenkins/ReleaseSchedule.groovy
@@ -9,6 +9,8 @@
 
 package jenkins
 
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import utils.ArgumentValidator
 
 /**
@@ -18,26 +20,60 @@ import utils.ArgumentValidator
 class ReleaseSchedule {
 
     static final List<String> VALID_STATUSES = ['inactive', 'active', 'released', 'cancelled']
+    // A release becomes 'active' once it is within this many days of its RC date.
+    static final long ACTIVATION_WINDOW_DAYS = 30
 
     String version
     String rcDate
     String releaseDate
     String releaseIssue
-    String releaseManager
+    List<String> releaseManager
     String status
     String registeredBy
 
     ReleaseSchedule(Map args) {
         String context = this.class.simpleName
         this.version = ArgumentValidator.required(args, 'version', context)
-        // status defaults to 'inactive' when absent, then must be one of the allowed values.
-        // A release stays 'inactive' until ~1 month before its RC date, when it is flipped to 'active'.
-        this.status = ArgumentValidator.requireOneOf([status: args.status ?: 'inactive'], 'status', VALID_STATUSES, context)
+        // An explicit status is honored (manual override, e.g. released/cancelled/forced active).
+        // Otherwise the status is derived from the RC date: 'active' within the activation window,
+        // 'inactive' before it. Re-running registration recomputes this as the RC date approaches.
+        String resolvedStatus = args.status ?: deriveStatus(args.rcDate)
+        this.status = ArgumentValidator.requireOneOf([status: resolvedStatus], 'status', VALID_STATUSES, context)
         this.rcDate = args.rcDate
         this.releaseDate = args.releaseDate
         this.releaseIssue = args.releaseIssue
-        this.releaseManager = args.releaseManager
+        // Accept a list (from the schedule parser) or a single handle (manual callers); normalize to a list.
+        this.releaseManager = normalizeManagers(args.releaseManager)
         this.registeredBy = args.registeredBy
+    }
+
+    private static List<String> normalizeManagers(managers) {
+        if (managers == null) {
+            return []
+        }
+        return (managers instanceof List) ? managers : [managers]
+    }
+
+    /**
+     * Derives the schedule status from the RC date relative to today:
+     *  - 'active' when today is within ACTIVATION_WINDOW_DAYS of the RC date (or the RC date has passed)
+     *  - 'inactive' when the RC date is further out, or is absent/unparseable (safe default)
+     *
+     * @param rcDate RC date in yyyy-MM-dd, or null
+     * @param today reference date; defaults to LocalDate.now(). Overridable for testing.
+     */
+    static String deriveStatus(String rcDate, LocalDate today = LocalDate.now()) {
+        if (!rcDate) {
+            return 'inactive'
+        }
+        LocalDate rc
+        try {
+            rc = LocalDate.parse(rcDate)
+        } catch (Exception ignored) {
+            return 'inactive'
+        }
+        long daysUntilRc = ChronoUnit.DAYS.between(today, rc)
+        return (daysUntilRc <= ACTIVATION_WINDOW_DAYS) ? 'active' : 'inactive'
     }
 
     /**

--- a/src/jenkins/ReleaseScheduleParser.groovy
+++ b/src/jenkins/ReleaseScheduleParser.groovy
@@ -37,7 +37,6 @@ import java.util.Locale
  */
 class ReleaseScheduleParser {
 
-    static final String SCHEDULE_TABLE_CLASS = 'desktop-release-schedule-table'
     private static final String STRIKETHROUGH_PATTERN = /(?s)<(strike|s|del)[^>]*>.*?<\/\1>/
 
     String html
@@ -55,13 +54,15 @@ class ReleaseScheduleParser {
             return []
         }
         List<Map> schedules = []
-        def rows = (table =~ /(?s)<tr>(.*?)<\/tr>/)
-        rows.each { match ->
-            String rowHtml = match[1]
-            def cells = (rowHtml =~ /(?s)<td>(.*?)<\/td>/).collect { it[1] }
+        // Use explicit Matcher.find() loops (not Matcher.each/.collect) to stay safe under the
+        // Jenkins pipeline runtime, which does not handle iterating a Matcher well.
+        def rowMatcher = (table =~ /(?s)<tr>(.*?)<\/tr>/)
+        while (rowMatcher.find()) {
+            String rowHtml = rowMatcher.group(1)
+            List<String> cells = extractCells(rowHtml)
             // Skip the header row (uses <th>) and any malformed row.
             if (cells.size() < 5) {
-                return
+                continue
             }
             Map row = parseRow(cells)
             if (row) {
@@ -69,6 +70,15 @@ class ReleaseScheduleParser {
             }
         }
         return schedules
+    }
+
+    private static List<String> extractCells(String rowHtml) {
+        List<String> cells = []
+        def cellMatcher = (rowHtml =~ /(?s)<td>(.*?)<\/td>/)
+        while (cellMatcher.find()) {
+            cells.add(cellMatcher.group(1))
+        }
+        return cells
     }
 
     private Map parseRow(List cells) {
@@ -91,8 +101,9 @@ class ReleaseScheduleParser {
     }
 
     private static String extractScheduleTable(String html) {
-        def matcher = (html =~ /(?s)<table class="${SCHEDULE_TABLE_CLASS}".*?<\/table>/)
-        return matcher ? matcher[0] : null
+        // Matches the release schedule table on opensearch.org/releases.html by its CSS class.
+        def matcher = (html =~ /(?s)<table class="desktop-release-schedule-table".*?<\/table>/)
+        return matcher.find() ? matcher.group() : null
     }
 
     /**
@@ -124,11 +135,12 @@ class ReleaseScheduleParser {
         }
         String live = cell.replaceAll(STRIKETHROUGH_PATTERN, '')
         // Prefer anchor texts when present (one manager per <a>).
-        def anchors = (live =~ /(?s)<a[^>]*>(.*?)<\/a>/).collect { stripTags(it[1]).trim() }
-        List<String> names
-        if (anchors) {
-            names = anchors
-        } else {
+        List<String> names = []
+        def anchorMatcher = (live =~ /(?s)<a[^>]*>(.*?)<\/a>/)
+        while (anchorMatcher.find()) {
+            names.add(stripTags(anchorMatcher.group(1)).trim())
+        }
+        if (names.isEmpty()) {
             // No anchors: treat as comma-separated plain text.
             names = stripTags(live).split(',').collect { it.trim() }
         }
@@ -142,7 +154,7 @@ class ReleaseScheduleParser {
         }
         String live = cell.replaceAll(STRIKETHROUGH_PATTERN, '')
         def matcher = (live =~ /<a[^>]*href="([^"]*)"/)
-        return matcher ? matcher[0][1] : null
+        return matcher.find() ? matcher.group(1) : null
     }
 
     /**

--- a/src/jenkins/ReleaseScheduleParser.groovy
+++ b/src/jenkins/ReleaseScheduleParser.groovy
@@ -56,7 +56,9 @@ class ReleaseScheduleParser {
         List<Map> schedules = []
         // Use explicit Matcher.find() loops (not Matcher.each/.collect) to stay safe under the
         // Jenkins pipeline runtime, which does not handle iterating a Matcher well.
-        def rowMatcher = (table =~ /(?s)<tr>(.*?)<\/tr>/)
+        // Tag patterns tolerate attributes and case (e.g. <tr class="...">, <TD>) so markup
+        // changes on the scraped page don't silently drop rows/cells.
+        def rowMatcher = (table =~ /(?si)<tr\b[^>]*>(.*?)<\/tr>/)
         while (rowMatcher.find()) {
             String rowHtml = rowMatcher.group(1)
             List<String> cells = extractCells(rowHtml)
@@ -74,7 +76,7 @@ class ReleaseScheduleParser {
 
     private static List<String> extractCells(String rowHtml) {
         List<String> cells = []
-        def cellMatcher = (rowHtml =~ /(?s)<td>(.*?)<\/td>/)
+        def cellMatcher = (rowHtml =~ /(?si)<td\b[^>]*>(.*?)<\/td>/)
         while (cellMatcher.find()) {
             cells.add(cellMatcher.group(1))
         }

--- a/src/jenkins/ReleaseScheduleParser.groovy
+++ b/src/jenkins/ReleaseScheduleParser.groovy
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Parses the OpenSearch release schedule table from the rendered opensearch.org/releases.html page.
+ *
+ * The page (a WordPress site, HTML only) contains a table with class
+ * 'desktop-release-schedule-table' whose rows are:
+ *   Release Number | First RC Generated | Latest Possible Release Date | Release Manager | Tracking Issue
+ *
+ * Each parsed row is normalized to a Map:
+ *   [version, rcDate (yyyy-MM-dd), releaseDate (yyyy-MM-dd), releaseManager (List<String>), releaseIssue (URL)]
+ *
+ * A release can have more than one release manager, so releaseManager is always a list
+ * (empty when the cell is blank).
+ *
+ * Revised dates: when a date is changed, the original is kept as struck-through text
+ * (<strike>/<s>/<del>) followed by the new live date, e.g.
+ *   "<strike>June 30th, 2026</strike> July 2nd, 2026".
+ * The struck-through element and its contents are removed before parsing so only the
+ * current (live) value is used.
+ *
+ * Rows that cannot be parsed (e.g. malformed dates) are skipped rather than failing the whole parse,
+ * since this scrapes external HTML that can change.
+ */
+class ReleaseScheduleParser {
+
+    static final String SCHEDULE_TABLE_CLASS = 'desktop-release-schedule-table'
+    private static final String STRIKETHROUGH_PATTERN = /(?s)<(strike|s|del)[^>]*>.*?<\/\1>/
+
+    String html
+
+    ReleaseScheduleParser(String html) {
+        this.html = html
+    }
+
+    /**
+     * Returns the parsed schedule rows as a list of maps. Empty if the table is absent.
+     */
+    List<Map> parseSchedule() {
+        String table = extractScheduleTable(html)
+        if (!table) {
+            return []
+        }
+        List<Map> schedules = []
+        def rows = (table =~ /(?s)<tr>(.*?)<\/tr>/)
+        rows.each { match ->
+            String rowHtml = match[1]
+            def cells = (rowHtml =~ /(?s)<td>(.*?)<\/td>/).collect { it[1] }
+            // Skip the header row (uses <th>) and any malformed row.
+            if (cells.size() < 5) {
+                return
+            }
+            Map row = parseRow(cells)
+            if (row) {
+                schedules.add(row)
+            }
+        }
+        return schedules
+    }
+
+    private Map parseRow(List cells) {
+        String version = cleanText(cells[0])
+        String rcDate = normalizeDate(cleanText(cells[1]))
+        String releaseDate = normalizeDate(cleanText(cells[2]))
+        List<String> releaseManagers = extractManagers(cells[3])
+        String releaseIssue = extractAnchorUrl(cells[4])
+
+        if (!version || !rcDate || !releaseDate) {
+            return null
+        }
+        return [
+            version       : version,
+            rcDate        : rcDate,
+            releaseDate   : releaseDate,
+            releaseManager: releaseManagers,
+            releaseIssue  : releaseIssue
+        ]
+    }
+
+    private static String extractScheduleTable(String html) {
+        def matcher = (html =~ /(?s)<table class="${SCHEDULE_TABLE_CLASS}".*?<\/table>/)
+        return matcher ? matcher[0] : null
+    }
+
+    /**
+     * Converts a display date like "January 27th, 2026" to ISO "2026-01-27".
+     * Returns null if the value cannot be parsed.
+     */
+    static String normalizeDate(String display) {
+        if (!display) {
+            return null
+        }
+        // Strip ordinal suffixes (1st, 2nd, 3rd, 27th) and collapse whitespace.
+        String cleaned = display.replaceAll(/(\d+)(st|nd|rd|th)/, '$1').replaceAll(/\s+/, ' ').trim()
+        try {
+            def formatter = DateTimeFormatter.ofPattern('MMMM d, yyyy', Locale.ENGLISH)
+            return LocalDate.parse(cleaned, formatter).toString()
+        } catch (Exception ignored) {
+            return null
+        }
+    }
+
+    /**
+     * Extracts the release manager name(s) from a cell, ignoring struck-through (revised) content.
+     * A cell may contain multiple managers as separate anchors, or as comma-separated plain text.
+     * Returns an empty list when the cell is blank.
+     */
+    static List<String> extractManagers(String cell) {
+        if (!cell) {
+            return []
+        }
+        String live = cell.replaceAll(STRIKETHROUGH_PATTERN, '')
+        // Prefer anchor texts when present (one manager per <a>).
+        def anchors = (live =~ /(?s)<a[^>]*>(.*?)<\/a>/).collect { stripTags(it[1]).trim() }
+        List<String> names
+        if (anchors) {
+            names = anchors
+        } else {
+            // No anchors: treat as comma-separated plain text.
+            names = stripTags(live).split(',').collect { it.trim() }
+        }
+        return names.findAll { it }
+    }
+
+    // Returns the href URL of the (non-struck) anchor in the cell, or null.
+    private static String extractAnchorUrl(String cell) {
+        if (!cell) {
+            return null
+        }
+        String live = cell.replaceAll(STRIKETHROUGH_PATTERN, '')
+        def matcher = (live =~ /<a[^>]*href="([^"]*)"/)
+        return matcher ? matcher[0][1] : null
+    }
+
+    /**
+     * Removes struck-through (revised) content, strips remaining tags, and collapses whitespace.
+     * Keeps only the current live value when a cell contains a revision.
+     */
+    private static String cleanText(String cell) {
+        if (!cell) {
+            return cell
+        }
+        String live = cell.replaceAll(STRIKETHROUGH_PATTERN, '')
+        return stripTags(live).replaceAll(/\s+/, ' ').trim()
+    }
+
+    private static String stripTags(String value) {
+        return value ? value.replaceAll(/<[^>]+>/, '').trim() : value
+    }
+}

--- a/src/jenkins/ReleaseStateData.groovy
+++ b/src/jenkins/ReleaseStateData.groovy
@@ -42,15 +42,15 @@ class ReleaseStateData {
     }
 
     void registerSchedule(ReleaseSchedule schedule) {
-        metricsQuery.indexDocument(ReleaseStateIndex.SCHEDULE_INDEX, schedule.toDocument(nowIso()))
+        metricsQuery.indexDocument(ReleaseIndices.SCHEDULE, schedule.toDocument(nowIso()))
     }
 
     void indexCriterion(ReleaseCriterion criterion) {
-        metricsQuery.indexDocument(ReleaseStateIndex.STATE_INDEX, criterion.toDocument(nowIso()))
+        metricsQuery.indexDocument(ReleaseIndices.STATE, criterion.toDocument(nowIso()))
     }
 
     void indexDecision(ReleaseDecision decision) {
-        metricsQuery.indexDocument(ReleaseStateIndex.STATE_INDEX, decision.toDocument(nowIso()))
+        metricsQuery.indexDocument(ReleaseIndices.STATE, decision.toDocument(nowIso()))
     }
 
     /**

--- a/src/jenkins/ReleaseStateIndex.groovy
+++ b/src/jenkins/ReleaseStateIndex.groovy
@@ -24,8 +24,8 @@ import utils.OpenSearchMetricsQuery
  */
 class ReleaseStateIndex {
 
-    public static final String SCHEDULE_INDEX = 'opensearch_release_schedule'
-    public static final String STATE_INDEX = 'opensearch_release_state'
+    public static final String SCHEDULE_INDEX = ReleaseIndices.SCHEDULE
+    public static final String STATE_INDEX = ReleaseIndices.STATE
 
     def script
     OpenSearchMetricsQuery metricsQuery

--- a/tests/jenkins/TestRegisterReleaseSchedule.groovy
+++ b/tests/jenkins/TestRegisterReleaseSchedule.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.MatcherAssert.assertThat
+
+class TestRegisterReleaseSchedule extends BuildPipelineTest {
+
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        binding.setVariable('METRICS_HOST_ACCOUNT', 'METRICS_HOST_ACCOUNT')
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken',
+                'JOB_NAME'             : 'register-release-schedule',
+                'BUILD_NUMBER'         : '5'
+        ])
+        helper.registerAllowedMethod('withSecrets', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('writeFile', [Map])
+        // The exact curl command contains a generated temp filename, so match on the Map form
+        // and return a 201 for any cluster call (the cleanup 'rm' return value is unused).
+        helper.registerAllowedMethod('sh', [Map.class], { map -> return '201' })
+    }
+
+    @Test
+    void testRegisterReleaseSchedule() {
+        runScript('tests/jenkins/jobs/RegisterReleaseSchedule_Jenkinsfile')
+        assertThat(getCommands('echo', 'Registered'),
+                hasItem("Registered release schedule for version 3.8.0 with status 'inactive'."))
+    }
+
+    @Test
+    void testRegisterReleaseScheduleWritesDocument() {
+        runScript('tests/jenkins/jobs/RegisterReleaseSchedule_Jenkinsfile')
+        // The schedule document is written to a temp file before the POST.
+        def writes = helper.callStack.findAll { call -> call.methodName == 'writeFile' }
+        assert writes.size() == 1
+        String body = writes.first().args[0].text
+        assert body.contains('"version":"3.8.0"')
+        assert body.contains('"rc_date":"2026-08-01"')
+        assert body.contains('"release_date":"2026-08-12"')
+        assert body.contains('"status":"inactive"')
+        assert body.contains('"registered_by":"register-release-schedule #5"')
+    }
+
+    def getCommands(String methodName, String searchString) {
+        def matches = []
+        helper.callStack.findAll { call -> call.methodName == methodName }.each { call ->
+            def args = callArgsToString(call)
+            if (args.contains(searchString)) {
+                matches.add(args)
+            }
+        }
+        return matches
+    }
+}

--- a/tests/jenkins/TestReleaseScheduleParser.groovy
+++ b/tests/jenkins/TestReleaseScheduleParser.groovy
@@ -30,14 +30,14 @@ class TestReleaseScheduleParser {
 <td>3.5.0</td>
 <td>January 27th, 2026</td>
 <td>February 10th, 2026</td>
-<td><a href="https://github.com/rishabh6788">Rishabh Singh</a></td>
+<td><a href="https://github.com/foo">Foo</a></td>
 <td><a href="https://github.com/opensearch-project/opensearch-build/issues/5897">5897</a></td>
 </tr>
 <tr>
 <td>2.19.6</td>
 <td>June 23rd, 2026</td>
 <td><strike>June 30th, 2026</strike> July 2nd, 2026</td>
-<td><a href="https://github.com/Divyaasm/">Divya Madala</a></td>
+<td><a href="https://github.com/bar/">Bar</a></td>
 <td><a href="https://github.com/opensearch-project/opensearch-build/issues/6050">6050</a></td>
 </tr>
 <tr>
@@ -70,7 +70,7 @@ class TestReleaseScheduleParser {
         def row = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule().find { it.version == '3.5.0' }
         assert row.rcDate == '2026-01-27'
         assert row.releaseDate == '2026-02-10'
-        assert row.releaseManager == ['Rishabh Singh']
+        assert row.releaseManager == ['Foo']
         assert row.releaseIssue == 'https://github.com/opensearch-project/opensearch-build/issues/5897'
     }
 

--- a/tests/jenkins/TestReleaseScheduleParser.groovy
+++ b/tests/jenkins/TestReleaseScheduleParser.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import org.junit.Test
+import jenkins.ReleaseScheduleParser
+
+class TestReleaseScheduleParser {
+
+    // Mirrors the real opensearch.org/releases.html schedule table, including revised (struck-through)
+    // dates, a row with two release managers, and a row with empty manager / tracking-issue cells.
+    private static final String SAMPLE_HTML = '''
+<html><body>
+<table class="desktop-release-schedule-table">
+<tr>
+<th>Release Number</th>
+<th>First RC Generated (release window opens)</th>
+<th>Latest Possible Release Date (release window closes)</th>
+<th>Release Manager</th>
+<th>Tracking Issue</th>
+</tr>
+<tr>
+<td>3.5.0</td>
+<td>January 27th, 2026</td>
+<td>February 10th, 2026</td>
+<td><a href="https://github.com/rishabh6788">Rishabh Singh</a></td>
+<td><a href="https://github.com/opensearch-project/opensearch-build/issues/5897">5897</a></td>
+</tr>
+<tr>
+<td>2.19.6</td>
+<td>June 23rd, 2026</td>
+<td><strike>June 30th, 2026</strike> July 2nd, 2026</td>
+<td><a href="https://github.com/Divyaasm/">Divya Madala</a></td>
+<td><a href="https://github.com/opensearch-project/opensearch-build/issues/6050">6050</a></td>
+</tr>
+<tr>
+<td>3.8.0</td>
+<td><s>July 14th, 2026</s> July 21st, 2026</td>
+<td>August 4th, 2026</td>
+<td><a href="https://github.com/alice">Alice</a>, <a href="https://github.com/bob">Bob</a></td>
+<td><a href="https://github.com/opensearch-project/opensearch-build/issues/6278">6278</a></td>
+</tr>
+<tr>
+<td>3.9.0</td>
+<td><s>September 22nd, 2026</s> September 15th, 2026</td>
+<td>September 29th, 2026</td>
+<td></td>
+<td></td>
+</tr>
+</table>
+</body></html>
+'''
+
+    @Test
+    void testParsesAllScheduleRows() {
+        def schedules = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule()
+        assert schedules.size() == 4
+        assert schedules.collect { it.version } == ['3.5.0', '2.19.6', '3.8.0', '3.9.0']
+    }
+
+    @Test
+    void testParsesNormalRowFields() {
+        def row = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule().find { it.version == '3.5.0' }
+        assert row.rcDate == '2026-01-27'
+        assert row.releaseDate == '2026-02-10'
+        assert row.releaseManager == ['Rishabh Singh']
+        assert row.releaseIssue == 'https://github.com/opensearch-project/opensearch-build/issues/5897'
+    }
+
+    @Test
+    void testRevisedReleaseDateUsesLiveValueNotStruckThrough() {
+        // <strike>June 30th</strike> July 2nd -> July 2nd
+        def row = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule().find { it.version == '2.19.6' }
+        assert row.releaseDate == '2026-07-02'
+    }
+
+    @Test
+    void testRevisedRcDateUsesLiveValueNotStruckThrough() {
+        // <s>July 14th</s> July 21st -> July 21st
+        def row = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule().find { it.version == '3.8.0' }
+        assert row.rcDate == '2026-07-21'
+    }
+
+    @Test
+    void testMultipleReleaseManagersParsedAsList() {
+        def row = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule().find { it.version == '3.8.0' }
+        assert row.releaseManager == ['Alice', 'Bob']
+    }
+
+    @Test
+    void testRowWithEmptyManagerAndIssueStillParses() {
+        def row = new ReleaseScheduleParser(SAMPLE_HTML).parseSchedule().find { it.version == '3.9.0' }
+        assert row.rcDate == '2026-09-15'   // revised, live value
+        assert row.releaseDate == '2026-09-29'
+        assert row.releaseManager == []
+        assert row.releaseIssue == null
+    }
+
+    @Test
+    void testReturnsEmptyListWhenScheduleTableAbsent() {
+        assert new ReleaseScheduleParser('<html><body>no table here</body></html>').parseSchedule() == []
+    }
+
+    @Test
+    void testExtractManagersHandlesCommaSeparatedPlainText() {
+        // No anchors, comma-separated names.
+        assert ReleaseScheduleParser.extractManagers('Alice, Bob') == ['Alice', 'Bob']
+        assert ReleaseScheduleParser.extractManagers('') == []
+        assert ReleaseScheduleParser.extractManagers(null) == []
+    }
+
+    @Test
+    void testNormalizeDateHandlesOrdinalsAndInvalid() {
+        assert ReleaseScheduleParser.normalizeDate('January 27th, 2026') == '2026-01-27'
+        assert ReleaseScheduleParser.normalizeDate('August 4th, 2026') == '2026-08-04'
+        assert ReleaseScheduleParser.normalizeDate('not a date') == null
+        assert ReleaseScheduleParser.normalizeDate(null) == null
+    }
+}

--- a/tests/jenkins/TestReleaseStateDocuments.groovy
+++ b/tests/jenkins/TestReleaseStateDocuments.groovy
@@ -10,6 +10,7 @@
 package jenkins.tests
 
 import org.junit.Test
+import java.time.LocalDate
 import jenkins.ReleaseCriterion
 import jenkins.ReleaseDecision
 import jenkins.ReleaseSchedule
@@ -116,29 +117,78 @@ class TestReleaseStateDocuments {
     // ---- ReleaseSchedule ----
 
     @Test
-    void testScheduleToDocumentMapsSnakeCaseAndDefaultsStatusToInactive() {
+    void testScheduleToDocumentMapsSnakeCaseFields() {
+        // status is passed explicitly so this test stays focused on field mapping (not date-derived status).
         def doc = new ReleaseSchedule([
                 version       : '3.8.0',
                 rcDate        : '2026-08-01',
                 releaseDate   : '2026-08-12',
                 releaseManager: 'test-rm',
+                status        : 'inactive',
                 registeredBy  : 'release-schedule-job #5'
         ]).toDocument(TS)
 
         assert doc.version == '3.8.0'
         assert doc.rc_date == '2026-08-01'
         assert doc.release_date == '2026-08-12'
-        assert doc.release_manager == 'test-rm'
+        // A single manager handle is normalized to a one-element list.
+        assert doc.release_manager == ['test-rm']
         assert doc.registered_by == 'release-schedule-job #5'
-        // A newly registered release is inactive until ~1 month before its RC date.
         assert doc.status == 'inactive'
         assert doc.registered_at == TS
     }
 
     @Test
+    void testScheduleAcceptsMultipleReleaseManagers() {
+        def doc = new ReleaseSchedule([version: '3.8.0', releaseManager: ['Alice', 'Bob'], status: 'active']).toDocument(TS)
+        assert doc.release_manager == ['Alice', 'Bob']
+    }
+
+    @Test
+    void testScheduleNormalizesNullReleaseManagerToEmptyList() {
+        def doc = new ReleaseSchedule([version: '3.8.0', status: 'active']).toDocument(TS)
+        assert doc.release_manager == []
+    }
+
+    @Test
     void testScheduleHonorsExplicitStatus() {
+        // An explicit status always wins, even when the RC date would derive a different value.
         assert new ReleaseSchedule([version: '3.8.0', status: 'active']).toDocument(TS).status == 'active'
         assert new ReleaseSchedule([version: '3.8.0', status: 'released']).toDocument(TS).status == 'released'
+    }
+
+    @Test
+    void testScheduleDefaultsToInactiveWhenNoRcDateOrStatus() {
+        // No rcDate and no explicit status -> cannot derive -> safe default 'inactive'.
+        assert new ReleaseSchedule([version: '3.8.0']).toDocument(TS).status == 'inactive'
+    }
+
+    @Test
+    void testDeriveStatusActiveWithinWindow() {
+        def today = LocalDate.of(2026, 7, 22)
+        assert ReleaseSchedule.deriveStatus('2026-08-01', today) == 'active'   // 10 days before RC
+        assert ReleaseSchedule.deriveStatus('2026-08-21', today) == 'active'   // exactly 30 days before RC
+    }
+
+    @Test
+    void testDeriveStatusInactiveBeyondWindow() {
+        def today = LocalDate.of(2026, 7, 22)
+        assert ReleaseSchedule.deriveStatus('2026-08-22', today) == 'inactive' // 31 days before RC
+        assert ReleaseSchedule.deriveStatus('2026-12-01', today) == 'inactive' // far out
+    }
+
+    @Test
+    void testDeriveStatusActiveWhenRcDatePassed() {
+        def today = LocalDate.of(2026, 8, 15)
+        assert ReleaseSchedule.deriveStatus('2026-08-01', today) == 'active'   // RC already passed
+    }
+
+    @Test
+    void testDeriveStatusInactiveWhenRcDateMissingOrInvalid() {
+        def today = LocalDate.of(2026, 7, 22)
+        assert ReleaseSchedule.deriveStatus(null, today) == 'inactive'
+        assert ReleaseSchedule.deriveStatus('', today) == 'inactive'
+        assert ReleaseSchedule.deriveStatus('not-a-date', today) == 'inactive'
     }
 
     @Test(expected = IllegalArgumentException)

--- a/tests/jenkins/TestReleaseStateDocuments.groovy
+++ b/tests/jenkins/TestReleaseStateDocuments.groovy
@@ -166,29 +166,37 @@ class TestReleaseStateDocuments {
     @Test
     void testDeriveStatusActiveWithinWindow() {
         def today = LocalDate.of(2026, 7, 22)
-        assert ReleaseSchedule.deriveStatus('2026-08-01', today) == 'active'   // 10 days before RC
-        assert ReleaseSchedule.deriveStatus('2026-08-21', today) == 'active'   // exactly 30 days before RC
+        // rc 10 days out / exactly 30 days out, release still in the future -> active
+        assert ReleaseSchedule.deriveStatus('2026-08-01', '2026-08-12', today) == 'active'
+        assert ReleaseSchedule.deriveStatus('2026-08-21', '2026-09-01', today) == 'active'
     }
 
     @Test
     void testDeriveStatusInactiveBeyondWindow() {
         def today = LocalDate.of(2026, 7, 22)
-        assert ReleaseSchedule.deriveStatus('2026-08-22', today) == 'inactive' // 31 days before RC
-        assert ReleaseSchedule.deriveStatus('2026-12-01', today) == 'inactive' // far out
+        assert ReleaseSchedule.deriveStatus('2026-08-22', '2026-09-01', today) == 'inactive' // 31 days before RC
+        assert ReleaseSchedule.deriveStatus('2026-12-01', '2026-12-15', today) == 'inactive' // far out
     }
 
     @Test
-    void testDeriveStatusActiveWhenRcDatePassed() {
+    void testDeriveStatusActiveBetweenRcAndReleaseDate() {
+        // RC passed but release not yet reached -> still active
+        def today = LocalDate.of(2026, 8, 5)
+        assert ReleaseSchedule.deriveStatus('2026-08-01', '2026-08-12', today) == 'active'
+    }
+
+    @Test
+    void testDeriveStatusReleasedAfterReleaseDate() {
         def today = LocalDate.of(2026, 8, 15)
-        assert ReleaseSchedule.deriveStatus('2026-08-01', today) == 'active'   // RC already passed
+        assert ReleaseSchedule.deriveStatus('2026-08-01', '2026-08-12', today) == 'released'
     }
 
     @Test
     void testDeriveStatusInactiveWhenRcDateMissingOrInvalid() {
         def today = LocalDate.of(2026, 7, 22)
-        assert ReleaseSchedule.deriveStatus(null, today) == 'inactive'
-        assert ReleaseSchedule.deriveStatus('', today) == 'inactive'
-        assert ReleaseSchedule.deriveStatus('not-a-date', today) == 'inactive'
+        assert ReleaseSchedule.deriveStatus(null, null, today) == 'inactive'
+        assert ReleaseSchedule.deriveStatus('', '', today) == 'inactive'
+        assert ReleaseSchedule.deriveStatus('not-a-date', null, today) == 'inactive'
     }
 
     @Test(expected = IllegalArgumentException)

--- a/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMavenManifestYml_Jenkinsfile.txt
@@ -109,6 +109,14 @@ function create_maven_settings() {
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                             http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>opensearch-maven-mirror</id>
+      <name>OpenSearch CI Maven Mirror</name>
+      <url>https://ci.opensearch.org/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>central</id>
@@ -126,19 +134,21 @@ echo "==========================================="
 echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
-deployment=$(mvn --settings="${mvn_settings}" \
+deployment_log="${workdir}/deployment.log"
+
+mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}")
+  -DstagingProfileId="${STAGING_PROFILE_ID}" > "${deployment_log}" 2>&1 || echo "Maven command failed with exit code: $?"
 
-echo $deployment
+cat "${deployment_log}"
 
-if echo "$deployment" | grep "BUILD SUCCESS"; then
-  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
+if grep -q "BUILD SUCCESS" "${deployment_log}"; then
+  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" "${deployment_log}" | grep -o "\"[^\"]*\"" | tr -d '"')
   echo "Successfully staged and validated artifacts. Staging repository ID: ${DEPLOYED_STAGING_REPO_ID}"
 else
   echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing."

--- a/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishToMaven_Jenkinsfile.txt
@@ -109,6 +109,14 @@ function create_maven_settings() {
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                             http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>opensearch-maven-mirror</id>
+      <name>OpenSearch CI Maven Mirror</name>
+      <url>https://ci.opensearch.org/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>central</id>
@@ -126,19 +134,21 @@ echo "==========================================="
 echo "Deploying artifacts under ${ARTIFACT_DIRECTORY} to Staging Repository."
 echo "==========================================="
 
-deployment=$(mvn --settings="${mvn_settings}" \
+deployment_log="${workdir}/deployment.log"
+
+mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy-staged-repository \
   -DrepositoryDirectory="${ARTIFACT_DIRECTORY}" \
   -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
   -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}")
+  -DstagingProfileId="${STAGING_PROFILE_ID}" > "${deployment_log}" 2>&1 || echo "Maven command failed with exit code: $?"
 
-echo $deployment
+cat "${deployment_log}"
 
-if echo "$deployment" | grep "BUILD SUCCESS"; then
-  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" <<< "$deployment" | grep -o "\"[^\"]*\"" | tr -d '"')
+if grep -q "BUILD SUCCESS" "${deployment_log}"; then
+  DEPLOYED_STAGING_REPO_ID=$(grep "Closing staging repository with ID" "${deployment_log}" | grep -o "\"[^\"]*\"" | tr -d '"')
   echo "Successfully staged and validated artifacts. Staging repository ID: ${DEPLOYED_STAGING_REPO_ID}"
 else
   echo "Deployment failed!! Please check the logs above for details or check the Sonatype portal https://central.sonatype.com/publishing."

--- a/tests/jenkins/jobs/RegisterReleaseSchedule_Jenkinsfile
+++ b/tests/jenkins/jobs/RegisterReleaseSchedule_Jenkinsfile
@@ -1,0 +1,27 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('registerReleaseSchedule') {
+            steps {
+                script {
+                    registerReleaseSchedule(
+                        version: '3.8.0',
+                        rcDate: '2026-08-01',
+                        releaseDate: '2026-08-12',
+                        releaseIssue: 'https://github.com/opensearch-project/opensearch-build/issues/6062',
+                        releaseManager: 'test-rm',
+                        status: 'inactive'
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/lib-testers/RegisterReleaseScheduleLibTester.groovy
+++ b/tests/jenkins/lib-testers/RegisterReleaseScheduleLibTester.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+class RegisterReleaseScheduleLibTester extends LibFunctionTester {
+    private String version
+    private String rcDate
+    private String releaseDate
+
+    RegisterReleaseScheduleLibTester(version, rcDate, releaseDate) {
+        this.version = version
+        this.rcDate = rcDate
+        this.releaseDate = releaseDate
+    }
+
+    @Override
+    String libFunctionName() {
+        return 'registerReleaseSchedule'
+    }
+
+    @Override
+    void parameterInvariantsAssertions(Object call) {
+        assertThat(call.args.version.first(), notNullValue())
+    }
+
+    @Override
+    boolean expectedParametersMatcher(Object call) {
+        return call.args.version.first().equals(this.version)
+                && call.args.rcDate.first().equals(this.rcDate)
+                && call.args.releaseDate.first().equals(this.releaseDate)
+    }
+
+    @Override
+    void configure(Object helper, Object binding) {
+        binding.setVariable('METRICS_HOST_ACCOUNT', 'METRICS_HOST_ACCOUNT')
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken',
+                'JOB_NAME'             : 'register-release-schedule',
+                'BUILD_NUMBER'         : '5'
+        ])
+        helper.registerAllowedMethod('withSecrets', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        // The document body is written to a temp file, then POSTed via curl -d @file.
+        helper.registerAllowedMethod('writeFile', [Map])
+        // The curl command contains a generated temp filename; match on the Map form and
+        // return a 201 Created for any cluster call.
+        helper.registerAllowedMethod('sh', [Map.class], { map -> return '201' })
+    }
+}

--- a/vars/registerReleaseSchedule.groovy
+++ b/vars/registerReleaseSchedule.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import jenkins.ReleaseStateData
+import jenkins.ReleaseSchedule
+
+/**
+ * Registers a release schedule document in the opensearch_release_schedule index.
+ * Run once per release to record its RC and release dates so downstream jobs and OSCAR
+ * can discover active releases and compute notification cadence.
+ *
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.version <required> - Release version. eg: 3.8.0
+ * @param args.rcDate <optional> - Release candidate date in yyyy-MM-dd. eg: 2026-08-01
+ * @param args.releaseDate <optional> - Release date in yyyy-MM-dd. eg: 2026-08-12
+ * @param args.releaseIssue <optional> - URL of the GitHub release issue.
+ * @param args.releaseManager <optional> - GitHub handle of the release manager.
+ * @param args.status <optional> - Schedule status. Defaults to 'inactive'. One of: inactive, active, released, cancelled.
+ */
+void call(Map args = [:]) {
+    def secret_metrics_cluster = [
+        [envVar: 'METRICS_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number'],
+        [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
+    ]
+
+    def schedule = new ReleaseSchedule([
+        version       : args.version,
+        rcDate        : args.rcDate,
+        releaseDate   : args.releaseDate,
+        releaseIssue  : args.releaseIssue,
+        releaseManager: args.releaseManager,
+        status        : args.status,
+        registeredBy  : "${env.JOB_NAME} #${env.BUILD_NUMBER}"
+    ])
+
+    withSecrets(secrets: secret_metrics_cluster) {
+        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+            def metricsUrl = env.METRICS_HOST_URL
+            def awsAccessKey = env.AWS_ACCESS_KEY_ID
+            def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+            def awsSessionToken = env.AWS_SESSION_TOKEN
+
+            def releaseStateData = new ReleaseStateData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, this)
+            releaseStateData.registerSchedule(schedule)
+            echo("Registered release schedule for version ${args.version} with status '${schedule.status}'.")
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a library that parses the given html page (example: https://opensearch.org/releases/), decides the release status (if not provided) and indexes it to the metrics cluster. 
It also fixes a critical dead-lock condition added in https://github.com/opensearch-project/opensearch-build-libraries/pull/862

> Root cause (from the thread dump): ReleaseStateData referenced ReleaseStateIndex.SCHEDULE_INDEX/STATE_INDEX — a cross-class static-constant reference. Under JenkinsPipelineUnit, resolving that during lazy compilation forced GroovyClassLoader.recompile to re-enter a class-cache write lock it already held → self-deadlock (StampedLock.acquireWrite parked forever).


### Issues Resolved
Part of https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
