### PR TITLE
Add a lib to index release state indices to metrics cluster

### DIFF
--- a/src/jenkins/ManualReleaseCriterion.groovy
+++ b/src/jenkins/ManualReleaseCriterion.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins
+
+/**
+ * The release criteria that no automated chore verifies and are read from the release issue's
+ * criteria tables instead. Each maps a stable keyword from the criterion's prose to its criterion
+ * name and type. Which product a criterion applies to depends on the table it appears in (entrance
+ * applies to both products, the exit tables are per product), so that is resolved by the parser.
+ */
+enum ManualReleaseCriterion {
+
+    SANITY_TESTING('sanity testing is done', 'sanity_testing_done', 'entrance'),
+    ROADMAP('roadmap is up-to-date', 'roadmap_up_to_date', 'entrance'),
+    SECURITY_REVIEWS('security reviews', 'security_reviews_complete', 'entrance'),
+    PERFORMANCE_TESTS('performance tests are run', 'performance_tests_posted', 'exit'),
+    RELEASE_BLOG('release blog is ready', 'release_blog_ready', 'exit')
+
+    final String keyword
+    final String criterionName
+    final String criterionType
+
+    ManualReleaseCriterion(String keyword, String criterionName, String criterionType) {
+        this.keyword = keyword
+        this.criterionName = criterionName
+        this.criterionType = criterionType
+    }
+}

--- a/src/jenkins/ReleaseStateData.groovy
+++ b/src/jenkins/ReleaseStateData.groovy
@@ -9,6 +9,7 @@
 
 package jenkins
 
+import groovy.json.JsonOutput
 import java.text.SimpleDateFormat
 import utils.OpenSearchMetricsQuery
 
@@ -64,6 +65,45 @@ class ReleaseStateData {
 
     void indexDecision(ReleaseDecision decision) {
         metricsQuery.indexDocument(ReleaseIndices.STATE, decision.toDocument(nowIso()))
+    }
+
+    /**
+     * Returns the currently active releases from the schedule index, one entry per version.
+     *
+     * Because the schedule index holds exactly one doc per version (upserted by version-derived id),
+     * a simple status filter is sufficient; no per-version dedup is needed. Each returned map carries
+     * the fields the state orchestrator needs to build criteria: version, release_date, release_issue.
+     *
+     * @return list of maps [version, releaseDate, releaseIssue]; empty when no releases are active.
+     */
+    List<Map> getActiveReleases() {
+        def response = metricsQuery.fetchMetricsFromIndex(ReleaseIndices.SCHEDULE, activeReleasesQuery())
+        def hits = response?.hits?.hits
+        if (!hits) {
+            return []
+        }
+        return hits.collect { hit ->
+            def doc = hit._source
+            [
+                version     : doc.version,
+                releaseDate : doc.release_date,
+                releaseIssue: doc.release_issue
+            ]
+        }
+    }
+
+    private String activeReleasesQuery() {
+        def queryMap = [
+            size : 100,
+            query: [
+                bool: [
+                    filter: [
+                        [match_phrase: [status: 'active']]
+                    ]
+                ]
+            ]
+        ]
+        return JsonOutput.toJson(queryMap).replace('"', '\\"')
     }
 
     /**

--- a/src/jenkins/ReleaseStateData.groovy
+++ b/src/jenkins/ReleaseStateData.groovy
@@ -11,6 +11,7 @@ package jenkins
 
 import groovy.json.JsonOutput
 import java.text.SimpleDateFormat
+import java.util.regex.Pattern
 import utils.OpenSearchMetricsQuery
 import jenkins.ManualReleaseCriterion
 
@@ -137,8 +138,16 @@ class ReleaseStateData {
                     return []
                 }
                 List<String> cells = line.split('\\|')*.trim()
+                // A leading pipe (| a | b |) splits to an empty first cell; drop it so the Criteria
+                // and Status columns are at the same indices whether or not the row is pipe-bounded.
+                if (cells && cells[0].isEmpty()) {
+                    cells = cells.drop(1)
+                }
+                // Match the keyword against the Criteria cell only so prose in the Description or
+                // Comments columns can never produce a spurious criterion.
+                String criteriaCell = (cells ? cells[0] : '').toLowerCase()
                 String statusCell = cells.size() > 1 ? cells[1] : ''
-                criteria.findAll { line.toLowerCase().contains(it.keyword) }.collect { criterion ->
+                criteria.findAll { criteriaCell.contains(it.keyword) }.collect { criterion ->
                     [name: criterion.criterionName, type: table.type, product: table.product, status: statusFor(statusCell)]
                 }
             }
@@ -157,7 +166,7 @@ class ReleaseStateData {
         }
         String rest = body.substring(start.end())
         if (stopKeyword) {
-            def stop = (rest =~ /(?im)^#+.*${stopKeyword}/)
+            def stop = (rest =~ /(?im)^#+.*${Pattern.quote(stopKeyword)}/)
             if (stop.find()) {
                 return rest.substring(0, stop.start())
             }

--- a/src/jenkins/ReleaseStateData.groovy
+++ b/src/jenkins/ReleaseStateData.groovy
@@ -12,6 +12,7 @@ package jenkins
 import groovy.json.JsonOutput
 import java.text.SimpleDateFormat
 import utils.OpenSearchMetricsQuery
+import jenkins.ManualReleaseCriterion
 
 /**
  * Indexes release state documents on the OpenSearch metrics cluster.
@@ -104,6 +105,69 @@ class ReleaseStateData {
             ]
         ]
         return JsonOutput.toJson(queryMap).replace('"', '\\"')
+    }
+
+    private static final Map<String, String> CIRCLE_STATUS = [
+        green_circle : 'met',
+        yellow_circle: 'in_progress',
+        red_circle   : 'not_met'
+    ]
+
+    /**
+     * Reads the manual criteria (those no chore verifies) from the release issue's criteria tables.
+     *
+     * The issue holds three tables: an entrance table that applies to both products, and one exit
+     * table per product. A criterion's product is therefore the table it sits in, not the row itself.
+     * Manual rows are matched by a stable keyword from their prose (see ManualReleaseCriterion) and
+     * their status circle maps to a criterion status via CIRCLE_STATUS (unrecognised -> unknown).
+     *
+     * @param issueBody the raw markdown body of the release issue
+     * @return list of maps [name, type, product, status], one per manual row found
+     */
+    List<Map> parseManualCriteria(String issueBody) {
+        def tables = [
+            [type: 'entrance', product: 'both', start: /(?im)^#+.*entrance criteria/, stop: 'exit'],
+            [type: 'exit', product: 'opensearch', start: /(?im)^#+\s+opensearch\s+\S+\s+\[?exit criteria/, stop: 'dashboards'],
+            [type: 'exit', product: 'opensearch-dashboards', start: /(?im)^#+.*dashboards\s+\S+\s+\[?exit criteria/, stop: null]
+        ]
+        return tables.collectMany { table ->
+            def criteria = ManualReleaseCriterion.values().findAll { it.criterionType == table.type }
+            sectionBetween(issueBody, table.start, table.stop).readLines().collectMany { line ->
+                if (!line.contains('|')) {
+                    return []
+                }
+                List<String> cells = line.split('\\|')*.trim()
+                String statusCell = cells.size() > 1 ? cells[1] : ''
+                criteria.findAll { line.toLowerCase().contains(it.keyword) }.collect { criterion ->
+                    [name: criterion.criterionName, type: table.type, product: table.product, status: statusFor(statusCell)]
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the slice of the body from the heading matching startPattern up to the next heading
+     * whose text contains stopKeyword (or end of body when stopKeyword is null), so each criteria
+     * table is parsed in isolation.
+     */
+    private static String sectionBetween(String body, String startPattern, String stopKeyword) {
+        def start = (body =~ startPattern)
+        if (!start.find()) {
+            return ''
+        }
+        String rest = body.substring(start.end())
+        if (stopKeyword) {
+            def stop = (rest =~ /(?im)^#+.*${stopKeyword}/)
+            if (stop.find()) {
+                return rest.substring(0, stop.start())
+            }
+        }
+        return rest
+    }
+
+    private static String statusFor(String statusCell) {
+        def match = CIRCLE_STATUS.find { circle, status -> statusCell.contains(circle) }
+        return match ? match.value : 'unknown'
     }
 
     /**

--- a/src/utils/OpenSearchMetricsQuery.groovy
+++ b/src/utils/OpenSearchMetricsQuery.groovy
@@ -41,12 +41,26 @@ class OpenSearchMetricsQuery {
     }
 
     def fetchMetrics(String query) {
+        return searchIndex(indexName, query)
+    }
+
+    /**
+     * Runs a search against an explicit index, for callers built with the index-less constructor
+     * (e.g. ReleaseStateData, which reads and writes across multiple indices).
+     * @param targetIndex the index to search
+     * @param query the SigV4-shell-escaped query body
+     */
+    def fetchMetricsFromIndex(String targetIndex, String query) {
+        return searchIndex(targetIndex, query)
+    }
+
+    private def searchIndex(String targetIndex, String query) {
         this.script.println('Running query: '+ query)
         def response = script.sh(
             script: """
             set -e
             set +x
-            curl -s -XGET "${metricsUrl}/${indexName}/_search" ${curlAuthArgs()} -H 'Content-Type: application/json' -d "${query}" | jq '.'
+            curl -s -XGET "${metricsUrl}/${targetIndex}/_search" ${curlAuthArgs()} -H 'Content-Type: application/json' -d "${query}" | jq '.'
         """,
         returnStdout: true
         ).trim()

--- a/tests/jenkins/TestReleaseStateData.groovy
+++ b/tests/jenkins/TestReleaseStateData.groovy
@@ -29,6 +29,9 @@ class TestReleaseStateData {
     // Captures each POSTed doc as [index: <targetIndex>, doc: <parsed body>]
     private List<Map> indexedDocs
     private String responseCode
+    // Search response returned to -XGET calls, and the index the search targeted.
+    private String searchResponse
+    private String searchedIndex
 
     // Holds the body written by the most recent writeFile call, to pair with the following POST.
     private String pendingBody
@@ -38,7 +41,10 @@ class TestReleaseStateData {
         indexedDocs = []
         pendingBody = null
         responseCode = '201'
+        searchResponse = '{"hits":{"hits":[]}}'
+        searchedIndex = null
         script = new Expando()
+        script.println = { msg -> }
         // The body is written to a temp file first, then the POST curl references it.
         script.writeFile = { Map args -> pendingBody = args.text }
         script.sh = { Map args ->
@@ -47,6 +53,11 @@ class TestReleaseStateData {
             // PUT /_doc/<id>. Capture both, recording the id when the write targets a specific doc.
             if (s.contains('-XPOST') || s.contains('-XPUT')) {
                 indexedDocs.add([index: extractIndex(s), id: extractId(s), doc: new JsonSlurper().parseText(pendingBody)])
+                return responseCode
+            }
+            if (s.contains('-XGET')) {
+                searchedIndex = extractSearchIndex(s)
+                return searchResponse
             }
             return responseCode
         }
@@ -61,6 +72,11 @@ class TestReleaseStateData {
     // Returns the explicit document id when the write is PUT /_doc/<id>, or null for POST /_doc.
     private String extractId(String shScript) {
         def matcher = (shScript =~ /${metricsUrl}\/[^\/]+\/_doc\/([^"]+)/)
+        return matcher ? matcher[0][1] : null
+    }
+
+    private String extractSearchIndex(String shScript) {
+        def matcher = (shScript =~ /${metricsUrl}\/([^\/]+)\/_search/)
         return matcher ? matcher[0][1] : null
     }
 
@@ -132,5 +148,45 @@ class TestReleaseStateData {
         } catch (RuntimeException e) {
             assert e.message.contains('Failed to index document')
         }
+    }
+
+    @Test
+    void testGetActiveReleasesQueriesScheduleIndexAndMapsFields() {
+        searchResponse = '''
+            {
+              "hits": {
+                "hits": [
+                  {
+                    "_source": {
+                      "version": "3.8.0",
+                      "release_date": "2026-08-15",
+                      "release_issue": "https://github.com/opensearch-project/opensearch-build/issues/5152",
+                      "status": "active"
+                    }
+                  },
+                  {
+                    "_source": {
+                      "version": "2.19.7",
+                      "release_date": "2026-09-01",
+                      "release_issue": "https://github.com/opensearch-project/opensearch-build/issues/5200",
+                      "status": "active"
+                    }
+                  }
+                ]
+              }
+            }
+        '''
+        def active = releaseStateData.getActiveReleases()
+        // Reads the schedule index and filters on active status.
+        assert searchedIndex == ReleaseStateIndex.SCHEDULE_INDEX
+        assert active.size() == 2
+        assert active[0] == [version: '3.8.0', releaseDate: '2026-08-15', releaseIssue: 'https://github.com/opensearch-project/opensearch-build/issues/5152']
+        assert active[1].version == '2.19.7'
+    }
+
+    @Test
+    void testGetActiveReleasesReturnsEmptyWhenNoActiveReleases() {
+        searchResponse = '{"hits":{"hits":[]}}'
+        assert releaseStateData.getActiveReleases() == []
     }
 }

--- a/tests/jenkins/TestReleaseStateData.groovy
+++ b/tests/jenkins/TestReleaseStateData.groovy
@@ -291,4 +291,32 @@ Sanity testing is done for all components |  |   |
     void testParseManualCriteriaReturnsEmptyWhenNoTables() {
         assert releaseStateData.parseManualCriteria('no criteria tables here') == []
     }
+
+    @Test
+    void testParseManualCriteriaHandlesLeadingPipeRows() {
+        // Pipe-bounded rows (| a | b |) must map the Criteria and Status columns to the same cells
+        // as the unbounded style, so the leading empty cell is dropped rather than shifting columns.
+        String body = '''
+### [Entrance Criteria](https://example.com)
+| Criteria | Status | Description | Comments |
+| -- | -- | -- | -- |
+| Sanity testing is done for all components | :green_circle: | | |
+| Roadmap is up-to-date | :red_circle: | | |
+'''
+        def byName = releaseStateData.parseManualCriteria(body).collectEntries { [it.name, it] }
+        assert byName['sanity_testing_done'].status == 'met'
+        assert byName['roadmap_up_to_date'].status == 'not_met'
+    }
+
+    @Test
+    void testParseManualCriteriaMatchesCriteriaCellNotOtherColumns() {
+        // A keyword appearing only in the Comments column must not produce a spurious criterion.
+        String body = '''
+### [Entrance Criteria](https://example.com)
+Criteria | Status | Description  | Comments
+-- | -- | -- | --
+Each component release issue has an assigned owner | :green_circle: |   | sanity testing is done later
+'''
+        assert releaseStateData.parseManualCriteria(body) == []
+    }
 }

--- a/tests/jenkins/TestReleaseStateData.groovy
+++ b/tests/jenkins/TestReleaseStateData.groovy
@@ -189,4 +189,106 @@ class TestReleaseStateData {
         searchResponse = '{"hits":{"hits":[]}}'
         assert releaseStateData.getActiveReleases() == []
     }
+
+    // A trimmed release issue body carrying all three criteria tables in their real markdown shape.
+    private static final String ISSUE_BODY = '''
+## Release OpenSearch and OpenSearch Dashboards 3.8.0
+
+I noticed that a manifest was automatically created in [manifests/3.8.0](/opensearch-project/opensearch-build/tree/main/manifests/3.8.0). Please follow the following checklist to make a release.
+
+<details><summary>How to use this issue</summary>
+<p>
+
+## This Release Issue
+
+This issue captures the state of the OpenSearch release, its assignee (Release Manager) is responsible for driving the release. Please contact them or @mention them on this issue for help. There are linked issues on components of the release where individual components can be tracked. For more information check the the [Release Process OpenSearch Guide](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution).
+
+</p>
+</details>
+
+Please refer to the following link for the release version dates: [Release Schedule and Maintenance Policy](https://opensearch.org/releases.html).
+
+### [Entrance Criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#entrance-criteria-to-start-release-window)
+Criteria | Status | Description  | Comments
+-- | -- | -- | --
+Each component release issue has an assigned owner | :green_circle: |   |
+Documentation draft PRs are up and in tech review for all component changes | :green_circle: |   |
+Sanity testing is done for all components | :green_circle: |   |
+Code coverage has not decreased (all new code has tests) | :green_circle: |   |
+Release notes are ready and available for all components | :green_circle: |   |
+Roadmap is up-to-date (information is available to create release highlights) | :yellow_circle: |   |
+Release ticket is cut, and there's a forum post announcing the start of the window | :green_circle: |   |
+[Any necessary security reviews](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#security-reviews) are complete | :red_circle: |   |
+
+### OpenSearch 3.8.0 [exit criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#exit-criteria-to-close-release-window) status:
+Criteria | Status | Description  | Comments
+-- | -- | -- | --
+Performance tests are run, results are posted to the release ticket and there no unexpected regressions | :green_circle: |   |
+No unpatched vulnerabilities of medium or higher severity that have been publicly known for more than 60 days | :green_circle: |   |
+Documentation has been fully reviewed and   signed off by the documentation community. | :green_circle: |   |
+All integration tests are passing |  :green_circle: |   |
+Release blog is ready | :yellow_circle: |   |
+
+### OpenSearch-Dashboards 3.8.0 [exit criteria](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#exit-criteria-to-close-release-window) status:
+Criteria | Status | Description  | Comments
+-- | -- | -- | --
+Documentation has been fully reviewed and   signed off by the documentation community | :green_circle: |   |
+No unpatched vulnerabilities of medium or higher severity that have been publicly known for more than 60 days | :green_circle: |   |
+All integration tests are passing | :green_circle: |   |
+Release blog is ready | :red_circle: |   |
+
+</p>
+</details>
+'''
+
+    @Test
+    void testParseManualCriteriaMapsCirclesToStatuses() {
+        def byName = releaseStateData.parseManualCriteria(ISSUE_BODY).collectEntries { [it.name, it] }
+        assert byName['sanity_testing_done'].status == 'met'
+        assert byName['roadmap_up_to_date'].status == 'in_progress'
+        assert byName['security_reviews_complete'].status == 'not_met'
+    }
+
+    @Test
+    void testParseManualCriteriaAssignsProductFromTable() {
+        def criteria = releaseStateData.parseManualCriteria(ISSUE_BODY)
+        // Entrance rows apply to both products; the exit tables are per product.
+        assert criteria.find { it.name == 'sanity_testing_done' }.product == 'both'
+        assert criteria.find { it.name == 'sanity_testing_done' }.type == 'entrance'
+        assert criteria.find { it.name == 'performance_tests_posted' }.product == 'opensearch'
+        assert criteria.findAll { it.name == 'release_blog_ready' }*.product.sort() == ['opensearch', 'opensearch-dashboards']
+    }
+
+    @Test
+    void testParseManualCriteriaOnlyReturnsManualRows() {
+        // Rows covered by a chore (owners, integration tests) are not manual criteria and are skipped.
+        def names = releaseStateData.parseManualCriteria(ISSUE_BODY)*.name as Set
+        assert names == ['sanity_testing_done', 'roadmap_up_to_date', 'security_reviews_complete',
+                         'performance_tests_posted', 'release_blog_ready'] as Set
+    }
+
+    @Test
+    void testParseManualCriteriaPerformanceRowIsOpenSearchOnly() {
+        // The OSD exit table has no performance row, so performance_tests_posted appears exactly once.
+        def performance = releaseStateData.parseManualCriteria(ISSUE_BODY).findAll { it.name == 'performance_tests_posted' }
+        assert performance.size() == 1
+        assert performance[0].product == 'opensearch'
+    }
+
+    @Test
+    void testParseManualCriteriaUnrecognisedStatusIsUnknown() {
+        String body = '''
+### [Entrance Criteria](https://example.com)
+Criteria | Status | Description  | Comments
+-- | -- | -- | --
+Sanity testing is done for all components |  |   |
+'''
+        def sanity = releaseStateData.parseManualCriteria(body).find { it.name == 'sanity_testing_done' }
+        assert sanity.status == 'unknown'
+    }
+
+    @Test
+    void testParseManualCriteriaReturnsEmptyWhenNoTables() {
+        assert releaseStateData.parseManualCriteria('no criteria tables here') == []
+    }
 }

--- a/tests/utils/TestOpenSearchMetricsQuery.groovy
+++ b/tests/utils/TestOpenSearchMetricsQuery.groovy
@@ -74,6 +74,15 @@ class TestOpenSearchMetricsQuery {
     }
 
     @Test
+    void testFetchMetricsFromIndexSearchesExplicitIndex() {
+        // Callers built with the index-less constructor can search a named index.
+        def metricsQuery = new OpenSearchMetricsQuery("metricsUrl", "awsAccessKey", "awsSecretKey", "awsSessionToken", this.script)
+        def result = metricsQuery.fetchMetricsFromIndex("explicitIndex", "{\\\"query\\\":{}}")
+        assertEquals(result, new JsonSlurperClassic().parseText(response))
+        assertTrue(scriptArgs.script.contains('-XGET "metricsUrl/explicitIndex/_search"'))
+    }
+
+    @Test
     void testIndexExistsReturnsTrueOn200() {
         script.sh = { Map args ->
             scriptArgs = args

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -154,6 +154,14 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
         return
     }
 
+    // The release issue is read from the schedule index as a full GitHub issue URL; resolve it to a
+    // bare issue number so a crafted value can never inject into the gh shell command.
+    def issueNumber = (release.releaseIssue =~ /\/issues\/(\d+)/)
+    if (!issueNumber.find()) {
+        echo("Release issue '${release.releaseIssue}' for version ${release.version} is not a valid issue URL; skipping manual criteria.")
+        return
+    }
+
     def secret_github_bot = [
         [envVar: 'GITHUB_USER', secretRef: 'op://opensearch-release-secrets/github-bot/ci-bot-username'],
         [envVar: 'GITHUB_TOKEN', secretRef: 'op://opensearch-release-secrets/github-bot/ci-bot-token']
@@ -162,7 +170,7 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
     String issueBody
     withSecrets(secrets: secret_github_bot) {
         issueBody = sh(
-            script: "gh issue view ${release.releaseIssue} --repo opensearch-project/opensearch-build --json body --jq '.body'",
+            script: "gh issue view ${issueNumber.group(1)} --repo opensearch-project/opensearch-build --json body --jq '.body'",
             returnStdout: true
         )
     }
@@ -225,7 +233,7 @@ private def runCheck(String name, Closure check) {
 /**
  * Normalizes a check's raw result into an explicit [blockingComponents, details] contract so
  * indexCriterion never has to infer which axis of a Map is the component.
- *   - null (the check threw)      -> null, recorded as 'unknown'
+ *   - null (the check threw)       -> null, recorded as 'unknown'
  *   - checks with a render closure -> that closure derives components vs details
  *   - otherwise (a List<String>)   -> the list is the blocking components, no details
  *

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -55,6 +55,7 @@ void call(Map args = [:]) {
             releases.each { release ->
                 echo("Indexing release state for version ${release.version}.")
                 indexCriteriaForRelease(releaseStateData, release)
+                indexManualCriteriaForRelease(releaseStateData, release)
             }
         }
     }
@@ -80,7 +81,8 @@ private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map rele
     //   render  - optional closure that normalizes a keyed-map result into blocking_components + details
     //
     // Criteria not covered by an automated chore (sanity testing, roadmap, security reviews,
-    // performance tests, release blog) are manual and parsed elsewhere.
+    // performance tests, release blog) are manual and parsed from the release issue's tables by
+    // indexManualCriteriaForRelease.
     def checks = [
         [
             name   : 'release_owners_assigned',
@@ -138,6 +140,45 @@ private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map rele
         def raw = runCheck(check.name, check.run)
         def result = normalizeResult(check, raw)
         indexCriterion(releaseStateData, release, check, result)
+    }
+}
+
+/**
+ * Reads the manual criteria (no chore verifies them) from the release issue's criteria tables and
+ * indexes one criterion document for each. The issue body is fetched with the github-bot token and
+ * parsed by ReleaseStateData; each row's status circle is recorded as-is (source 'issue_table').
+ */
+private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Map release) {
+    if (!release.releaseIssue) {
+        echo("No release issue for version ${release.version}; skipping manual criteria.")
+        return
+    }
+
+    def secret_github_bot = [
+        [envVar: 'GITHUB_USER', secretRef: 'op://opensearch-release-secrets/github-bot/ci-bot-username'],
+        [envVar: 'GITHUB_TOKEN', secretRef: 'op://opensearch-release-secrets/github-bot/ci-bot-token']
+    ]
+
+    String issueBody
+    withSecrets(secrets: secret_github_bot) {
+        issueBody = sh(
+            script: "gh issue view ${release.releaseIssue} --repo opensearch-project/opensearch-build --json body --jq '.body'",
+            returnStdout: true
+        )
+    }
+
+    releaseStateData.parseManualCriteria(issueBody).each { criterion ->
+        releaseStateData.indexCriterion(new ReleaseCriterion([
+            version      : release.version,
+            releaseDate  : release.releaseDate,
+            product      : criterion.product,
+            criterionType: criterion.type,
+            criterionName: criterion.name,
+            status       : criterion.status,
+            source       : 'issue_table',
+            releaseIssue : release.releaseIssue,
+            checkedBy    : "${env.JOB_NAME} #${env.BUILD_NUMBER}"
+        ]))
     }
 }
 

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -1,0 +1,236 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import jenkins.ReleaseStateData
+import jenkins.ReleaseCriterion
+
+/**
+ * Computes and indexes per-criterion release readiness state for active releases.
+ *
+ * For each active release (from the opensearch_release_schedule index), this runs the automated
+ * release chore checks, maps each result to a criterion status, and indexes one criterion document
+ * per check into the opensearch_release_state index. OSCAR reads that index to compute a Red/Yellow/
+ * Green verdict; this job only records state (Jenkins is the hands, OSCAR is the brain).
+ *
+ * Each chore returns its problems (an empty result means the criterion is met, a non-empty result
+ * means it is not met, and a null return from a query failure is recorded as 'unknown' so a failed
+ * check never reads as met). A chore may return a flat list of blocking components, or a keyed map
+ * (e.g. project -> CVEs, or dist/arch -> failing components); a per-check render closure normalizes
+ * the latter into blocking_components plus a human-readable details breakdown.
+ *
+ * @param Map args = [:] args A map of the following parameters
+ * @param args.version <optional> - Restrict to a single release version. When omitted, all active
+ *                                   releases from the schedule index are processed.
+ */
+void call(Map args = [:]) {
+    def secret_metrics_cluster = [
+        [envVar: 'METRICS_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number'],
+        [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
+    ]
+
+    withSecrets(secrets: secret_metrics_cluster) {
+        withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
+            def metricsUrl = env.METRICS_HOST_URL
+            def awsAccessKey = env.AWS_ACCESS_KEY_ID
+            def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
+            def awsSessionToken = env.AWS_SESSION_TOKEN
+
+            def releaseStateData = new ReleaseStateData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, this)
+
+            def releases = releaseStateData.getActiveReleases()
+            if (args.version) {
+                releases = releases.findAll { it.version == args.version }
+            }
+            if (releases.isEmpty()) {
+                echo('No active releases to index state for.')
+                return
+            }
+
+            releases.each { release ->
+                echo("Indexing release state for version ${release.version}.")
+                indexCriteriaForRelease(releaseStateData, release)
+            }
+        }
+    }
+}
+
+/**
+ * Runs every automated criterion check for a release and indexes a criterion document for each.
+ */
+private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map release) {
+    String version = release.version
+    List<String> inputManifest = [
+        "manifests/${version}/opensearch-${version}.yml",
+        "manifests/${version}/opensearch-dashboards-${version}.yml"
+    ]
+
+    // Each entry maps a release criterion (from the release issue's entrance/exit tables) to the chore
+    // that verifies it:
+    //   name    - the criterion name, matching the release_state index
+    //   type    - entrance or exit criterion
+    //   product - which product line the criterion applies to
+    //   run     - closure that runs the chore and returns its problems; invoked via runCheck so a
+    //             failure in one check is isolated and recorded as 'unknown'
+    //   render  - optional closure that normalizes a keyed-map result into blocking_components + details
+    //
+    // Criteria not covered by an automated chore (sanity testing, roadmap, security reviews,
+    // performance tests, release blog) are manual and parsed elsewhere.
+    def checks = [
+        [
+            name   : 'release_owners_assigned',
+            type   : 'entrance',
+            product: 'both',
+            run    : { checkRequestAssignReleaseOwners(inputManifest: inputManifest, action: 'check') }
+        ],
+        [
+            name   : 'documentation_draft_prs_up',
+            type   : 'entrance',
+            product: 'both',
+            run    : { checkDocumentationIssues(version: version, action: 'check') }
+        ],
+        [
+            name   : 'code_coverage_not_decreased',
+            type   : 'entrance',
+            product: 'both',
+            run    : { checkCodeCoverage(inputManifest: inputManifest, action: 'check') }
+        ],
+        [
+            name   : 'release_notes_ready',
+            type   : 'entrance',
+            product: 'both',
+            run    : { checkReleaseNotes(inputManifest: inputManifest, action: 'check') }
+        ],
+        [
+            name   : 'release_ticket_and_forum_post',
+            type   : 'entrance',
+            product: 'both',
+            run    : { checkReleaseIssues(inputManifest: inputManifest, action: 'check') }
+        ],
+        [
+            name   : 'documentation_reviewed_signed_off',
+            type   : 'exit',
+            product: 'both',
+            run    : { checkDocumentationPullRequests(version: version) }
+        ],
+        [
+            name   : 'all_integration_tests_passing',
+            type   : 'exit',
+            product: 'both',
+            run    : { checkIntegTestResultsOverview(inputManifest: inputManifest) },
+            render : { raw -> renderIntegResults(raw) }
+        ],
+        [
+            name   : 'no_unpatched_vulnerabilities',
+            type   : 'exit',
+            product: 'both',
+            run    : { checkUnpatchedVulnerabilities(version: version, releaseDate: release.releaseDate) },
+            render : { raw -> renderVulnerabilityResults(raw) }
+        ]
+    ]
+
+    checks.each { check ->
+        def raw = runCheck(check.name, check.run)
+        def result = normalizeResult(check, raw)
+        indexCriterion(releaseStateData, release, check, result)
+    }
+}
+
+/**
+ * Renders a keyed problem map into a readable one-line summary for the criterion's details field,
+ * e.g. [SQL: [CVE-1, CVE-2], Alerting: [CVE-3]] -> "SQL: CVE-1, CVE-2; Alerting: CVE-3".
+ */
+private String renderDetails(Map<String, List<String>> problemsByKey) {
+    return problemsByKey.collect { key, items -> "${key}: ${items.join(', ')}" }.join('; ')
+}
+
+/**
+ * checkUnpatchedVulnerabilities returns a Map of project -> blocking CVE ids. The projects are the
+ * blocking components; the per-project CVE breakdown is preserved in details.
+ */
+private Map renderVulnerabilityResults(Map<String, List<String>> byProject) {
+    return [blockingComponents: byProject.keySet().toList(), details: renderDetails(byProject)]
+}
+
+/**
+ * checkIntegTestResultsOverview always returns a Map keyed by every "${dist}_${arch}", with an empty
+ * list for combinations where nothing failed. The failing components (deduped across arch/dist) are
+ * the blocking components; only the combinations that actually had failures are kept in details.
+ */
+private Map renderIntegResults(Map<String, List<String>> byDistArch) {
+    Map<String, List<String>> failing = byDistArch.findAll { distArch, components -> components }
+    List<String> components = failing.values().flatten().unique()
+    return [blockingComponents: components, details: failing ? renderDetails(failing) : null]
+}
+
+/**
+ * Invokes a chore check, returning its raw result, or null if the check threw so it is recorded
+ * as 'unknown' rather than silently passing.
+ */
+private def runCheck(String name, Closure check) {
+    try {
+        return check.call()
+    } catch (Exception e) {
+        echo("Check '${name}' failed to run: ${e.getMessage()}. Recording status as unknown.")
+        return null
+    }
+}
+
+/**
+ * Normalizes a check's raw result into an explicit [blockingComponents, details] contract so
+ * indexCriterion never has to infer which axis of a Map is the component.
+ *   - null (the check threw)      -> null, recorded as 'unknown'
+ *   - checks with a render closure -> that closure derives components vs details
+ *   - otherwise (a List<String>)   -> the list is the blocking components, no details
+ *
+ * "Met" is decided downstream from blockingComponents being empty, not from the raw container being
+ * empty: checkIntegTestResultsOverview always returns a Map keyed by every arch/dist, with empty
+ * lists when nothing fails, so the container is never empty even when the criterion is met.
+ */
+private Map normalizeResult(Map check, def raw) {
+    if (raw == null) {
+        return null
+    }
+    if (check.render) {
+        return check.render(raw)
+    }
+    return [blockingComponents: raw, details: null]
+}
+
+/**
+ * Builds and indexes a single criterion document from a normalized check result.
+ * null -> unknown, empty blockingComponents -> met, otherwise not_met with the components and details.
+ */
+private void indexCriterion(ReleaseStateData releaseStateData, Map release, Map check, Map result) {
+    String status
+    List<String> blockingComponents = []
+    String details = null
+    if (result == null) {
+        status = 'unknown'
+    } else if (result.blockingComponents.isEmpty()) {
+        status = 'met'
+    } else {
+        status = 'not_met'
+        blockingComponents = result.blockingComponents
+        details = result.details
+    }
+
+    releaseStateData.indexCriterion(new ReleaseCriterion([
+        version            : release.version,
+        releaseDate        : release.releaseDate,
+        product            : check.product,
+        criterionType      : check.type,
+        criterionName      : check.name,
+        status             : status,
+        details            : details,
+        blockingComponents : blockingComponents,
+        source             : 'chore_check',
+        releaseIssue       : release.releaseIssue,
+        checkedBy          : "${env.JOB_NAME} #${env.BUILD_NUMBER}"
+    ]))
+}

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -241,7 +241,7 @@ private def runCheck(String name, Closure check) {
  * empty: checkIntegTestResultsOverview always returns a Map keyed by every arch/dist, with empty
  * lists when nothing fails, so the container is never empty even when the criterion is met.
  */
-private Map normalizeResult(Map check, def raw) {
+private def normalizeResult(Map check, def raw) {
     if (raw == null) {
         return null
     }


### PR DESCRIPTION
### Description
The PR adds a library to index per criteria based status indices to metrics cluster. There are 2 sources:
1. Chore check: The status calculated based on programmatically calculable data
2. Issue check: For some manual components such as release blog readiness, performance tests, etc which will be manually updated by release manager and indexed into the metrics cluster.

### Issues Resolved
https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
