### PR TITLE
Add a library to check unpatched vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.7.1'
+String version = '13.8.0'
 
 task updateVersion {
     doLast {

--- a/src/jenkins/SecurityAdvisoryData.groovy
+++ b/src/jenkins/SecurityAdvisoryData.groovy
@@ -1,0 +1,198 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+import groovy.json.JsonOutput
+import utils.SecurityAdvisoriesQuery
+
+/**
+ * Reads unpatched-vulnerability data from the security advisories OpenSearch cluster.
+ *
+ * Mirrors ReleaseStateData in shape (a thin, testable wrapper over a query client), but reads a
+ * different, read-only cluster. The data supports the release exit criterion "no unpatched
+ * vulnerabilities of medium or higher severity that have been publicly known for more than 60 days":
+ *
+ *   1. resolveVersionTag  - map a release version to the branch tag the scans are keyed on
+ *                           (e.g. 3.8.0 / 3.8 -> origin/3.8, main -> origin/main). Never the exact
+ *                           3.8.0 tag, which only exists after release.
+ *   2. getLatestScansIndex - resolve the newest concrete scans-NNNNNN index.
+ *   3. getOpenVulnerabilityIds - the open (non-excluded) CVE ids scanned for that branch tag.
+ *   4. getAgedMediumOrHigherAdvisories - of those ids, the ones the advisories index says are
+ *                           medium/high/critical AND were published on or before the cutoff.
+ *
+ * Every method returns concrete data or throws; callers (checkUnpatchedVulnerabilities) translate a
+ * throw into an 'unknown' criterion so a failed lookup never reads as a clean release.
+ */
+class SecurityAdvisoryData {
+
+    /** Severities that count toward the criterion (medium or higher). */
+    static final List<String> BLOCKING_SEVERITIES = ['CRITICAL', 'HIGH', 'MEDIUM']
+
+    /** The advisories index (an alias pointing at the current advisories index). */
+    static final String ADVISORIES_INDEX = 'advisories'
+
+    /**
+     * Max CVE ids per advisories terms lookup. OpenSearch's default max_terms_count is 65536; a
+     * conservative batch keeps payloads small and mirrors the security_advisories agent.
+     */
+    private static final int ADVISORIES_BATCH_SIZE = 1000
+
+    /** Page size for scan/advisory searches, matching the agent's default query size. */
+    private static final int QUERY_SIZE = 1000
+
+    def script
+    SecurityAdvisoriesQuery advisoriesQuery
+
+    SecurityAdvisoryData(String advisoriesUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, def script) {
+        this.script = script
+        this.advisoriesQuery = new SecurityAdvisoriesQuery(advisoriesUrl, awsAccessKey, awsSecretKey, awsSessionToken, script)
+    }
+
+    /**
+     * Maps a release version to the canonical branch tag the scans are keyed on (project.tag).
+     * Scans store release branches as origin/{major}.{minor}; the exact three-part tag (3.8.0) is
+     * only created at release time, so it is never used here.
+     *
+     *   - already origin/-prefixed -> returned as-is
+     *   - main / latest            -> origin/main
+     *   - 3.8.0 (three-part)       -> origin/3.8
+     *   - 3.8   (two-part)         -> origin/3.8
+     *   - anything else            -> returned as-is
+     */
+    static String resolveVersionTag(String version) {
+        if (!version) {
+            return version
+        }
+        if (version.startsWith('origin/')) {
+            return version
+        }
+        if (version.toLowerCase() in ['main', 'latest']) {
+            return 'origin/main'
+        }
+        def parts = version.tokenize('.')
+        if (parts.size() >= 2 && parts[0].isInteger() && parts[1].isInteger()) {
+            return "origin/${parts[0]}.${parts[1]}"
+        }
+        return version
+    }
+
+    /**
+     * Resolves the most recently created scans index. Scan indices are named scans-NNNNNN, so a
+     * cluster-wide search for docs that have timestamp.scan, sorted by _index descending, returns
+     * the highest-numbered (newest) index first.
+     *
+     * @return the concrete scans index name (e.g. scans-000164)
+     * @throws RuntimeException if no scans index can be resolved
+     */
+    String getLatestScansIndex() {
+        def query = shellEscape([
+            size   : 1,
+            query  : [exists: [field: 'timestamp.scan']],
+            sort   : [['_index': [order: 'desc']]],
+            _source: false
+        ])
+        def response = advisoriesQuery.searchAllIndices(query)
+        def hits = response?.hits?.hits
+        if (!hits) {
+            throw new RuntimeException('Could not resolve latest scans index: no scan documents found.')
+        }
+        return hits[0]._index
+    }
+
+    /**
+     * Returns the open (non-excluded) CVE ids scanned for the branch tag, keyed by project name so a
+     * blocking CVE is attributable to a component. Collapsing on project.name keeps each project's
+     * latest scan. Projects with no open vulnerabilities are omitted.
+     *
+     * @param scansIndex the concrete scans index (from getLatestScansIndex)
+     * @param branchTag  the resolved project.tag (from resolveVersionTag)
+     * @return map of project name -> sorted list of its open CVE ids
+     */
+    Map<String, List<String>> getOpenVulnerabilitiesByProject(String scansIndex, String branchTag) {
+        // project.name is carried through so results can be scoped to release components once that
+        // filter lands upstream (security-advisories#132).
+        def query = shellEscape([
+            size    : QUERY_SIZE,
+            sort    : [['timestamp.scan': [order: 'desc']]],
+            collapse: [field: 'project.name'],
+            _source : ['project.name', 'vulnerabilities.id', 'vulnerabilities.excluded'],
+            query   : [bool: [filter: [[term: ['project.tag': branchTag]]]]]
+        ])
+        def response = advisoriesQuery.search(scansIndex, query)
+        def hits = response?.hits?.hits ?: []
+        Map<String, List<String>> vulnerabilitiesByProject = [:]
+        hits.each { hit ->
+            String projectName = hit._source?.project?.name
+            if (!projectName) {
+                return
+            }
+            Set<String> openCves = [] as Set
+            (hit._source?.vulnerabilities ?: []).each { vuln ->
+                if (!vuln.excluded && vuln.id) {
+                    openCves.add(vuln.id)
+                }
+            }
+            if (openCves) {
+                vulnerabilitiesByProject[projectName] = openCves.toList().sort()
+            }
+        }
+        return vulnerabilitiesByProject
+    }
+
+    /**
+     * Of the given CVE ids, returns those the advisories index reports as medium/high/critical AND
+     * published on or before the cutoff (i.e. publicly known long enough to breach the age window).
+     *
+     * Matches on the advisory aliases field rather than id: advisory re-keying can change id while
+     * aliases retains every known identifier, so aliases is the resilient join key (same rationale
+     * as the security_advisories agent). The lookup is batched to stay within OpenSearch term limits.
+     *
+     * @param cveIds    open CVE ids to check (the flattened values of getOpenVulnerabilitiesByProject)
+     * @param cutoffIso publish-age cutoff as an ISO-8601 string; advisories with
+     *                  timestamp.publish <= cutoff breach the window
+     * @return the subset of cveIds that are aged and medium-or-higher, as a sorted list
+     */
+    List<String> getAgedMediumOrHigherAdvisories(List<String> cveIds, String cutoffIso) {
+        if (!cveIds) {
+            return []
+        }
+        Set<String> matched = [] as Set
+        cveIds.collate(ADVISORIES_BATCH_SIZE).each { batch ->
+            Set<String> batchSet = batch as Set
+            def query = shellEscape([
+                size   : batch.size(),
+                _source: ['aliases'],
+                query  : [bool: [filter: [
+                    [terms: [aliases: batch]],
+                    [range: ['timestamp.publish': [lte: cutoffIso]]],
+                    [terms: [severity: BLOCKING_SEVERITIES]]
+                ]]]
+            ])
+            def response = advisoriesQuery.search(ADVISORIES_INDEX, query)
+            def hits = response?.hits?.hits ?: []
+            hits.each { hit ->
+                (hit._source?.aliases ?: []).each { alias ->
+                    if (batchSet.contains(alias)) {
+                        matched.add(alias)
+                    }
+                }
+            }
+        }
+        return matched.toList().sort()
+    }
+
+    /**
+     * Serializes a query map to JSON and escapes the double quotes so it survives being passed
+     * inside the double-quoted curl -d "..." argument (same convention as ReleaseStateData).
+     */
+    private static String shellEscape(Map queryMap) {
+        return JsonOutput.toJson(queryMap).replace('"', '\\"')
+    }
+}

--- a/src/jenkins/SecurityAdvisoryData.groovy
+++ b/src/jenkins/SecurityAdvisoryData.groovy
@@ -38,6 +38,9 @@ class SecurityAdvisoryData {
     /** The advisories index (an alias pointing at the current advisories index). */
     static final String ADVISORIES_INDEX = 'advisories'
 
+    /** The index of project-scoped advisory exemptions, edited live ahead of the next scan. */
+    static final String IGNORED_ADVISORIES_INDEX = 'ignored-advisories'
+
     /**
      * Max CVE ids per advisories terms lookup. OpenSearch's default max_terms_count is 65536; a
      * conservative batch keeps payloads small and mirrors the security_advisories agent.
@@ -107,22 +110,26 @@ class SecurityAdvisoryData {
     }
 
     /**
-     * Returns the open (non-excluded) CVE ids scanned for the branch tag, keyed by project name so a
-     * blocking CVE is attributable to a component. Collapsing on project.name keeps each project's
-     * latest scan. Projects with no open vulnerabilities are omitted.
+     * Returns the open (non-excluded) vulnerability identifiers scanned for the branch tag, keyed by
+     * project name so a blocking vulnerability is attributable to a component. Collapsing on
+     * project.name keeps each project's latest scan (sorted by commit time so a re-scan of older code
+     * does not win). Every identifier a scan carries per vulnerability (id plus aliases) is collected
+     * so the join to advisory aliases survives CVE/GHSA re-keying. Live, project-scoped exemptions
+     * from ignored-advisories are applied on top of the scan's own excluded flag.
      *
      * @param scansIndex the concrete scans index (from getLatestScansIndex)
      * @param branchTag  the resolved project.tag (from resolveVersionTag)
-     * @return map of project name -> sorted list of its open CVE ids
+     * @return map of project name -> sorted list of its open vulnerability identifiers
      */
     Map<String, List<String>> getOpenVulnerabilitiesByProject(String scansIndex, String branchTag) {
+        Map<String, Set<String>> exemptedByProject = getExemptedAliasesByProject(branchTag)
         // project.name is carried through so results can be scoped to release components once that
         // filter lands upstream (security-advisories#132).
         def query = shellEscape([
             size    : QUERY_SIZE,
-            sort    : [['timestamp.scan': [order: 'desc']]],
+            sort    : [['timestamp.commit': [order: 'desc']], ['timestamp.scan': [order: 'desc']]],
             collapse: [field: 'project.name'],
-            _source : ['project.name', 'vulnerabilities.id', 'vulnerabilities.excluded'],
+            _source : ['project.name', 'vulnerabilities.id', 'vulnerabilities.aliases', 'vulnerabilities.excluded'],
             query   : [bool: [filter: [[term: ['project.tag': branchTag]]]]]
         ])
         def response = advisoriesQuery.search(scansIndex, query)
@@ -133,10 +140,17 @@ class SecurityAdvisoryData {
             if (!projectName) {
                 return
             }
+            Set<String> exemptedAliases = exemptedByProject[projectName] ?: ([] as Set)
             Set<String> openCves = [] as Set
             (hit._source?.vulnerabilities ?: []).each { vuln ->
-                if (!vuln.excluded && vuln.id) {
-                    openCves.add(vuln.id)
+                Set<String> identifiers = [] as Set
+                if (vuln.id) {
+                    identifiers.add(vuln.id)
+                }
+                (vuln.aliases ?: []).each { identifiers.add(it) }
+                boolean exempted = vuln.excluded || identifiers.any { exemptedAliases.contains(it) }
+                if (!exempted) {
+                    openCves.addAll(identifiers)
                 }
             }
             if (openCves) {
@@ -144,6 +158,36 @@ class SecurityAdvisoryData {
             }
         }
         return vulnerabilitiesByProject
+    }
+
+    /**
+     * Returns the exempted advisory aliases for the branch tag, keyed by project name, read live from
+     * ignored-advisories. An exemption applies when its tag matches the branch tag or it is a
+     * project-wide exemption (tag null or absent), matching the website's project/tag and project/*
+     * keys. Keying by project ensures an exemption on one component never suppresses another's.
+     */
+    private Map<String, Set<String>> getExemptedAliasesByProject(String branchTag) {
+        def query = shellEscape([
+            size   : QUERY_SIZE,
+            _source: ['aliases', 'project', 'tag'],
+            query  : [bool: [should: [
+                [term: [tag: branchTag]],
+                [bool: [must_not: [[exists: [field: 'tag']]]]]
+            ], minimum_should_match: 1]]
+        ])
+        def response = advisoriesQuery.search(IGNORED_ADVISORIES_INDEX, query)
+        def hits = response?.hits?.hits ?: []
+        Map<String, Set<String>> exemptedByProject = [:]
+        hits.each { hit ->
+            String projectName = hit._source?.project
+            String tag = hit._source?.tag
+            if (!projectName || (tag && tag != branchTag)) {
+                return
+            }
+            Set<String> aliases = exemptedByProject.get(projectName, [] as Set)
+            (hit._source?.aliases ?: []).each { aliases.add(it) }
+        }
+        return exemptedByProject
     }
 
     /**

--- a/src/utils/SecurityAdvisoriesQuery.groovy
+++ b/src/utils/SecurityAdvisoriesQuery.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils
+
+import groovy.json.JsonSlurperClassic
+
+/**
+ * SigV4-signed read client for the security advisories OpenSearch cluster.
+ *
+ * This is a separate cluster from the metrics cluster (different endpoint and credentials), so it
+ * has its own client rather than reusing OpenSearchMetricsQuery. It intentionally exposes reads
+ * only: the release-readiness checks consume advisory/scan data but never write to this cluster.
+ *
+ * The target index is passed per query rather than bound to the instance, because callers span
+ * several indices (a cluster-wide search to resolve the latest scans index, then that scans index,
+ * then the advisories index) with a single client.
+ */
+class SecurityAdvisoriesQuery {
+    private static final String SIGV4_REGION = 'us-east-1'
+
+    String advisoriesUrl
+    String awsAccessKey
+    String awsSecretKey
+    String awsSessionToken
+    def script
+
+    SecurityAdvisoriesQuery(String advisoriesUrl, String awsAccessKey, String awsSecretKey, String awsSessionToken, def script) {
+        this.advisoriesUrl = advisoriesUrl
+        this.awsAccessKey = awsAccessKey
+        this.awsSecretKey = awsSecretKey
+        this.awsSessionToken = awsSessionToken
+        this.script = script
+    }
+
+    /**
+     * Runs a search against an explicit index.
+     * @param targetIndex the index to search
+     * @param query the SigV4-shell-escaped query body
+     */
+    def search(String targetIndex, String query) {
+        this.script.println("Querying advisories index '${targetIndex}' with query: ${query}")
+        def response = runSearch("${advisoriesUrl}/${targetIndex}/_search", query)
+        this.script.println("Advisories index '${targetIndex}' returned ${response?.hits?.hits?.size() ?: 0} hit(s).")
+        return response
+    }
+
+    /**
+     * Runs a cluster-wide search (GET /_search with no index prefix), used to resolve which
+     * concrete scan index is the most recent across all indices.
+     * @param query the SigV4-shell-escaped query body
+     */
+    def searchAllIndices(String query) {
+        this.script.println("Querying advisories cluster (all indices) with query: ${query}")
+        def response = runSearch("${advisoriesUrl}/_search", query)
+        this.script.println("Advisories cluster search returned ${response?.hits?.hits?.size() ?: 0} hit(s).")
+        return response
+    }
+
+    // The cluster endpoint is a secret, so the URL itself is never logged (callers log the index
+    // and query instead). Issues the signed request, then fails loudly on an empty body or a cluster
+    // error response so a failed query throws (and the caller records the criterion as unknown)
+    // instead of parsing to an error object that silently looks like zero hits. An empty hits list
+    // is a valid, non-error response and is returned as-is.
+    private def runSearch(String url, String query) {
+        def rawResponse = script.sh(
+            script: """
+            set -e
+            set +x
+            curl -s -XGET "${url}" ${curlAuthArgs()} -H 'Content-Type: application/json' -d "${query}" | jq '.'
+        """,
+        returnStdout: true
+        ).trim()
+        if (!rawResponse) {
+            throw new RuntimeException('Advisories cluster returned an empty response.')
+        }
+        def response = new JsonSlurperClassic().parseText(rawResponse)
+        if (response?.error) {
+            throw new RuntimeException("Advisories cluster query failed: ${response.error}")
+        }
+        return response
+    }
+
+    /**
+     * Common SigV4 authentication arguments shared by every cluster request.
+     * Keeping this private ensures credentials and the signing region are defined once.
+     */
+    private String curlAuthArgs() {
+        return "--aws-sigv4 \"aws:amz:${SIGV4_REGION}:es\" --user \"${awsAccessKey}:${awsSecretKey}\" -H \"x-amz-security-token:${awsSessionToken}\""
+    }
+}

--- a/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
+++ b/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.MatcherAssert.assertThat
+
+class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
+
+    // Response for the scans index and the advisories lookup, overridable per test.
+    private String scansResponse
+    private String advisoriesResponse
+    // Captures every query body sent to the cluster, keyed by the index it targeted.
+    private List<Map> searches
+
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        searches = []
+        binding.setVariable('ADVISORIES_HOST_ACCOUNT', 'ADVISORIES_HOST_ACCOUNT')
+        binding.setVariable('env', [
+                'ADVISORIES_HOST_URL'  : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken'
+        ])
+        helper.registerAllowedMethod('withSecrets', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+
+        // Two projects, three open (non-excluded) CVEs; CVE-2 is excluded and must be dropped.
+        scansResponse = '''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"id": "CVE-1", "excluded": false},
+                        {"id": "CVE-2", "excluded": true}
+                      ]
+                    }
+                  },
+                  {
+                    "_source": {
+                      "project": {"name": "SQL"},
+                      "vulnerabilities": [
+                        {"id": "CVE-3", "excluded": false},
+                        {"id": "CVE-4", "excluded": false}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        '''
+        // Of the open CVEs, CVE-1 and CVE-3 are aged medium-or-higher; CVE-4 is not returned.
+        advisoriesResponse = '''
+            {
+              "hits": {
+                "hits": [
+                  {"_source": {"aliases": ["CVE-1"]}},
+                  {"_source": {"aliases": ["CVE-3"]}}
+                ]
+              }
+            }
+        '''
+
+        // Route each cluster search by the index in its URL: the index-less _search resolves the
+        // latest scans index, scans-* returns open vulnerabilities, advisories returns aged CVEs.
+        helper.registerAllowedMethod('sh', [Map.class], { Map args ->
+            String s = args.script
+            def indexMatcher = (s =~ /sample\.url\/([^\/]*)\/?_search/)
+            String index = indexMatcher ? indexMatcher[0][1] : null
+            def bodyMatcher = (s =~ /-d "(.*)" \| jq/)
+            searches.add([index: index, body: bodyMatcher ? bodyMatcher[0][1] : null])
+            if (index == null || index.isEmpty()) {
+                return '{"hits":{"hits":[{"_index":"scans-000335"}]}}'
+            }
+            if (index.startsWith('scans-')) {
+                return scansResponse
+            }
+            return advisoriesResponse
+        })
+    }
+
+    @Test
+    void testReturnsBlockingCvesKeyedByProject() {
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        // The 60-day window is measured back from the release date (2026-08-15 -> 2026-06-16).
+        assertThat(getCommands('echo', 'published on or before'),
+                hasItem('Checking unpatched medium-or-higher vulnerabilities for origin/3.8 (published on or before 2026-06-16T23:59:59.999Z).'))
+        // CVE-1 -> Alerting, CVE-3 -> SQL; CVE-2 (excluded) and CVE-4 (not aged) are absent.
+        assertThat(getCommands('echo', 'older than the 60-day window'),
+                hasItem('Unpatched medium-or-higher vulnerabilities older than the 60-day window: [Alerting:[CVE-1], SQL:[CVE-3]]'))
+    }
+
+    @Test
+    void testReleaseBranchTagIsFilteredOnTheScansSearch() {
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        def scansSearch = searches.find { it.index?.startsWith('scans-') }
+        assert scansSearch != null
+        assert scansSearch.body.contains('project.tag')
+        assert scansSearch.body.contains('origin/3.8')
+    }
+
+    @Test
+    void testCriterionMetWhenNoAgedAdvisories() {
+        // No advisory is aged medium-or-higher, so the criterion is met (empty map).
+        advisoriesResponse = '{"hits":{"hits":[]}}'
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        assertThat(getCommands('echo', 'No unpatched'),
+                hasItem('No unpatched medium-or-higher vulnerabilities older than the 60-day window.'))
+    }
+
+    def getCommands(String methodName, String searchString) {
+        def matches = []
+        helper.callStack.findAll { call -> call.methodName == methodName }.each { call ->
+            def args = callArgsToString(call)
+            if (args.contains(searchString)) {
+                matches.add(args)
+            }
+        }
+        return matches
+    }
+}

--- a/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
+++ b/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
@@ -93,6 +93,9 @@ class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
             if (index == null || index.isEmpty()) {
                 return '{"hits":{"hits":[{"_index":"scans-000335"}]}}'
             }
+            if (index == 'ignored-advisories') {
+                return '{"hits":{"hits":[]}}'
+            }
             if (index.startsWith('scans-')) {
                 return scansResponse
             }

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -144,6 +144,39 @@ class TestSecurityAdvisoryData {
     }
 
     @Test
+    void testGetOpenVulnerabilitiesByProjectSkipsHitsWithoutProjectNameAndVulnsWithoutId() {
+        // A scan hit with no project.name is skipped, and a vulnerability with no id is ignored
+        // (only the well-formed CVE on the named project survives).
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "vulnerabilities": [
+                        {"id": "CVE-9", "excluded": false}
+                      ]
+                    }
+                  },
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"excluded": false},
+                        {"id": "CVE-1", "excluded": false}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        ''']
+        def byProject = advisoryData.getOpenVulnerabilitiesByProject('scans-000335', 'origin/3.8')
+        assertEquals(['Alerting'], byProject.keySet().toList())
+        assertEquals(['CVE-1'], byProject['Alerting'])
+    }
+
+    @Test
     void testGetOpenVulnerabilitiesByProjectOmitsProjectsWithNoOpenCves() {
         // A project whose only vulnerability is excluded is left out of the map entirely.
         responses = ['''
@@ -187,6 +220,23 @@ class TestSecurityAdvisoryData {
         assertTrue(queryBodies[0].contains('severity'))
         assertTrue(queryBodies[0].contains('timestamp.publish'))
         assertTrue(queryBodies[0].contains('2026-06-01T23:59:59.999Z'))
+    }
+
+    @Test
+    void testGetAgedMediumOrHigherAdvisoriesIgnoresAliasesOutsideTheQueriedBatch() {
+        // An advisory hit can carry extra aliases (e.g. GHSA ids) alongside the CVE we asked about;
+        // only aliases actually in the queried batch are kept, the rest are ignored.
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {"_source": {"aliases": ["CVE-1", "GHSA-xxxx-yyyy-zzzz"]}}
+                ]
+              }
+            }
+        ''']
+        def aged = advisoryData.getAgedMediumOrHigherAdvisories(['CVE-1'], '2026-06-01T23:59:59.999Z')
+        assertEquals(['CVE-1'], aged)
     }
 
     @Test

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -28,21 +28,26 @@ class TestSecurityAdvisoryData {
     private List<String> searchedIndices
     private List<String> queryBodies
     private List<String> responses
+    private String ignoredAdvisoriesResponse
 
     @Before
     void setUp() {
         searchedIndices = []
         queryBodies = []
         responses = []
+        ignoredAdvisoriesResponse = '{"hits":{"hits":[]}}'
         script = new Expando()
         script.println = { msg -> }
         script.sh = { Map args ->
             String s = args.script
             def matcher = (s =~ /${advisoriesUrl}\/([^\/]*)\/?_search/)
-            searchedIndices.add(matcher ? matcher[0][1] : null)
+            String index = matcher ? matcher[0][1] : null
+            searchedIndices.add(index)
             def bodyMatcher = (s =~ /-d "(.*)" \| jq/)
             queryBodies.add(bodyMatcher ? bodyMatcher[0][1] : null)
-            // Hand back responses in FIFO order; default to empty hits if none queued.
+            if (index == SecurityAdvisoryData.IGNORED_ADVISORIES_INDEX) {
+                return ignoredAdvisoriesResponse
+            }
             return responses ? responses.remove(0) : '{"hits":{"hits":[]}}'
         }
         advisoryData = new SecurityAdvisoryData(advisoriesUrl, awsAccessKey, awsSecretKey, awsSessionToken, script)
@@ -113,9 +118,76 @@ class TestSecurityAdvisoryData {
         assertEquals(['CVE-1', 'CVE-2'], byProject['Alerting'])
         assertEquals(['CVE-3'], byProject['SQL'])
         // The scans index is searched, and the branch tag is filtered on project.tag.
-        assertEquals('scans-000335', searchedIndices[0])
-        assertTrue(queryBodies[0].contains('project.tag'))
-        assertTrue(queryBodies[0].contains('origin/3.8'))
+        int scansSearch = searchedIndices.indexOf('scans-000335')
+        assertTrue(scansSearch >= 0)
+        assertTrue(queryBodies[scansSearch].contains('project.tag'))
+        assertTrue(queryBodies[scansSearch].contains('origin/3.8'))
+        assertTrue(queryBodies[scansSearch].contains('timestamp.commit'))
+    }
+
+    @Test
+    void testGetOpenVulnerabilitiesByProjectCollectsAliasesAlongsideId() {
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"id": "CVE-1", "aliases": ["GHSA-xxxx-yyyy-zzzz"], "excluded": false}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        ''']
+        def byProject = advisoryData.getOpenVulnerabilitiesByProject('scans-000335', 'origin/3.8')
+        assertEquals(['CVE-1', 'GHSA-xxxx-yyyy-zzzz'], byProject['Alerting'])
+    }
+
+    @Test
+    void testGetOpenVulnerabilitiesByProjectHonorsLiveExemptionsForItsOwnProject() {
+        // Alerting has a live exemption for CVE-1 (added after the last scan, so still flagged in the
+        // scan); SQL shares that exemption alias but it must not suppress SQL's own CVE-1.
+        ignoredAdvisoriesResponse = '''
+            {
+              "hits": {
+                "hits": [
+                  {"_source": {"project": "Alerting", "tag": "origin/3.8", "aliases": ["CVE-1"]}}
+                ]
+              }
+            }
+        '''
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"id": "CVE-1", "excluded": false},
+                        {"id": "CVE-2", "excluded": false}
+                      ]
+                    }
+                  },
+                  {
+                    "_source": {
+                      "project": {"name": "SQL"},
+                      "vulnerabilities": [
+                        {"id": "CVE-1", "excluded": false}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        ''']
+        def byProject = advisoryData.getOpenVulnerabilitiesByProject('scans-000335', 'origin/3.8')
+        assertEquals(['CVE-2'], byProject['Alerting'])
+        assertEquals(['CVE-1'], byProject['SQL'])
     }
 
     @Test

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -1,0 +1,213 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import org.junit.Before
+import org.junit.Test
+import jenkins.SecurityAdvisoryData
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.fail
+
+class TestSecurityAdvisoryData {
+    private final String advisoriesUrl = 'http://example.com'
+    private final String awsAccessKey = 'testAccessKey'
+    private final String awsSecretKey = 'testSecretKey'
+    private final String awsSessionToken = 'testSessionToken'
+
+    private SecurityAdvisoryData advisoryData
+    private def script
+    // Each search's target index in call order, and the queued responses to hand back in call order.
+    private List<String> searchedIndices
+    private List<String> queryBodies
+    private List<String> responses
+
+    @Before
+    void setUp() {
+        searchedIndices = []
+        queryBodies = []
+        responses = []
+        script = new Expando()
+        script.println = { msg -> }
+        script.sh = { Map args ->
+            String s = args.script
+            def matcher = (s =~ /${advisoriesUrl}\/([^\/]*)\/?_search/)
+            searchedIndices.add(matcher ? matcher[0][1] : null)
+            def bodyMatcher = (s =~ /-d "(.*)" \| jq/)
+            queryBodies.add(bodyMatcher ? bodyMatcher[0][1] : null)
+            // Hand back responses in FIFO order; default to empty hits if none queued.
+            return responses ? responses.remove(0) : '{"hits":{"hits":[]}}'
+        }
+        advisoryData = new SecurityAdvisoryData(advisoriesUrl, awsAccessKey, awsSecretKey, awsSessionToken, script)
+    }
+
+    @Test
+    void testResolveVersionTagMapsVersionsToBranchTags() {
+        assertEquals('origin/3.8', SecurityAdvisoryData.resolveVersionTag('3.8.0'))
+        assertEquals('origin/3.8', SecurityAdvisoryData.resolveVersionTag('3.8'))
+        assertEquals('origin/main', SecurityAdvisoryData.resolveVersionTag('main'))
+        assertEquals('origin/main', SecurityAdvisoryData.resolveVersionTag('latest'))
+        assertEquals('origin/main', SecurityAdvisoryData.resolveVersionTag('LATEST'))
+        // An already-resolved tag is passed through unchanged.
+        assertEquals('origin/2.19', SecurityAdvisoryData.resolveVersionTag('origin/2.19'))
+        // Non-numeric / unrecognised values pass through rather than being mangled.
+        assertEquals('some-branch', SecurityAdvisoryData.resolveVersionTag('some-branch'))
+        assertEquals(null, SecurityAdvisoryData.resolveVersionTag(null))
+    }
+
+    @Test
+    void testGetLatestScansIndexReturnsHighestNumberedIndex() {
+        // The cluster-wide search sorts _index desc, so the first hit is the newest scans index.
+        responses = ['{"hits":{"hits":[{"_index":"scans-000335"}]}}']
+        assertEquals('scans-000335', advisoryData.getLatestScansIndex())
+        // Resolved via a cluster-wide search (no index prefix in the URL).
+        assertEquals('', searchedIndices[0])
+    }
+
+    @Test
+    void testGetLatestScansIndexThrowsWhenNoScanDocuments() {
+        responses = ['{"hits":{"hits":[]}}']
+        try {
+            advisoryData.getLatestScansIndex()
+            fail('Expected RuntimeException when no scan documents exist')
+        } catch (RuntimeException e) {
+            assertTrue(e.message.contains('Could not resolve latest scans index'))
+        }
+    }
+
+    @Test
+    void testGetOpenVulnerabilitiesByProjectKeysOpenCvesByProjectName() {
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"id": "CVE-1", "excluded": false},
+                        {"id": "CVE-2", "excluded": false}
+                      ]
+                    }
+                  },
+                  {
+                    "_source": {
+                      "project": {"name": "SQL"},
+                      "vulnerabilities": [
+                        {"id": "CVE-3", "excluded": false}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        ''']
+        def byProject = advisoryData.getOpenVulnerabilitiesByProject('scans-000335', 'origin/3.8')
+        assertEquals(['CVE-1', 'CVE-2'], byProject['Alerting'])
+        assertEquals(['CVE-3'], byProject['SQL'])
+        // The scans index is searched, and the branch tag is filtered on project.tag.
+        assertEquals('scans-000335', searchedIndices[0])
+        assertTrue(queryBodies[0].contains('project.tag'))
+        assertTrue(queryBodies[0].contains('origin/3.8'))
+    }
+
+    @Test
+    void testGetOpenVulnerabilitiesByProjectExcludesExcludedCvesAndDedupes() {
+        // Excluded CVEs are dropped; the same open CVE listed across sub-components is deduped to one.
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"id": "CVE-1", "excluded": false},
+                        {"id": "CVE-1", "excluded": false},
+                        {"id": "CVE-2", "excluded": true}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        ''']
+        def byProject = advisoryData.getOpenVulnerabilitiesByProject('scans-000335', 'origin/3.8')
+        assertEquals(['CVE-1'], byProject['Alerting'])
+    }
+
+    @Test
+    void testGetOpenVulnerabilitiesByProjectOmitsProjectsWithNoOpenCves() {
+        // A project whose only vulnerability is excluded is left out of the map entirely.
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "project": {"name": "Alerting"},
+                      "vulnerabilities": [
+                        {"id": "CVE-2", "excluded": true}
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+        ''']
+        def byProject = advisoryData.getOpenVulnerabilitiesByProject('scans-000335', 'origin/3.8')
+        assertEquals([:], byProject)
+    }
+
+    @Test
+    void testGetAgedMediumOrHigherAdvisoriesReturnsSortedIntersection() {
+        // Of the queried ids, the advisories index reports two as aged medium-or-higher; the third
+        // is neither aged nor severe, so it is not in the returned hits and is excluded.
+        responses = ['''
+            {
+              "hits": {
+                "hits": [
+                  {"_source": {"aliases": ["CVE-2"]}},
+                  {"_source": {"aliases": ["CVE-1"]}}
+                ]
+              }
+            }
+        ''']
+        def aged = advisoryData.getAgedMediumOrHigherAdvisories(['CVE-1', 'CVE-2', 'CVE-3'], '2026-06-01T23:59:59.999Z')
+        assertEquals(['CVE-1', 'CVE-2'], aged)
+        assertEquals('advisories', searchedIndices[0])
+        // The severity and publish-age filters are applied query-side.
+        assertTrue(queryBodies[0].contains('severity'))
+        assertTrue(queryBodies[0].contains('timestamp.publish'))
+        assertTrue(queryBodies[0].contains('2026-06-01T23:59:59.999Z'))
+    }
+
+    @Test
+    void testGetAgedMediumOrHigherAdvisoriesReturnsEmptyForNoInput() {
+        // No open CVEs means no lookup is issued and the criterion is met.
+        assertEquals([], advisoryData.getAgedMediumOrHigherAdvisories([], '2026-06-01T23:59:59.999Z'))
+        assertTrue(searchedIndices.isEmpty())
+    }
+
+    @Test
+    void testGetAgedMediumOrHigherAdvisoriesBatchesLargeCveSets() {
+        // Above the batch size the lookup is split into multiple advisories searches; every batch's
+        // matches are unioned. 1001 ids -> two batches (1000 + 1).
+        def cveIds = (1..1001).collect { "CVE-${it}".toString() }
+        responses = [
+            '{"hits":{"hits":[{"_source":{"aliases":["CVE-1"]}}]}}',
+            '{"hits":{"hits":[{"_source":{"aliases":["CVE-1001"]}}]}}'
+        ]
+        def aged = advisoryData.getAgedMediumOrHigherAdvisories(cveIds, '2026-06-01T23:59:59.999Z')
+        assertEquals(['CVE-1', 'CVE-1001'], aged)
+        assertEquals(2, searchedIndices.size())
+        assertEquals(['advisories', 'advisories'], searchedIndices)
+    }
+}

--- a/tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile
+++ b/tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile
@@ -1,0 +1,24 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+*/
+
+pipeline {
+    agent none
+    stages {
+        stage('check-unpatched-vulnerabilities') {
+            steps {
+                script {
+                    checkUnpatchedVulnerabilities(
+                        version: '3.8.0',
+                        releaseDate: '2026-08-15'
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/utils/TestSecurityAdvisoriesQuery.groovy
+++ b/tests/utils/TestSecurityAdvisoriesQuery.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package utils.tests
+
+import groovy.json.JsonSlurperClassic
+import org.junit.Before
+import org.junit.Test
+import utils.SecurityAdvisoriesQuery
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.fail
+
+class TestSecurityAdvisoriesQuery {
+    def script
+    def scriptArgs
+    String response
+
+    @Before
+    void setUp() {
+        response = '{"hits":{"hits":[{"_index":"scans-000335"}]}}'
+        script = new Expando()
+        script.sh = { Map args ->
+            scriptArgs = args
+            return response
+        }
+        script.println = { message -> }
+    }
+
+    @Test
+    void testSearchTargetsExplicitIndexWithSigV4Auth() {
+        def advisoriesQuery = new SecurityAdvisoriesQuery("advisoriesUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        def result = advisoriesQuery.search("advisories", "{\\\"query\\\":{}}")
+        assertEquals(result, new JsonSlurperClassic().parseText(response))
+        assertTrue(scriptArgs.script.contains('-XGET "advisoriesUrl/advisories/_search"'))
+        assertTrue(scriptArgs.script.contains('--aws-sigv4 "aws:amz:us-east-1:es"'))
+        assertTrue(scriptArgs.script.contains('--user "awsAccessKey:awsSecretKey"'))
+        assertTrue(scriptArgs.script.contains('x-amz-security-token:awsSessionToken'))
+    }
+
+    @Test
+    void testEmptyHitsIsAValidResponseNotAnError() {
+        // No vulnerabilities found is a legitimate result, not a failure: it must parse and return.
+        response = '{"hits":{"hits":[]}}'
+        def advisoriesQuery = new SecurityAdvisoriesQuery("advisoriesUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        def result = advisoriesQuery.search("advisories", "{\\\"query\\\":{}}")
+        assertEquals([], result.hits.hits)
+    }
+
+    @Test
+    void testEmptyBodyThrows() {
+        // A blank body (e.g. dropped connection) must throw rather than blow up in the JSON parser.
+        response = ''
+        def advisoriesQuery = new SecurityAdvisoriesQuery("advisoriesUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        try {
+            advisoriesQuery.search("advisories", "{\\\"query\\\":{}}")
+            fail("Expected RuntimeException on an empty response body")
+        } catch (RuntimeException e) {
+            assertTrue(e.message.contains('empty response'))
+        }
+    }
+
+    @Test
+    void testClusterErrorResponseThrows() {
+        // An error envelope parses as valid JSON but has no hits; it must throw so the caller records
+        // the criterion as unknown instead of mistaking it for zero results.
+        response = '{"error":{"type":"search_phase_execution_exception","reason":"all shards failed"},"status":503}'
+        def advisoriesQuery = new SecurityAdvisoriesQuery("advisoriesUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        try {
+            advisoriesQuery.search("advisories", "{\\\"query\\\":{}}")
+            fail("Expected RuntimeException on a cluster error response")
+        } catch (RuntimeException e) {
+            assertTrue(e.message.contains('query failed'))
+        }
+    }
+}

--- a/vars/checkUnpatchedVulnerabilities.groovy
+++ b/vars/checkUnpatchedVulnerabilities.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import jenkins.SecurityAdvisoryData
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Checks the release exit criterion: "No unpatched vulnerabilities of medium or higher severity
+ * that have been publicly known for more than 60 days."
+ *
+ * Reads the security advisories cluster (separate from the metrics cluster, with its own endpoint
+ * and credentials) in three steps: resolve the latest scans index, collect the open (non-excluded)
+ * CVE ids scanned for the release branch, then keep only those the advisories index reports as
+ * medium/high/critical AND published on or before the age cutoff.
+ *
+ * Age cutoff is release_date - 60 days when a release date is known, so a vulnerability is blocking
+ * only if it will have been public for more than 60 days by the time the release ships. When no
+ * release date is supplied, it falls back to now() - 60 days.
+ *
+ * The version is resolved to a branch tag (origin/3.8, origin/main) — never the exact 3.8.0 tag,
+ * which only exists after release.
+ *
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.version <required> - Release version, e.g. "3.8.0" or "3.8" (resolved to origin/3.8).
+ * @param args.releaseDate <optional> - Release date as yyyy-MM-dd; the age window is measured back
+ *                                       from this date. Falls back to today when omitted.
+ * @return Map of project name -> list of its blocking CVE ids (empty map when the criterion is met).
+ *         A bare CVE list is not actionable, so blocking CVEs are keyed by the component that owns
+ *         them. A query failure throws, so the caller records the criterion as 'unknown' rather than
+ *         silently passing.
+ */
+Map<String, List<String>> call(Map args = [:]) {
+    if (!args.version) {
+        error('version parameter is required.')
+    }
+
+    def secret_advisories_cluster = [
+        [envVar: 'ADVISORIES_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/security-advisories-account-number'],
+        [envVar: 'ADVISORIES_HOST_URL', secretRef: 'op://opensearch-release-secrets/security-advisories-cluster/security-advisories-cluster-endpoint']
+    ]
+
+    String branchTag = SecurityAdvisoryData.resolveVersionTag(args.version)
+    String cutoffIso = ageCutoffIso(args.releaseDate)
+    echo("Checking unpatched medium-or-higher vulnerabilities for ${branchTag} (published on or before ${cutoffIso}).")
+
+    Map<String, List<String>> blockingByProject = [:]
+    withSecrets(secrets: secret_advisories_cluster) {
+        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${ADVISORIES_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+            def advisoriesUrl = env.ADVISORIES_HOST_URL
+            def awsAccessKey = env.AWS_ACCESS_KEY_ID
+            def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+            def awsSessionToken = env.AWS_SESSION_TOKEN
+
+            def advisoryData = new SecurityAdvisoryData(advisoriesUrl, awsAccessKey, awsSecretKey, awsSessionToken, this)
+
+            String scansIndex = advisoryData.getLatestScansIndex()
+            Map<String, List<String>> openByProject = advisoryData.getOpenVulnerabilitiesByProject(scansIndex, branchTag)
+            List<String> openCves = openByProject.values().flatten().unique()
+            echo("Found ${openCves.size()} open vulnerability id(s) across ${openByProject.size()} project(s) for ${branchTag} in ${scansIndex}.")
+
+            // The advisories lookup is severity/age filtering over the whole CVE set; re-key the
+            // resulting blocking ids back onto their projects so each is attributable to a component.
+            List<String> blockingCves = advisoryData.getAgedMediumOrHigherAdvisories(openCves, cutoffIso)
+            Set<String> blockingCveSet = blockingCves as Set
+            openByProject.each { projectName, cves ->
+                def projectBlocking = cves.findAll { blockingCveSet.contains(it) }
+                if (projectBlocking) {
+                    blockingByProject[projectName] = projectBlocking
+                }
+            }
+        }
+    }
+
+    if (blockingByProject) {
+        echo("Unpatched medium-or-higher vulnerabilities older than the 60-day window: ${blockingByProject}")
+    } else {
+        echo('No unpatched medium-or-higher vulnerabilities older than the 60-day window.')
+    }
+    return blockingByProject
+}
+
+/**
+ * Age cutoff for "publicly known for more than 60 days": release_date - 60 days when a valid release
+ * date is supplied, otherwise today - 60 days. The schedule stores a date (yyyy-MM-dd) while
+ * advisories carry a datetime (timestamp.publish); rendering the cutoff at end-of-day
+ * (T23:59:59.999Z) means an advisory published anytime on the cutoff date is still treated as aged.
+ */
+private String ageCutoffIso(String releaseDate) {
+    LocalDate base
+    if (releaseDate?.trim()) {
+        try {
+            base = LocalDate.parse(releaseDate.trim(), DateTimeFormatter.ofPattern('yyyy-MM-dd'))
+        } catch (Exception e) {
+            echo("Could not parse releaseDate '${releaseDate}'; falling back to today for the age window.")
+            base = LocalDate.now()
+        }
+    } else {
+        base = LocalDate.now()
+    }
+    return "${base.minusDays(60).format(DateTimeFormatter.ofPattern('yyyy-MM-dd'))}T23:59:59.999Z"
+}


### PR DESCRIPTION
### Description
Adding a library to get data from security advisories cluster. This change will be incorporated in `indexReleaseState` to check CVE exit criteria.

### Issues Resolved
https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
