### PR TITLE
Fix code coverage query to fetch using component name and change return type

### DIFF
--- a/src/jenkins/ComponentRepoData.groovy
+++ b/src/jenkins/ComponentRepoData.groovy
@@ -64,7 +64,7 @@ class ComponentRepoData {
         return query.replace('"', '\\"')
     }
 
-    String getCodeCoverageQuery(String repository) {
+    String getCodeCoverageQuery(String component) {
         def queryMap = [
                 size   : 1,
                 _source: [
@@ -78,7 +78,7 @@ class ComponentRepoData {
                                 filter: [
                                         [
                                                 match_phrase: [
-                                                        "repository.keyword": "${repository}"
+                                                        "component.keyword": "${component}"
                                                 ]
                                         ],
                                         [
@@ -113,10 +113,13 @@ class ComponentRepoData {
         }
     }
 
-    def getCodeCoverage(String repository, String indexName) {
+    def getCodeCoverage(String component, String indexName) {
         try {
             def openSearchMetricsQuery = new OpenSearchMetricsQuery(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, indexName, script)
-            def jsonResponse = openSearchMetricsQuery.fetchMetrics(getCodeCoverageQuery(repository))
+            def jsonResponse = openSearchMetricsQuery.fetchMetrics(getCodeCoverageQuery(component))
+            if (!jsonResponse?.hits?.hits) {
+                return [:]
+            }
             return [
                     coverage: jsonResponse.hits.hits[0]._source.coverage,
                     state: jsonResponse.hits.hits[0]._source.state,
@@ -124,7 +127,7 @@ class ComponentRepoData {
                     url: jsonResponse.hits.hits[0]._source.url
             ]
         } catch (Exception e) {
-            this.script.println("Error fetching code coverage metrics for ${repository}: ${e.message}")
+            this.script.println("Error fetching code coverage metrics for ${component}: ${e.message}")
             return null
         }
     }

--- a/tests/jenkins/TestCheckCodeCoverage.groovy
+++ b/tests/jenkins/TestCheckCodeCoverage.groovy
@@ -118,7 +118,7 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
                       }
                     }
 '''
-        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
             return [stdout: coverageResponse, exitValue: 0]
         }
         helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/opensearch_release_metrics/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":\\"release_issue\\",\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}},{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
@@ -181,12 +181,43 @@ class TestCheckCodeCoverage extends BuildPipelineTest {
                   }
                 }
                     '''
-        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"repository.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
             return [stdout: coverageResponse, exitValue: 0]
         }
         this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'check'))
         runScript('tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile')
         assertThat(getCommands('echo', 'components'), hasItem("All components are reporting code coverage."))
+    }
+
+    @Test
+    void testCheckActionMissingCoverageDoc() {
+        addParam('ACTION', 'check')
+        def emptyCoverageResponse = '''
+                {
+                  "took": 3,
+                  "timed_out": false,
+                  "_shards": {
+                    "total": 5,
+                    "successful": 5,
+                    "skipped": 0,
+                    "failed": 0
+                  },
+                  "hits": {
+                    "total": {
+                      "value": 0,
+                      "relation": "eq"
+                    },
+                    "max_score": null,
+                    "hits": []
+                  }
+                }
+                    '''
+        helper.addShMock("""\n            set -e\n            set +x\n            curl -s -XGET \"sample.url/${codeCoverageIndex}/_search\" --aws-sigv4 \"aws:amz:us-east-1:es\" --user \"abc:xyz\" -H \"x-amz-security-token:sampleToken\" -H 'Content-Type: application/json' -d \"{\\"size\\":1,\\"_source\\":[\\"coverage\\",\\"branch\\",\\"state\\",\\"url\\"],\\"query\\":{\\"bool\\":{\\"filter\\":[{\\"match_phrase\\":{\\"component.keyword\\":\\"OpenSearch\\"}},{\\"match_phrase\\":{\\"version\\":\\"1.3.0\\"}}]}},\\"sort\\":[{\\"current_date\\":{\\"order\\":\\"desc\\"}}]}\" | jq '.'\n        """) { script ->
+            return [stdout: emptyCoverageResponse, exitValue: 0]
+        }
+        this.registerLibTester(new CheckCodeCoverageLibTester(['tests/data/opensearch-1.3.0.yml'], 'check'))
+        runScript('tests/jenkins/jobs/CheckCodeCoverage_Jenkinsfile')
+        assertThat(getCommands('echo', 'Components missing code coverage'), hasItem(containsString('OpenSearch')))
     }
 
     @Test

--- a/tests/jenkins/TestComponentRepoData.groovy
+++ b/tests/jenkins/TestComponentRepoData.groovy
@@ -162,7 +162,7 @@ class TestComponentRepoData {
                                 filter: [
                                         [
                                                 match_phrase: [
-                                                        "repository.keyword": "OpenSearch"
+                                                        "component.keyword": "OpenSearch"
                                                 ]
                                         ],
                                         [
@@ -237,6 +237,39 @@ class TestComponentRepoData {
         ]
         def result = componentRepoData.getCodeCoverage('OpenSearch', 'opensearch-code-coverage-metrics')
         assert  result == expectedOutput
+    }
+
+    @Test
+    void testGetCodeCoverageNoHits() {
+        script = new Expando()
+        script.sh = { Map args ->
+            if (args.containsKey("script")) {
+                return """
+                    {
+                      "took": 2,
+                      "timed_out": false,
+                      "_shards": {
+                        "total": 5,
+                        "successful": 5,
+                        "skipped": 0,
+                        "failed": 0
+                      },
+                      "hits": {
+                        "total": {
+                          "value": 0,
+                          "relation": "eq"
+                        },
+                        "max_score": null,
+                        "hits": []
+                      }
+                    }
+                """
+            }
+            return ""
+        }
+        componentRepoData = new ComponentRepoData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, script)
+        def result = componentRepoData.getCodeCoverage('OpenSearch', 'opensearch-code-coverage-metrics')
+        assert result == [:]
     }
 
     @Test

--- a/vars/checkCodeCoverage.groovy
+++ b/vars/checkCodeCoverage.groovy
@@ -15,8 +15,9 @@ import utils.TemplateProcessor
  * @param Map args = [:] args A map of the following parameters
  * @param args.inputManifest <required> - Array of input manifest(s). eg: ["manifests/2.0.0/opensearch-2.0.0.yml", "manifests/2.0.0/opensearch-dashboards-2.0.0.yml"]
  * @param args.action <optional> - Action to perform. Default is 'check'. Acceptable values are 'check' and 'notify'.
+ * @return List of component names missing code coverage (empty when all components are reporting coverage).
  */
-void call(Map args = [:]) {
+List<String> call(Map args = [:]) {
     def secret_metrics_cluster = [
         [envVar: 'METRICS_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number'],
         [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
@@ -47,11 +48,15 @@ void call(Map args = [:]) {
                 def releaseMetricsData = new ReleaseMetricsData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, version, this)
                 inputManifestObj.components.each { component ->
                     String repoName = component.repository.toString().split('/')[-1].replace('.git', '')
-                    def codeCoverage = componentRepoData.getCodeCoverage(repoName, codeCoverageIndex)
+                    def codeCoverage = componentRepoData.getCodeCoverage(component.name, codeCoverageIndex)
                     def releaseIssue = releaseMetricsData.getReleaseIssue(repoName)
-                    if (codeCoverage != null && !codeCoverage.isEmpty() && codeCoverage.state == "no-coverage") { // Also equivalent to codeCoverage.coverage == 0
-                        componentsMissingCodeCoverageWithUrl[component.name] = codeCoverage.url
-                        if (args.action == 'notify') {
+                    // Conservative gate: a component clears only when coverage is confirmed reporting.
+                    // A null/empty result (query failure or no metrics doc) or an explicit "no-coverage"
+                    // state (equivalent to codeCoverage.coverage == 0) flags the component as missing so
+                    // releases never pass silently.
+                    if (codeCoverage == null || codeCoverage.isEmpty() || codeCoverage.state == "no-coverage") {
+                        componentsMissingCodeCoverageWithUrl[component.name] = codeCoverage?.url
+                        if (args.action == 'notify' && codeCoverage?.state == "no-coverage") {
                             notifyReleaseOwners(component.name, codeCoverage, releaseIssue)
                         }
                     }
@@ -65,6 +70,8 @@ void call(Map args = [:]) {
     } else {
         echo('All components are reporting code coverage.')
     }
+
+    return componentsMissingCodeCoverageWithUrl.keySet().toList()
 }
 
 /**


### PR DESCRIPTION
### Description
Fix code coverage query to fetch using component name and change return type
Also addressed the bug in https://github.com/opensearch-project/opensearch-metrics/pull/169

### Issues Resolved
Part of https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
