### PR TITLE
Update docker copy to use readonly user to pull images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.7.0'
+String version = '13.7.1'
 
 task updateVersion {
     doLast {

--- a/tests/jenkins/jobs/DockerCopyAllTags_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/DockerCopyAllTags_Jenkinsfile.txt
@@ -6,7 +6,7 @@
          DockerCopyAllTags_Jenkinsfile.stage(Copy Image to ECR/DockerHub with All Tags, groovy.lang.Closure)
             DockerCopyAllTags_Jenkinsfile.script(groovy.lang.Closure)
                DockerCopyAllTags_Jenkinsfile.copyContainer({allTags=true, sourceImage=ci-runner:centos7-123, sourceRegistry=opensearchstaging, destinationImage=ci-runner:centos7-123, destinationRegistry=opensearchstaging})
-                  copyContainer.withSecrets({secrets=[{envVar=DOCKER_USERNAME, secretRef=op://opensearch-release-secrets/dockerhub-staging-credentials/username}, {envVar=DOCKER_PASSWORD, secretRef=op://opensearch-release-secrets/dockerhub-staging-credentials/password}]}, groovy.lang.Closure)
+                  copyContainer.withSecrets({secrets=[{envVar=DOCKER_USERNAME, secretRef=op://opensearch-release-secrets/dockerhub-production-readonly-credentials/username}, {envVar=DOCKER_PASSWORD, secretRef=op://opensearch-release-secrets/dockerhub-production-readonly-credentials/password}]}, groovy.lang.Closure)
                      copyContainer.sh(set +x && echo dummy_docker_password | docker login --username dummy_docker_username --password-stdin)
                   copyContainer.echo(Copying all the tags of image opensearchstaging/ci-runner to opensearchstaging/ci-runner)
                   copyContainer.sh(set -x && crane cp opensearchstaging/ci-runner opensearchstaging/ci-runner --all-tags)

--- a/tests/jenkins/jobs/DockerCopy_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/DockerCopy_Jenkinsfile.txt
@@ -6,7 +6,7 @@
          DockerCopy_Jenkinsfile.stage(Copy Image to ECR/DockerHub, groovy.lang.Closure)
             DockerCopy_Jenkinsfile.script(groovy.lang.Closure)
                DockerCopy_Jenkinsfile.copyContainer({sourceImage=ci-runner:centos7-123, sourceRegistry=opensearchstaging, destinationImage=ci-runner:centos7-123, destinationRegistry=public.ecr.aws/opensearchstaging})
-                  copyContainer.withSecrets({secrets=[{envVar=DOCKER_USERNAME, secretRef=op://opensearch-release-secrets/dockerhub-staging-credentials/username}, {envVar=DOCKER_PASSWORD, secretRef=op://opensearch-release-secrets/dockerhub-staging-credentials/password}]}, groovy.lang.Closure)
+                  copyContainer.withSecrets({secrets=[{envVar=DOCKER_USERNAME, secretRef=op://opensearch-release-secrets/dockerhub-production-readonly-credentials/username}, {envVar=DOCKER_PASSWORD, secretRef=op://opensearch-release-secrets/dockerhub-production-readonly-credentials/password}]}, groovy.lang.Closure)
                      copyContainer.sh(set +x && echo dummy_docker_password | docker login --username dummy_docker_username --password-stdin)
                   copyContainer.sh(set +x && aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchstaging)
                   copyContainer.echo(Copying single image tag from opensearchstaging/ci-runner:centos7-123 to public.ecr.aws/opensearchstaging/ci-runner:centos7-123)

--- a/vars/copyContainer.groovy
+++ b/vars/copyContainer.groovy
@@ -17,9 +17,9 @@
   * @param args.allTags <optional>Copy all the tags of a sourceImage to destinationImage if 'true' and <IMAGE_TAG> is ignored in sourceImage/destinationImage, default to 'false'
  */
 void call(Map args = [:]) {
-    def secret_dockerhub_staging = [
-        [envVar: 'DOCKER_USERNAME', secretRef: 'op://opensearch-release-secrets/dockerhub-staging-credentials/username'],
-        [envVar: 'DOCKER_PASSWORD', secretRef: 'op://opensearch-release-secrets/dockerhub-staging-credentials/password']
+    def secret_dockerhub_readonly = [
+        [envVar: 'DOCKER_USERNAME', secretRef: 'op://opensearch-release-secrets/dockerhub-production-readonly-credentials/username'],
+        [envVar: 'DOCKER_PASSWORD', secretRef: 'op://opensearch-release-secrets/dockerhub-production-readonly-credentials/password']
     ]
 
     def secret_dockerhub_production = [
@@ -41,7 +41,7 @@ void call(Map args = [:]) {
     destination_registry = args.destinationRegistry
 
     if (source_registry == 'opensearchstaging' || destination_registry == 'opensearchstaging') {
-        withSecrets(secrets: secret_dockerhub_staging){
+        withSecrets(secrets: secret_dockerhub_readonly){
             sh("set +x && echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin")
         }
     }


### PR DESCRIPTION
### Description
Update docker copy to use readonly user to pull images

### Issues Resolved
https://build.ci.opensearch.org/job/docker-copy/3306/console
https://github.com/opensearch-project/opensearch-migrations/issues/3308

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
