### PR TITLE
Fix * operator while parsing issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.8.0'
+String version = '13.8.1'
 
 task updateVersion {
     doLast {

--- a/src/jenkins/ReleaseStateData.groovy
+++ b/src/jenkins/ReleaseStateData.groovy
@@ -238,7 +238,9 @@ class ReleaseStateData {
                 if (!line.contains('|')) {
                     return []
                 }
-                List<String> cells = line.split('\\|')*.trim()
+                // Use .collect { it.trim() } rather than the spread operator (*.trim()):
+                // Jenkins CPS transformation does not support spread, and this runs in a CPS context.
+                List<String> cells = line.split('\\|').collect { it.trim() }
                 // A leading pipe (| a | b |) splits to an empty first cell; drop it so the Criteria
                 // and Status columns are at the same indices whether or not the row is pipe-bounded.
                 if (cells && cells[0].isEmpty()) {


### PR DESCRIPTION
### Description
Jenkins CPS does not support the spread operator `*` Hence removing it.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
