### PR TITLE
Refactor checkReleaseNotes to use metrics data and change return type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.4.0'
+String version = '13.5.0'
 
 task updateVersion {
     doLast {

--- a/resources/release/missing-release-notes.md
+++ b/resources/release/missing-release-notes.md
@@ -1,6 +1,6 @@
 Hi, </br>
 
-This component is missing release notes at $BRANCH ref. Please add them on priority in order to meet the entrance criteria for the release. </br>
+This component is missing release notes. Please add them on priority in order to meet the entrance criteria for the release. </br>
 Please check out the [guidelines](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md) for the release notes. </br>
 
 Thank you!

--- a/src/jenkins/ReleaseMetricsData.groovy
+++ b/src/jenkins/ReleaseMetricsData.groovy
@@ -79,6 +79,38 @@ class ReleaseMetricsData {
         return query.replace('"', '\\"')
     }
 
+    String getReleaseNotesStatusQuery(String component) {
+        def queryMap = [
+                size   : 1,
+                _source: "release_notes",
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        version: "${this.version}"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        "component.keyword": "${component}"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ],
+                sort   : [
+                        [
+                                current_date: [
+                                        order: "desc"
+                                ]
+                        ]
+                ]
+        ]
+        String query = JsonOutput.toJson(queryMap)
+        return query.replace('"', '\\"')
+    }
+
     String getReleaseIssueQuery(String repository, String changedMatchPhraseKey = "repository.keyword") {
         def queryMap = [
                 size   : 1,
@@ -118,6 +150,17 @@ ArrayList getReleaseOwners(String component) {
                 return releaseOwners
         } catch (Exception e) {
                 this.script.println("Error fetching release owners: ${e.message}")
+                return null
+        }
+}
+
+def getReleaseNotesStatus(String component) {
+        try {
+                def jsonResponse = this.openSearchMetricsQuery.fetchMetrics(getReleaseNotesStatusQuery(component))
+                def releaseNotes = jsonResponse.hits.hits[0]._source.release_notes
+                return releaseNotes
+        } catch (Exception e) {
+                this.script.println("Error fetching release notes status: ${e.message}")
                 return null
         }
 }

--- a/tests/jenkins/TestCheckReleaseNotes.groovy
+++ b/tests/jenkins/TestCheckReleaseNotes.groovy
@@ -17,9 +17,54 @@ import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
 
 class TestCheckReleaseNotes extends BuildPipelineTest {
+
+    // Latest metrics doc for the component reports release notes are missing (release_notes: false).
+    def releaseNotesMissingResponse = '''
+                {
+                  "took": 4,
+                  "timed_out": false,
+                  "_shards": { "total": 5, "successful": 5, "skipped": 0, "failed": 0 },
+                  "hits": {
+                    "total": { "value": 1, "relation": "eq" },
+                    "max_score": null,
+                    "hits": [
+                      {
+                        "_index": "opensearch_release_metrics",
+                        "_id": "86739a31-40db-320f-b52c-d38d50e179bc",
+                        "_score": null,
+                        "_source": { "release_notes": false },
+                        "sort": [ 1738963520807 ]
+                      }
+                    ]
+                  }
+                }
+                '''
+
+    def releaseIssueResponse = '''
+                {
+                  "took": 5,
+                  "timed_out": false,
+                  "_shards": { "total": 5, "successful": 5, "skipped": 0, "failed": 0 },
+                  "hits": {
+                    "total": { "value": 1, "relation": "eq" },
+                    "max_score": null,
+                    "hits": [
+                      {
+                        "_index": "opensearch_release_metrics",
+                        "_id": "fec68961-abdb-3e49-b97f-b656b0a9a510",
+                        "_score": null,
+                        "_source": { "release_issue": "https://github.com/opensearch-project/opensearch/issues/123" },
+                        "sort": [ 1738963520807 ]
+                      }
+                    ]
+                  }
+                }
+                '''
+
     @Override
     @Before
     void setUp() {
@@ -42,87 +87,77 @@ class TestCheckReleaseNotes extends BuildPipelineTest {
             closure.delegate = delegate
             return helper.callClosure(closure)
         })
-        String testData = new File('tests/data/release-notes-check.md').text
-        helper.addFileExistsMock('tests/data/release-notes-check.md', true)
-        helper.addReadFileMock('tests/data/release-notes-check.md', testData)
+        helper.addFileExistsMock('tests/data/opensearch-1.3.0.yml', true)
+        // Pin the template's random file name so the notify callstack is deterministic (index 2 -> 'C').
         Random.metaClass.nextInt = { int max -> 2 }
 
-        def releaseIssueResponse = '''
-                    {
-                    
-                      "took": 5,
-                      "timed_out": false,
-                      "_shards": {
-                        "total": 5,
-                        "successful": 5,
-                        "skipped": 0,
-                        "failed": 0
-                      },
-                      "hits": {
-                        "total": {
-                          "value": 11,
-                          "relation": "eq"
-                        },
-                        "max_score": null,
-                        "hits": [
-                          {
-                            "_index": "opensearch_release_metrics",
-                            "_id": "86739a31-40db-320f-b52c-d38d50e179bc",
-                            "_score": null,
-                            "_source": {
-                              "release_issue": "https://github.com/opensearch-project/opensearch/issues/123"
-                            },
-                            "sort": [
-                              1738963520807
-                            ]
-                          }
-                        ]
-                      }
-                    }
-                    '''
-        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"2.19.0\\"}},{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}" | jq '.'\n        """) { script ->
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\\"size\\":1,\\"_source\\":\\"release_notes\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}},{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}" | jq '.'\n        """) { script ->
+            return [stdout: releaseNotesMissingResponse, exitValue: 0]
+        }
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}},{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}" | jq '.'\n        """) { script ->
             return [stdout: releaseIssueResponse, exitValue: 0]
         }
     }
 
-
     @Test
     void testNotifyAction() {
         addParam('ACTION', 'notify')
-        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'notify'))
+        this.registerLibTester(new CheckReleaseNotesLibTester(['tests/data/opensearch-1.3.0.yml'], 'notify'))
         super.testPipeline('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
         def fileContent = getCommands('writeFile', 'release')[0]
         assertThat(fileContent, allOf(containsString("{file=/tmp/workspace/CCCCCCCCCC.md, text=Hi, </br>"),
-        containsString("This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release. </br>")))
-        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch, functionalTestDashboards]"))
+                containsString("This component is missing release notes. Please add them on priority in order to meet the entrance criteria for the release. </br>")))
+        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch]"))
         assertThat(getCommands('sh', 'opensearch'), hasItem("{script=gh issue comment https://github.com/opensearch-project/opensearch/issues/123 --body-file /tmp/workspace/CCCCCCCCCC.md, returnStdout=true}"))
-        assertThat(getCommands('sh', 'functionalTestDashboards').size(), equalTo(0))
     }
 
     @Test
     void testCheckAction() {
         addParam('ACTION', 'check')
-        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'check'))
+        this.registerLibTester(new CheckReleaseNotesLibTester(['tests/data/opensearch-1.3.0.yml'], 'check'))
         runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
-        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch, functionalTestDashboards]"))
+        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: [OpenSearch]"))
+        // 'check' must not comment on the release issue.
+        assertThat(getCommands('sh', 'gh issue comment').size(), equalTo(0))
+    }
+
+    @Test
+    void testAllComponentsHaveReleaseNotes() {
+        addParam('ACTION', 'check')
+        def releaseNotesPresentResponse = '''
+                {
+                  "took": 4,
+                  "timed_out": false,
+                  "_shards": { "total": 5, "successful": 5, "skipped": 0, "failed": 0 },
+                  "hits": {
+                    "total": { "value": 1, "relation": "eq" },
+                    "max_score": null,
+                    "hits": [
+                      {
+                        "_index": "opensearch_release_metrics",
+                        "_id": "86739a31-40db-320f-b52c-d38d50e179bc",
+                        "_score": null,
+                        "_source": { "release_notes": true },
+                        "sort": [ 1738963520807 ]
+                      }
+                    ]
+                  }
+                }
+                '''
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\\"size\\":1,\\"_source\\":\\"release_notes\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}},{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}" | jq '.'\n        """) { script ->
+            return [stdout: releaseNotesPresentResponse, exitValue: 0]
+        }
+        this.registerLibTester(new CheckReleaseNotesLibTester(['tests/data/opensearch-1.3.0.yml'], 'check'))
+        runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
+        assertThat(getCommands('echo', 'missing'), hasItem("Components missing release notes: []"))
     }
 
     @Test
     void testMispelledAction() {
         addParam('ACTION', 'chek')
-        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'chek'))
+        this.registerLibTester(new CheckReleaseNotesLibTester(['tests/data/opensearch-1.3.0.yml'], 'chek'))
         runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
         assertThat(getCommands('error', ''), hasItem("Invalid action 'chek'. Valid values: check, notify"))
-        assertJobStatusFailure()
-    }
-
-    @Test
-    void testParsingError() {
-        addParam('ACTION', 'check')
-        helper.addReadFileMock('tests/data/release-notes-check.md', "testData")
-        this.registerLibTester(new CheckReleaseNotesLibTester('2.19.0', 'tests/data/release-notes-check.md', 'check'))
-        runScript('tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile')
-        assertThat(getCommands('error', ''), hasItem("Unable to parse the release notes markdown table: fromIndex = -1"))
         assertJobStatusFailure()
     }
 

--- a/tests/jenkins/TestReleaseMetricsData.groovy
+++ b/tests/jenkins/TestReleaseMetricsData.groovy
@@ -116,6 +116,99 @@ class TestReleaseMetricsData {
     }
 
     @Test
+    void testGetReleaseNotesStatusQuery(){
+        String expectedOutput = JsonOutput.toJson([
+                size   : 1,
+                _source: "release_notes",
+                query  : [
+                        bool: [
+                                filter: [
+                                        [
+                                                match_phrase: [
+                                                        version: "2.18.0"
+                                                ]
+                                        ],
+                                        [
+                                                match_phrase: [
+                                                        "component.keyword": "sql"
+                                                ]
+                                        ]
+                                ]
+                        ]
+                ],
+                sort   : [
+                        [
+                                current_date: [
+                                        order: "desc"
+                                ]
+                        ]
+                ]
+        ]).replace('"', '\\"')
+        def result = releaseMetricsData.getReleaseNotesStatusQuery('sql')
+        assert result == expectedOutput
+    }
+
+    @Test
+    void testGetReleaseNotesStatus() {
+        def responseText = """
+                    {
+                      "took": 4,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 1,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": [
+                          {
+                            "_index": "opensearch_release_metrics",
+                            "_id": "86739a31-40db-320f-b52c-d38d50e179bc",
+                            "_score": null,
+                            "_source": {
+                              "release_notes": false
+                            },
+                            "sort": [
+                              1738963520807
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                """
+        script = new Expando()
+        script.sh = { Map args ->
+            if (args.containsKey("script")) {
+                return responseText
+            }
+        }
+        releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
+        assert releaseMetricsData.getReleaseNotesStatus('sql') == false
+    }
+
+    @Test
+    void testGetReleaseNotesStatusException() {
+        script = new Expando()
+        script.println = { String message ->
+            assert message.startsWith("Error fetching release notes status:")
+        }
+        releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
+        releaseMetricsData.openSearchMetricsQuery = [
+                fetchMetrics: { query ->
+                    throw new RuntimeException("Test exception")
+                }
+        ]
+        def result = releaseMetricsData.getReleaseNotesStatus('sql')
+        assert result == null
+    }
+
+    @Test
     void testGetReleaseIssueQuery(){
         String expectedOutput = JsonOutput.toJson([
                 size   : 1,

--- a/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile
+++ b/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile
@@ -21,8 +21,7 @@ pipeline {
             steps {
                 script {
                     checkReleaseNotes(
-                        version: '2.19.0',
-                        dataTable: 'tests/data/release-notes-check.md',
+                        inputManifest: ['tests/data/opensearch-1.3.0.yml'],
                         action: "${params.ACTION}"
                     )
                 }

--- a/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
+++ b/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
@@ -3,28 +3,34 @@
          CheckReleaseNotes_JenkinsFile.echo(Executing on agent [label:none])
          CheckReleaseNotes_JenkinsFile.stage(checkReleaseNotes, groovy.lang.Closure)
             CheckReleaseNotes_JenkinsFile.script(groovy.lang.Closure)
-               CheckReleaseNotes_JenkinsFile.checkReleaseNotes({version=2.19.0, dataTable=tests/data/release-notes-check.md, action=notify})
-                  checkReleaseNotes.fileExists(tests/data/release-notes-check.md)
-                  checkReleaseNotes.readFile(tests/data/release-notes-check.md)
-                  ParseReleaseNotesMarkdownTable.parseReleaseNotesMarkdownTableRows()
-                  checkReleaseNotes.echo(Components missing release notes: [OpenSearch, functionalTestDashboards])
-                  checkReleaseNotes.echo(Notifying all the components with missing release notes.)
+               CheckReleaseNotes_JenkinsFile.checkReleaseNotes({inputManifest=[tests/data/opensearch-1.3.0.yml], action=notify})
+                  checkReleaseNotes.fileExists(tests/data/opensearch-1.3.0.yml)
+                  checkReleaseNotes.readYaml({file=tests/data/opensearch-1.3.0.yml})
+                  checkReleaseNotes.readYaml({file=tests/data/opensearch-1.3.0.yml})
                   checkReleaseNotes.withSecrets({secrets=[{envVar=METRICS_HOST_ACCOUNT, secretRef=op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number}, {envVar=METRICS_HOST_URL, secretRef=op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint}]}, groovy.lang.Closure)
                      checkReleaseNotes.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                        ReleaseMetricsData.getReleaseIssue(OpenSearch, component.keyword)
-                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
-                              checkReleaseNotes.println(Running query: {\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                        ReleaseMetricsData.getReleaseNotesStatus(OpenSearch)
+                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_notes\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkReleaseNotes.println(Running query: {\"size\":1,\"_source\":\"release_notes\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
                               checkReleaseNotes.sh({script=
             set -e
             set +x
-            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"2.19.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_notes\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
         , returnStdout=true})
-                        TemplateProcessor.process(release/missing-release-notes.md, {BRANCH=[main]}, /tmp/workspace)
+                        ReleaseMetricsData.getReleaseIssue(OpenSearch, component.keyword)
+                           OpenSearchMetricsQuery.fetchMetrics({\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkReleaseNotes.println(Running query: {\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]})
+                              checkReleaseNotes.sh({script=
+            set -e
+            set +x
+            curl -s -XGET "sample.url/opensearch_release_metrics/_search" --aws-sigv4 "aws:amz:us-east-1:es" --user "abc:xyz" -H "x-amz-security-token:sampleToken" -H 'Content-Type: application/json' -d "{\"size\":1,\"_source\":\"release_issue\",\"query\":{\"bool\":{\"filter\":[{\"match_phrase\":{\"version\":\"1.3.0\"}},{\"match_phrase\":{\"component.keyword\":\"OpenSearch\"}}]}},\"sort\":[{\"current_date\":{\"order\":\"desc\"}}]}" | jq '.'
+        , returnStdout=true})
+                        TemplateProcessor.process(release/missing-release-notes.md, {}, /tmp/workspace)
                            TemplateProcessor.getRandomName()
                            checkReleaseNotes.libraryResource(release/missing-release-notes.md)
                            checkReleaseNotes.writeFile({file=/tmp/workspace/CCCCCCCCCC.md, text=Hi, </br>
 
-This component is missing release notes at [main] ref. Please add them on priority in order to meet the entrance criteria for the release. </br>
+This component is missing release notes. Please add them on priority in order to meet the entrance criteria for the release. </br>
 Please check out the [guidelines](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md) for the release notes. </br>
 
 Thank you!
@@ -32,5 +38,4 @@ Thank you!
                            checkReleaseNotes.println(Wrote file to /tmp/workspace/CCCCCCCCCC.md)
                         checkReleaseNotes.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                            checkReleaseNotes.sh({script=gh issue comment https://github.com/opensearch-project/opensearch/issues/123 --body-file /tmp/workspace/CCCCCCCCCC.md, returnStdout=true})
-                  checkReleaseNotes.withSecrets({secrets=[{envVar=METRICS_HOST_ACCOUNT, secretRef=op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number}, {envVar=METRICS_HOST_URL, secretRef=op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint}]}, groovy.lang.Closure)
-                     checkReleaseNotes.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                  checkReleaseNotes.echo(Components missing release notes: [OpenSearch])

--- a/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
+++ b/tests/jenkins/jobs/CheckReleaseNotes_JenkinsFile.txt
@@ -6,7 +6,6 @@
                CheckReleaseNotes_JenkinsFile.checkReleaseNotes({inputManifest=[tests/data/opensearch-1.3.0.yml], action=notify})
                   checkReleaseNotes.fileExists(tests/data/opensearch-1.3.0.yml)
                   checkReleaseNotes.readYaml({file=tests/data/opensearch-1.3.0.yml})
-                  checkReleaseNotes.readYaml({file=tests/data/opensearch-1.3.0.yml})
                   checkReleaseNotes.withSecrets({secrets=[{envVar=METRICS_HOST_ACCOUNT, secretRef=op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number}, {envVar=METRICS_HOST_URL, secretRef=op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint}]}, groovy.lang.Closure)
                      checkReleaseNotes.withAWS({role=OpenSearchJenkinsAccessRole, roleAccount=METRICS_HOST_ACCOUNT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                         ReleaseMetricsData.getReleaseNotesStatus(OpenSearch)

--- a/tests/jenkins/lib-testers/CheckReleaseNotesLibTester.groovy
+++ b/tests/jenkins/lib-testers/CheckReleaseNotesLibTester.groovy
@@ -12,13 +12,11 @@ import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 
 class CheckReleaseNotesLibTester extends LibFunctionTester{
-    private String version
-    private String dataTable
+    private List inputManifest
     private String action = 'check'
 
-    public CheckReleaseNotesLibTester(version, dataTable, action){
-        this.version = version
-        this.dataTable = dataTable
+    public CheckReleaseNotesLibTester(inputManifest, action){
+        this.inputManifest = inputManifest
         this.action = action
     }
 
@@ -29,15 +27,13 @@ class CheckReleaseNotesLibTester extends LibFunctionTester{
 
     @Override
     void parameterInvariantsAssertions(Object call) {
-        assertThat(call.args.version.first(), notNullValue())
-        assertThat(call.args.dataTable.first(), notNullValue())
+        assertThat(call.args.inputManifest.first(), notNullValue())
         assertThat(call.args.action.first(), notNullValue())
     }
 
     @Override
     boolean expectedParametersMatcher(Object call) {
-        return call.args.version.first().equals(this.version)
-                && call.args.dataTable.first().equals(this.dataTable)
+        return call.args.inputManifest.first().equals(this.inputManifest)
                 && call.args.action.first().toString().equals(this.action)
     }
 

--- a/vars/checkReleaseNotes.groovy
+++ b/vars/checkReleaseNotes.groovy
@@ -7,44 +7,69 @@
  * compatible open source license.
  */
 import jenkins.ReleaseMetricsData
-import jenkins.ParseReleaseNotesMarkdownTable
 import utils.TemplateProcessor
 /**
  * Library to check and notify missing release notes.
+ * The release notes status is sourced from the opensearch_release_metrics index (release_notes boolean
+ * per component), the same index that backs the other release chores, instead of parsing a markdown table.
  * @param Map args = [:] args A map of the following parameters
- * @param args.version <required> - Release version. eg: 3.0.0
- * @param args.dataTable <required> - Markdown data table file in the format: https://github.com/opensearch-project/opensearch-build/issues/3747#issuecomment-2704366641 eg: ./table.md
+ * @param args.inputManifest <required> - Input manifest file(s) eg: [manifests/2.0.0/opensearch-2.0.0.yml, manifests/2.0.0/opensearch-dashboards-2.0.0.yml] .
  * @param args.action <optional> - Action to perform. Default is 'check'. Acceptable values are 'check' and 'notify'.
+ * @return List of component names missing release notes (empty when all components are ready).
  */
-void call(Map args = [:]) {
+List<String> call(Map args = [:]) {
+    def secret_metrics_cluster = [
+        [envVar: 'METRICS_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number'],
+        [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
+    ]
+
     String action = args.action ?: 'check'
+    def inputManifest = args.inputManifest
     // Parameter check
     validateParameters(args, action)
-    def version = args.version.tokenize('-')[0]
+    def manifestYaml = readYaml(file: inputManifest[0])
+    def version = manifestYaml.build.version.tokenize('-')[0]
 
-    def parsedContent = new ParseReleaseNotesMarkdownTable(readFile(args.dataTable)).parseReleaseNotesMarkdownTableRows()
-    def componentsWithFalseStatus = parsedContent.findAll { it['Status'] == 'False' }
-    echo("Components missing release notes: " + componentsWithFalseStatus.collect { it['Component'] })
+    List<String> componentsMissingReleaseNotes = []
 
-    if (action == 'notify' && !componentsWithFalseStatus.isEmpty()) {
-        echo "Notifying all the components with missing release notes."
-        notifyReleaseOwners(version, componentsWithFalseStatus)
+    inputManifest.each { inputManifestFile ->
+        def inputManifestObj = readYaml(file: inputManifestFile)
+        withSecrets(secrets: secret_metrics_cluster){
+            withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+                def metricsUrl = env.METRICS_HOST_URL
+                def awsAccessKey = env.AWS_ACCESS_KEY_ID
+                def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+                def awsSessionToken = env.AWS_SESSION_TOKEN
+
+                ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
+                inputManifestObj.components.each { component ->
+                    def releaseNotesExist = releaseMetricsData.getReleaseNotesStatus(component.name)
+                    if (releaseNotesExist == false) {
+                        componentsMissingReleaseNotes.add(component.name)
+                        if (action == 'notify') {
+                            notifyReleaseOwners(releaseMetricsData, component.name)
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    echo("Components missing release notes: ${componentsMissingReleaseNotes}")
+    return componentsMissingReleaseNotes
 }
 
 /**
  * Validates input parameters
  */
 private void validateParameters(Map args, String action) {
-    if (!args.version) {
-        error "Version parameter is required."
-    }
-
-    if (!args.dataTable || args.dataTable.isEmpty()) {
-        error "dataTable is required to get the content."
+    if (!args.inputManifest || args.inputManifest.isEmpty()) {
+        error "inputManifest parameter is required."
     } else {
-        if (!fileExists(args.dataTable)) {
-            error("Invalid path.Data Table file does not exist at ${args.dataTable}")
+        args.inputManifest.each { inputManifestFile ->
+            if (!fileExists(inputManifestFile)) {
+                error("Invalid path. Input manifest file does not exist at ${inputManifestFile}")
+            }
         }
     }
 
@@ -55,36 +80,18 @@ private void validateParameters(Map args, String action) {
 }
 
 /**
- * Notify components regarding the missing release notes by adding a comment to the release issue.
- * @param version: Release version.
- * @param componentsWithFalseStatus: Parsed content with status as False.
+ * Notify a component regarding the missing release notes by adding a comment to its release issue.
+ * @param releaseMetricsData: Data accessor used to look up the component's release issue.
+ * @param componentName: Component missing release notes.
  */
-private void notifyReleaseOwners(String version,def componentsWithFalseStatus) {
-    def secret_metrics_cluster = [
-        [envVar: 'METRICS_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number'],
-        [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
-    ]
-    componentsWithFalseStatus.each { component ->
-        withSecrets(secrets: secret_metrics_cluster){
-            withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
-                def metricsUrl = env.METRICS_HOST_URL
-                def awsAccessKey = env.AWS_ACCESS_KEY_ID
-                def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
-                def awsSessionToken = env.AWS_SESSION_TOKEN
-
-                ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
-                def componentName = component["Component"]
-                if(componentName != 'functionalTestDashboards') {
-                    def releaseIssueUrl = releaseMetricsData.getReleaseIssue("${componentName}", "component.keyword")
-                    def bindings = [
-                            BRANCH: component["Branch"]
-                    ]
-                    def ghCommentContent = new TemplateProcessor(this).process("release/missing-release-notes.md", bindings, "${WORKSPACE}")
-                    addComment(releaseIssueUrl, ghCommentContent)
-                }
-            }
-        }
+private void notifyReleaseOwners(ReleaseMetricsData releaseMetricsData, String componentName) {
+    def releaseIssueUrl = releaseMetricsData.getReleaseIssue(componentName, "component.keyword")
+    if (releaseIssueUrl == null || releaseIssueUrl == 'null') {
+        echo("No release issue found for ${componentName}. Skipping notification.")
+        return
     }
+    def ghCommentContent = new TemplateProcessor(this).process("release/missing-release-notes.md", [:], "${WORKSPACE}")
+    addComment(releaseIssueUrl, ghCommentContent)
 }
 
 /**

--- a/vars/checkReleaseNotes.groovy
+++ b/vars/checkReleaseNotes.groovy
@@ -27,13 +27,12 @@ List<String> call(Map args = [:]) {
     def inputManifest = args.inputManifest
     // Parameter check
     validateParameters(args, action)
-    def manifestYaml = readYaml(file: inputManifest[0])
-    def version = manifestYaml.build.version.tokenize('-')[0]
 
     List<String> componentsMissingReleaseNotes = []
 
     inputManifest.each { inputManifestFile ->
         def inputManifestObj = readYaml(file: inputManifestFile)
+        def version = inputManifestObj.build.version.tokenize('-')[0]
         withSecrets(secrets: secret_metrics_cluster){
             withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
                 def metricsUrl = env.METRICS_HOST_URL
@@ -44,7 +43,9 @@ List<String> call(Map args = [:]) {
                 ReleaseMetricsData releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
                 inputManifestObj.components.each { component ->
                     def releaseNotesExist = releaseMetricsData.getReleaseNotesStatus(component.name)
-                    if (releaseNotesExist == false) {
+                    // Conservative gate: only a confirmed `true` clears a component. A missing metrics doc
+                    // or a query failure returns null and is flagged as missing so releases never pass silently.
+                    if (releaseNotesExist != true) {
                         componentsMissingReleaseNotes.add(component.name)
                         if (action == 'notify') {
                             notifyReleaseOwners(releaseMetricsData, component.name)


### PR DESCRIPTION
### Description
Earlier checkReleaseNotes used the git parser to find the release notes in the component repositories. However, this data is already present in the metrics which gathers using the same method. This PR changes the information retrieval to metrics.
Also another important change is to change the return type from `void` to `List<String>` which will be used by OSCAR's entrance criteria check later.


### Issues Resolved
https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
