### PR TITLE
Add release type as bundle for DSL query

### DIFF
--- a/src/jenkins/SecurityAdvisoryData.groovy
+++ b/src/jenkins/SecurityAdvisoryData.groovy
@@ -41,6 +41,9 @@ class SecurityAdvisoryData {
     /** The index of project-scoped advisory exemptions, edited live ahead of the next scan. */
     static final String IGNORED_ADVISORIES_INDEX = 'ignored-advisories'
 
+    /** The release_type of components shipped in the bundled distribution (security-advisories#135). */
+    static final String RELEASE_TYPE = 'bundle'
+
     /**
      * Max CVE ids per advisories terms lookup. OpenSearch's default max_terms_count is 65536; a
      * conservative batch keeps payloads small and mirrors the security_advisories agent.
@@ -123,14 +126,15 @@ class SecurityAdvisoryData {
      */
     Map<String, List<String>> getOpenVulnerabilitiesByProject(String scansIndex, String branchTag) {
         Map<String, Set<String>> exemptedByProject = getExemptedAliasesByProject(branchTag)
-        // project.name is carried through so results can be scoped to release components once that
-        // filter lands upstream (security-advisories#132).
         def query = shellEscape([
             size    : QUERY_SIZE,
             sort    : [['timestamp.commit': [order: 'desc']], ['timestamp.scan': [order: 'desc']]],
             collapse: [field: 'project.name'],
             _source : ['project.name', 'vulnerabilities.id', 'vulnerabilities.aliases', 'vulnerabilities.excluded'],
-            query   : [bool: [filter: [[term: ['project.tag': branchTag]]]]]
+            query   : [bool: [filter: [
+                [term: ['project.tag': branchTag]],
+                [term: ['release_type.keyword': RELEASE_TYPE]]
+            ]]]
         ])
         def response = advisoriesQuery.search(scansIndex, query)
         def hits = response?.hits?.hits ?: []

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -123,6 +123,8 @@ class TestSecurityAdvisoryData {
         assertTrue(queryBodies[scansSearch].contains('project.tag'))
         assertTrue(queryBodies[scansSearch].contains('origin/3.8'))
         assertTrue(queryBodies[scansSearch].contains('timestamp.commit'))
+        assertTrue(queryBodies[scansSearch].contains('release_type.keyword'))
+        assertTrue(queryBodies[scansSearch].contains('bundle'))
     }
 
     @Test


### PR DESCRIPTION
### Description
In order to get the unptached vulnerabilities only for release related components, add release_type filter.
Related PR: https://github.com/opensearch-project/security-advisories/pull/135

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
