### PR TITLE
Fix multiple bugs with indexReleaseState library and add tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ jacocoTestReport {
     }
 }
 
-String version = '13.8.1'
+String version = '13.8.2'
 
 task updateVersion {
     doLast {

--- a/src/jenkins/SecurityAdvisoryData.groovy
+++ b/src/jenkins/SecurityAdvisoryData.groovy
@@ -41,10 +41,19 @@ class SecurityAdvisoryData {
     /** The index of project-scoped advisory exemptions, edited live ahead of the next scan. */
     static final String IGNORED_ADVISORIES_INDEX = 'ignored-advisories'
 
+    /** Index pattern for scan indices (scans-NNNNNN), searched to resolve the most recent one. */
+    static final String SCANS_INDEX_PATTERN = 'scans-*'
+
     /** The per-product release_type of bundled components, keyed by product (security-advisories#135). */
     static final Map<String, String> RELEASE_TYPE_BY_PRODUCT = [
         'opensearch'           : 'bundle_opensearch',
         'opensearch-dashboards': 'bundle_opensearch_dashboards'
+    ]
+
+    /** The core component whose manifest ref determines the scan branch tag, keyed by product. */
+    static final Map<String, String> CORE_COMPONENT_BY_PRODUCT = [
+        'opensearch'           : 'OpenSearch',
+        'opensearch-dashboards': 'OpenSearch-Dashboards'
     ]
 
     /**
@@ -93,9 +102,42 @@ class SecurityAdvisoryData {
     }
 
     /**
+     * Maps a component's manifest ref to the branch tag the scans are keyed on (project.tag). The
+     * manifest ref is the source of truth for the branch a release currently builds from, so before a
+     * release branch is cut the ref is still 'main' and scans are keyed on origin/main, not the
+     * not-yet-existing origin/{major}.{minor}. Manifest refs seen in practice: 'main' (pre-cut),
+     * '3.8' (branch cut, e.g. a patch line), and 'tags/3.8.0' (released).
+     *
+     *   - blank                    -> null (caller falls back to the version)
+     *   - main / latest            -> origin/main
+     *   - already origin/-prefixed -> returned as-is
+     *   - tags/3.8.0               -> origin/3.8
+     *   - '3.8' / 3.8.1            -> origin/3.8
+     *   - anything else            -> origin/{ref}
+     */
+    static String resolveManifestRefTag(String ref) {
+        if (!ref?.trim()) {
+            return null
+        }
+        String cleaned = ref.trim()
+        if (cleaned.startsWith('origin/')) {
+            return cleaned
+        }
+        if (cleaned.toLowerCase() in ['main', 'latest']) {
+            return 'origin/main'
+        }
+        String stripped = cleaned.startsWith('tags/') ? cleaned.substring('tags/'.length()) : cleaned
+        def parts = stripped.tokenize('.')
+        if (parts.size() >= 2 && parts[0].isInteger() && parts[1].isInteger()) {
+            return "origin/${parts[0]}.${parts[1]}"
+        }
+        return "origin/${stripped}"
+    }
+
+    /**
      * Resolves the most recently created scans index. Scan indices are named scans-NNNNNN, so a
-     * cluster-wide search for docs that have timestamp.scan, sorted by _index descending, returns
-     * the highest-numbered (newest) index first.
+     * search over the scans-* pattern for docs that have timestamp.scan, sorted by _index descending,
+     * returns the highest-numbered (newest) index first.
      *
      * @return the concrete scans index name (e.g. scans-000164)
      * @throws RuntimeException if no scans index can be resolved
@@ -107,7 +149,7 @@ class SecurityAdvisoryData {
             sort   : [['_index': [order: 'desc']]],
             _source: false
         ])
-        def response = advisoriesQuery.searchAllIndices(query)
+        def response = advisoriesQuery.search(SCANS_INDEX_PATTERN, query)
         def hits = response?.hits?.hits
         if (!hits) {
             script.error('Could not resolve latest scans index: no scan documents found.')

--- a/src/jenkins/SecurityAdvisoryData.groovy
+++ b/src/jenkins/SecurityAdvisoryData.groovy
@@ -110,7 +110,7 @@ class SecurityAdvisoryData {
         def response = advisoriesQuery.searchAllIndices(query)
         def hits = response?.hits?.hits
         if (!hits) {
-            throw new RuntimeException('Could not resolve latest scans index: no scan documents found.')
+            script.error('Could not resolve latest scans index: no scan documents found.')
         }
         return hits[0]._index
     }
@@ -132,7 +132,7 @@ class SecurityAdvisoryData {
     Map<String, List<String>> getOpenVulnerabilitiesByProject(String scansIndex, String branchTag, String product) {
         String releaseType = RELEASE_TYPE_BY_PRODUCT[product]
         if (!releaseType) {
-            throw new RuntimeException("Unknown product '${product}'; expected one of ${RELEASE_TYPE_BY_PRODUCT.keySet()}.")
+            script.error("Unknown product '${product}'; expected one of ${RELEASE_TYPE_BY_PRODUCT.keySet()}.")
         }
         Map<String, Set<String>> exemptedByProject = getExemptedAliasesByProject(branchTag)
         def query = shellEscape([

--- a/src/jenkins/SecurityAdvisoryData.groovy
+++ b/src/jenkins/SecurityAdvisoryData.groovy
@@ -41,9 +41,6 @@ class SecurityAdvisoryData {
     /** The index of project-scoped advisory exemptions, edited live ahead of the next scan. */
     static final String IGNORED_ADVISORIES_INDEX = 'ignored-advisories'
 
-    /** Index pattern for scan indices (scans-NNNNNN), searched to resolve the most recent one. */
-    static final String SCANS_INDEX_PATTERN = 'scans-*'
-
     /** The per-product release_type of bundled components, keyed by product (security-advisories#135). */
     static final Map<String, String> RELEASE_TYPE_BY_PRODUCT = [
         'opensearch'           : 'bundle_opensearch',
@@ -135,9 +132,11 @@ class SecurityAdvisoryData {
     }
 
     /**
-     * Resolves the most recently created scans index. Scan indices are named scans-NNNNNN, so a
-     * search over the scans-* pattern for docs that have timestamp.scan, sorted by _index descending,
-     * returns the highest-numbered (newest) index first.
+     * Resolves the most recently created scans index. Scan indices are named scans-NNNNNN, so an
+     * unscoped search for docs that have timestamp.scan, sorted by _index descending, returns the
+     * highest-numbered (newest) index first. The search is unscoped rather than scoped to a scans-*
+     * pattern because a wildcard in a SigV4-signed request path is percent-encoded and then read as a
+     * literal index name (matching nothing).
      *
      * @return the concrete scans index name (e.g. scans-000164)
      * @throws RuntimeException if no scans index can be resolved
@@ -149,7 +148,7 @@ class SecurityAdvisoryData {
             sort   : [['_index': [order: 'desc']]],
             _source: false
         ])
-        def response = advisoriesQuery.search(SCANS_INDEX_PATTERN, query)
+        def response = advisoriesQuery.searchForLatestScanIndex(query)
         def hits = response?.hits?.hits
         if (!hits) {
             script.error('Could not resolve latest scans index: no scan documents found.')

--- a/src/utils/OpenSearchMetricsQuery.groovy
+++ b/src/utils/OpenSearchMetricsQuery.groovy
@@ -89,7 +89,7 @@ class OpenSearchMetricsQuery {
     void createIndex(String targetIndex, Map mapping) {
         String httpCode = sendJson('PUT', "${metricsUrl}/${targetIndex}", mapping)
         if (httpCode != '200' && httpCode != '201') {
-            throw new RuntimeException("Failed to create index ${targetIndex}. HTTP status: ${httpCode}")
+            script.error("Failed to create index ${targetIndex}. HTTP status: ${httpCode}")
         }
     }
 
@@ -110,7 +110,7 @@ class OpenSearchMetricsQuery {
         String url = documentId ? "${metricsUrl}/${targetIndex}/_doc/${documentId}" : "${metricsUrl}/${targetIndex}/_doc"
         String httpCode = sendJson(method, url, document)
         if (httpCode != '200' && httpCode != '201') {
-            throw new RuntimeException("Failed to index document into ${targetIndex}. HTTP status: ${httpCode}")
+            script.error("Failed to index document into ${targetIndex}. HTTP status: ${httpCode}")
         }
     }
 

--- a/src/utils/SecurityAdvisoriesQuery.groovy
+++ b/src/utils/SecurityAdvisoriesQuery.groovy
@@ -51,6 +51,20 @@ class SecurityAdvisoriesQuery {
         return response
     }
 
+    /**
+     * Runs an unscoped search (GET /_search with no index in the path) to resolve the most recent
+     * scan index. The path deliberately carries no index name: a wildcard like scans-* would be
+     * percent-encoded by the SigV4 signer and then read as a literal index name (matching nothing),
+     * so the newest scan index is found by searching across the cluster and sorting by _index.
+     * @param query the SigV4-shell-escaped query body
+     */
+    def searchForLatestScanIndex(String query) {
+        this.script.println("Resolving the latest scan index with query: ${query}")
+        def response = runSearch("${advisoriesUrl}/_search", query)
+        this.script.println("Latest-scan-index resolution matched ${response?.hits?.hits?.size() ?: 0} scan doc(s).")
+        return response
+    }
+
     // The cluster endpoint is a secret, so the URL itself is never logged (callers log the index
     // and query instead). Issues the signed request, then fails loudly on an empty body or a cluster
     // error response so a failed query throws (and the caller records the criterion as unknown)

--- a/src/utils/SecurityAdvisoriesQuery.groovy
+++ b/src/utils/SecurityAdvisoriesQuery.groovy
@@ -78,11 +78,11 @@ class SecurityAdvisoriesQuery {
         returnStdout: true
         ).trim()
         if (!rawResponse) {
-            throw new RuntimeException('Advisories cluster returned an empty response.')
+            script.error('Advisories cluster returned an empty response.')
         }
         def response = new JsonSlurperClassic().parseText(rawResponse)
         if (response?.error) {
-            throw new RuntimeException("Advisories cluster query failed: ${response.error}")
+            script.error("Advisories cluster query failed: ${response.error}")
         }
         return response
     }

--- a/src/utils/SecurityAdvisoriesQuery.groovy
+++ b/src/utils/SecurityAdvisoriesQuery.groovy
@@ -51,18 +51,6 @@ class SecurityAdvisoriesQuery {
         return response
     }
 
-    /**
-     * Runs a cluster-wide search (GET /_search with no index prefix), used to resolve which
-     * concrete scan index is the most recent across all indices.
-     * @param query the SigV4-shell-escaped query body
-     */
-    def searchAllIndices(String query) {
-        this.script.println("Querying advisories cluster (all indices) with query: ${query}")
-        def response = runSearch("${advisoriesUrl}/_search", query)
-        this.script.println("Advisories cluster search returned ${response?.hits?.hits?.size() ?: 0} hit(s).")
-        return response
-    }
-
     // The cluster endpoint is a secret, so the URL itself is never logged (callers log the index
     // and query instead). Issues the signed request, then fails loudly on an empty body or a cluster
     // error response so a failed query throws (and the caller records the criterion as unknown)

--- a/tests/jenkins/TestCheckIntegTestResultsOverview.groovy
+++ b/tests/jenkins/TestCheckIntegTestResultsOverview.groovy
@@ -577,6 +577,25 @@ class TestCheckIntegTestResultsOverview extends BuildPipelineTest {
                 hasItem(containsString('\\"rc_number\\":\\"0\\"')))
     }
 
+    @Test
+    void testErrorsWhenRcNumberQueryFails() {
+        // A malformed RC-number response makes getLatestRcNumber return null (a query failure, distinct
+        // from 0). That must error rather than fall back, so the criterion reads as unknown.
+        helper.registerAllowedMethod('sh', [Map], { Map args ->
+            String s = args.script ?: ''
+            if (s.contains('opensearch-distribution-build-results')) {
+                return 'not-json'
+            }
+            return '{"hits":{"hits":[]}}'
+        })
+
+        this.registerLibTester(new CheckIntegTestResultsOverviewLibTester(['tests/data/opensearch-input-2.12.0.yml', 'tests/data/opensearch-dashboards-input-2.12.0.yml']))
+        runScript('tests/jenkins/jobs/CheckIntegTestResultsOverview_Jenkinsfile')
+
+        assertThat(getCommands('error', 'Unable to fetch latest RC number'),
+                hasItem(containsString('Unable to fetch latest RC number from metrics. Received null value.')))
+    }
+
     def getCommands(method, text) {
         def shCommands = helper.callStack.findAll { call ->
             call.methodName == method

--- a/tests/jenkins/TestCheckIntegTestResultsOverview.groovy
+++ b/tests/jenkins/TestCheckIntegTestResultsOverview.groovy
@@ -545,6 +545,38 @@ class TestCheckIntegTestResultsOverview extends BuildPipelineTest {
         assertThat(getCommands('echo', 'Components failing integration tests'), hasItem("Components failing integration tests:\nopensearch:\n  tar_x64: [cross-cluster-replication, ml-commons, sql]\n  rpm_x64: [cross-cluster-replication, ml-commons, sql]\n  deb_x64: [cross-cluster-replication, ml-commons, sql]\n  zip_x64: [cross-cluster-replication, ml-commons, sql]\n  tar_arm64: [cross-cluster-replication, ml-commons, sql]\n  rpm_arm64: [cross-cluster-replication, ml-commons, sql]\n  deb_arm64: [cross-cluster-replication, ml-commons, sql]\nopensearch-dashboards:\n  tar_x64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]\n  rpm_x64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]\n  deb_x64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]\n  zip_x64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]\n  tar_arm64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]\n  rpm_arm64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]\n  deb_arm64: [observabilityDashboards, OpenSearch-Dashboards-ci-group-2]"))
     }
 
+    @Test
+    void testFallsBackToCurrentResultsWhenNoRcYet() {
+        // Before the first successful RC build, getLatestRcNumber returns 0 (not null). The overview
+        // must not error; it queries the current (non-RC, rc_number 0) integration results instead of
+        // recording the criterion as unknown for the whole pre-RC window. Route sh by script content:
+        // the RC-number lookups return zero hits (-> 0), and the rc_number "0" integ queries return a
+        // small failed/passed set.
+        String rcZeroHits = '{"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}'
+        String integResults = '{"hits":{"total":{"value":2,"relation":"eq"},"hits":[' +
+                '{"_source":{"component":"sql","component_build_result":"failed"}},' +
+                '{"_source":{"component":"k-NN","component_build_result":"passed"}}]}}'
+        helper.registerAllowedMethod('sh', [Map], { Map args ->
+            String s = args.script ?: ''
+            if (s.contains('opensearch-distribution-build-results')) {
+                return rcZeroHits
+            }
+            return integResults
+        })
+
+        this.registerLibTester(new CheckIntegTestResultsOverviewLibTester(['tests/data/opensearch-input-2.12.0.yml', 'tests/data/opensearch-dashboards-input-2.12.0.yml']))
+        runScript('tests/jenkins/jobs/CheckIntegTestResultsOverview_Jenkinsfile')
+
+        // The pre-RC fallback is announced and the criterion is computed (not errored to unknown).
+        assertThat(getCommands('echo', 'No successful RC build yet'),
+                hasItem('No successful RC build yet; reporting current (non-RC) integration test results.'))
+        assertThat(getCommands('echo', 'Components failing integration tests'),
+                hasItem(containsString('sql')))
+        // The integ query is keyed on rc_number 0, i.e. the current non-RC results.
+        assertThat(getCommands('sh', 'opensearch-integration-test-results'),
+                hasItem(containsString('\\"rc_number\\":\\"0\\"')))
+    }
+
     def getCommands(method, text) {
         def shCommands = helper.callStack.findAll { call ->
             call.methodName == method

--- a/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
+++ b/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
@@ -43,6 +43,13 @@ class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
             return helper.callClosure(closure)
         })
 
+        // The branch tag is derived from the core component's manifest ref. The job under test is
+        // version 3.8.0, whose real manifest ref is 'tags/3.8.0' -> origin/3.8.
+        helper.registerAllowedMethod('fileExists', [String], { String path -> return true })
+        helper.registerAllowedMethod('readYaml', [Map], { Map args ->
+            return [components: [[name: 'OpenSearch', ref: 'tags/3.8.0']]]
+        })
+
         // Two projects, three open (non-excluded) CVEs; CVE-2 is excluded and must be dropped.
         scansResponse = '''
             {
@@ -82,15 +89,16 @@ class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
             }
         '''
 
-        // Route each cluster search by the index in its URL: the index-less _search resolves the
-        // latest scans index, scans-* returns open vulnerabilities, advisories returns aged CVEs.
+        // Route each cluster search by the index in its URL: the scans-* search resolves the latest
+        // scans index, the concrete scans-NNNNNN returns open vulnerabilities, advisories returns
+        // aged CVEs, ignored-advisories returns exemptions.
         helper.registerAllowedMethod('sh', [Map.class], { Map args ->
             String s = args.script
             def indexMatcher = (s =~ /sample\.url\/([^\/]*)\/?_search/)
             String index = indexMatcher ? indexMatcher[0][1] : null
             def bodyMatcher = (s =~ /-d "(.*)" \| jq/)
             searches.add([index: index, body: bodyMatcher ? bodyMatcher[0][1] : null])
-            if (index == null || index.isEmpty()) {
+            if (index == 'scans-*') {
                 return '{"hits":{"hits":[{"_index":"scans-000335"}]}}'
             }
             if (index == 'ignored-advisories') {
@@ -117,11 +125,34 @@ class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
     @Test
     void testReleaseBranchTagIsFilteredOnTheScansSearch() {
         runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
-        def scansSearch = searches.find { it.index?.startsWith('scans-') }
+        def scansSearch = searches.find { it.index?.startsWith('scans-0') }
         assert scansSearch != null
         assert scansSearch.body.contains('project.tag')
         assert scansSearch.body.contains('origin/3.8')
         assert scansSearch.body.contains('bundle_opensearch')
+    }
+
+    @Test
+    void testBranchTagComesFromManifestRefNotVersionBeforeBranchCut() {
+        // Before the release branch is cut the core ref is still 'main', so the scan must be keyed on
+        // origin/main — not origin/3.8 derived from the version (the bug this fixes).
+        helper.registerAllowedMethod('readYaml', [Map], { Map args ->
+            return [components: [[name: 'OpenSearch', ref: 'main']]]
+        })
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        assertThat(getCommands('echo', 'published on or before'),
+                hasItem('Checking unpatched medium-or-higher vulnerabilities for origin/main (published on or before 2026-06-16T23:59:59.999Z).'))
+        def scansSearch = searches.find { it.index?.startsWith('scans-0') }
+        assert scansSearch.body.contains('origin/main')
+    }
+
+    @Test
+    void testBranchTagFallsBackToVersionWhenManifestMissing() {
+        // No manifest on disk -> derive the tag from the version (3.8.0 -> origin/3.8).
+        helper.registerAllowedMethod('fileExists', [String], { String path -> return false })
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        assertThat(getCommands('echo', 'published on or before'),
+                hasItem('Checking unpatched medium-or-higher vulnerabilities for origin/3.8 (published on or before 2026-06-16T23:59:59.999Z).'))
     }
 
     @Test

--- a/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
+++ b/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
@@ -156,6 +156,28 @@ class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
     }
 
     @Test
+    void testBranchTagFromAlreadyPrefixedManifestRef() {
+        // A ref already in origin/ form is passed through unchanged.
+        helper.registerAllowedMethod('readYaml', [Map], { Map args ->
+            return [components: [[name: 'OpenSearch', ref: 'origin/2.19']]]
+        })
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        assertThat(getCommands('echo', 'published on or before'),
+                hasItem('Checking unpatched medium-or-higher vulnerabilities for origin/2.19 (published on or before 2026-06-16T23:59:59.999Z).'))
+    }
+
+    @Test
+    void testBranchTagFromNonNumericManifestRef() {
+        // A non-version ref is prefixed rather than reduced to major.minor.
+        helper.registerAllowedMethod('readYaml', [Map], { Map args ->
+            return [components: [[name: 'OpenSearch', ref: 'feature-branch']]]
+        })
+        runScript('tests/jenkins/jobs/CheckUnpatchedVulnerabilities_Jenkinsfile')
+        assertThat(getCommands('echo', 'published on or before'),
+                hasItem('Checking unpatched medium-or-higher vulnerabilities for origin/feature-branch (published on or before 2026-06-16T23:59:59.999Z).'))
+    }
+
+    @Test
     void testCriterionMetWhenNoAgedAdvisories() {
         // No advisory is aged medium-or-higher, so the criterion is met (empty map).
         advisoriesResponse = '{"hits":{"hits":[]}}'

--- a/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
+++ b/tests/jenkins/TestCheckUnpatchedVulnerabilities.groovy
@@ -89,16 +89,16 @@ class TestCheckUnpatchedVulnerabilities extends BuildPipelineTest {
             }
         '''
 
-        // Route each cluster search by the index in its URL: the scans-* search resolves the latest
-        // scans index, the concrete scans-NNNNNN returns open vulnerabilities, advisories returns
-        // aged CVEs, ignored-advisories returns exemptions.
+        // Route each cluster search by the index in its URL: the index-less _search resolves the
+        // latest scans index, the concrete scans-NNNNNN returns open vulnerabilities, advisories
+        // returns aged CVEs, ignored-advisories returns exemptions.
         helper.registerAllowedMethod('sh', [Map.class], { Map args ->
             String s = args.script
             def indexMatcher = (s =~ /sample\.url\/([^\/]*)\/?_search/)
             String index = indexMatcher ? indexMatcher[0][1] : null
             def bodyMatcher = (s =~ /-d "(.*)" \| jq/)
             searches.add([index: index, body: bodyMatcher ? bodyMatcher[0][1] : null])
-            if (index == 'scans-*') {
+            if (index == null || index.isEmpty()) {
                 return '{"hits":{"hits":[{"_index":"scans-000335"}]}}'
             }
             if (index == 'ignored-advisories') {

--- a/tests/jenkins/TestIndexReleaseState.groovy
+++ b/tests/jenkins/TestIndexReleaseState.groovy
@@ -1,0 +1,298 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package jenkins.tests
+
+import groovy.json.JsonSlurperClassic
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.MatcherAssert.assertThat
+
+/**
+ * Tests for the indexReleaseState var.
+ *
+ * The var orchestrates: read active releases from the schedule index (a curl via sh), run each
+ * automated chore check, normalize its result, and index one criterion doc per check; then parse
+ * the release issue's manual-criteria tables and index one doc per manual row.
+ *
+ * The chore vars are stubbed by name via registerAllowedMethod so each chore's OUTCOME can be
+ * injected directly, and the indexed documents are captured from the writeFile payloads (every
+ * indexDocument writes the body to a temp file before the POST). Asserting on those payloads
+ * exercises statusOf, indexCriterion, normalizeResult, the per-check render closures, and
+ * indexManualCriteriaForRelease end to end.
+ */
+class TestIndexReleaseState extends BuildPipelineTest {
+
+    // The active-releases search response returned by the schedule-index curl (a single active
+    // release with a release issue so the manual-criteria path also runs).
+    private static final String ACTIVE_RELEASES_RESPONSE = '''
+        {
+          "hits": {
+            "hits": [
+              {
+                "_source": {
+                  "version": "3.9.0",
+                  "release_date": "2026-09-15",
+                  "release_issue": "https://github.com/opensearch-project/opensearch-build/issues/6062"
+                }
+              }
+            ]
+          }
+        }
+    '''
+
+    // A minimal release issue body with one manual criterion per table, each with a status circle,
+    // so parseManualCriteria yields entrance-both, exit-opensearch, exit-osd manual rows.
+    private static final String ISSUE_BODY = '''\
+## Entrance Criteria
+| Criteria | Status | Description |
+| --- | --- | --- |
+| Security reviews are complete | :green_circle: | done |
+
+## OpenSearch 3.9.0 [Exit Criteria]
+| Criteria | Status | Description |
+| --- | --- | --- |
+| Performance tests are run | :yellow_circle: | in progress |
+
+## OpenSearch Dashboards 3.9.0 [Exit Criteria]
+| Criteria | Status | Description |
+| --- | --- | --- |
+| Release blog is ready | :red_circle: | not started |
+'''
+
+    // Captured index documents (parsed JSON), one per writeFile call.
+    private List<Map> indexedDocs
+
+    // Chore outcomes for the current test; keyed by var name. Overridable per test before running.
+    private Map choreOutcomes
+
+    // Chore var names that should throw when invoked, to exercise the runCheck -> 'unknown' path.
+    private Set choreThrows
+
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+        indexedDocs = []
+        choreThrows = [] as Set
+        binding.setVariable('METRICS_HOST_ACCOUNT', 'METRICS_HOST_ACCOUNT')
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken',
+                'JOB_NAME'             : 'release-state',
+                'BUILD_NUMBER'         : '7'
+        ])
+        binding.setVariable('GITHUB_USER', 'GITHUB_USER')
+        binding.setVariable('GITHUB_TOKEN', 'GITHUB_TOKEN')
+        helper.registerAllowedMethod('withSecrets', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('withAWS', [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+
+        // Default chore outcomes: all checks "met" (empty problems). Individual tests override.
+        choreOutcomes = [
+            checkRequestAssignReleaseOwners : [],
+            checkDocumentationIssues        : [],
+            checkCodeCoverage               : [],
+            checkReleaseNotes               : [],
+            checkReleaseIssues              : [],
+            checkDocumentationPullRequests  : [],
+            checkIntegTestResultsOverview   : ['opensearch': ['linux_x64': []], 'opensearch-dashboards': ['linux_x64': []]],
+            checkUnpatchedVulnerabilities   : [:]
+        ]
+
+        // The active-releases read is a curl (XGET) via sh returning stdout; the manual-criteria
+        // read is a `gh issue view` via sh; every index write is a POST curl returning an HTTP code.
+        // Dispatch on the script text.
+        helper.registerAllowedMethod('sh', [Map], { Map callArgs ->
+            String script = callArgs.script ?: ''
+            if (script.contains('_search')) {
+                return ACTIVE_RELEASES_RESPONSE
+            }
+            if (script.contains('gh issue view')) {
+                return ISSUE_BODY
+            }
+            return '201'
+        })
+
+        // Every indexed document is written to a temp file before the POST; capture and parse it.
+        helper.registerAllowedMethod('writeFile', [Map], { Map callArgs ->
+            indexedDocs.add(new JsonSlurperClassic().parseText(callArgs.text))
+            return null
+        })
+    }
+
+    /**
+     * Loads the job, then overrides each chore var before running.
+     *
+     * A chore call from indexReleaseState (checkCodeCoverage(...)) dispatches through the framework's
+     * allowed-method registry, not the binding. loadScript's setGlobalVars registers every loaded
+     * library global (including the real chore vars) as allowed methods, overwriting any override
+     * registered in setUp. Re-registering the chores AFTER load but BEFORE run is the only point at
+     * which the injected outcomes win. Each override returns choreOutcomes[name] (read at call time,
+     * so a test can set the outcome before calling this), or throws when the name is present in
+     * choreThrows to exercise the runCheck -> 'unknown' path.
+     */
+    private void runIndexReleaseState() {
+        def script = loadScript('tests/jenkins/jobs/IndexReleaseState_Jenkinsfile')
+        ['checkRequestAssignReleaseOwners', 'checkDocumentationIssues', 'checkCodeCoverage',
+         'checkReleaseNotes', 'checkReleaseIssues', 'checkDocumentationPullRequests',
+         'checkIntegTestResultsOverview', 'checkUnpatchedVulnerabilities'].each { String name ->
+            helper.registerAllowedMethod(name, [Map], { Map callArgs ->
+                if (choreThrows.contains(name)) {
+                    throw new RuntimeException('boom')
+                }
+                return choreOutcomes[name]
+            })
+        }
+        runScript(script)
+    }
+
+    private List<Map> criterionDocs(String name) {
+        return indexedDocs.findAll { it.criterion_name == name }
+    }
+
+    private Map criterionDoc(String name, String product) {
+        return indexedDocs.find { it.criterion_name == name && it.product == product }
+    }
+
+    def getCommands(String methodName, String searchString) {
+        def matches = []
+        helper.callStack.findAll { call -> call.methodName == methodName }.each { call ->
+            def args = callArgsToString(call)
+            if (args.contains(searchString)) {
+                matches.add(args)
+            }
+        }
+        return matches
+    }
+
+    @Test
+    void testAllChecksMetIndexGreenAndManualCriteria() {
+        runIndexReleaseState()
+
+        // 10 chore criteria docs (8 unique names; integration tests and vulnerabilities are each
+        // indexed once per product) + 3 manual criteria docs.
+        assert indexedDocs.findAll { it.source == 'chore_check' }.size() == 10
+        assert indexedDocs.findAll { it.source == 'issue_table' }.size() == 3
+
+        // Every chore check returned no blocking components -> met.
+        assert criterionDocs('code_coverage_not_decreased').every { it.status == 'met' }
+        assert criterionDoc('release_owners_assigned', 'both').status == 'met'
+
+        // Manual rows carry the circle-mapped status, product from their table, source issue_table.
+        assert criterionDoc('security_reviews_complete', 'both').status == 'met'
+        assert criterionDoc('performance_tests_posted', 'opensearch').status == 'in_progress'
+        assert criterionDoc('release_blog_ready', 'opensearch-dashboards').status == 'not_met'
+    }
+
+    @Test
+    void testProgressLoggingPerCheck() {
+        runIndexReleaseState()
+        assertThat(getCommands('echo', 'active release'),
+                hasItem('Found 1 active release(s) in the schedule index.'))
+        assertThat(getCommands('echo', 'Running check'),
+                hasItem("Running check 'code_coverage_not_decreased [both]' for version 3.9.0."))
+        assertThat(getCommands('echo', 'recorded as'),
+                hasItem("Check 'code_coverage_not_decreased [both]' for version 3.9.0 recorded as 'met'."))
+    }
+
+    @Test
+    void testNotMetWhenChoreReturnsBlockingComponents() {
+        choreOutcomes.checkCodeCoverage = ['k-NN', 'SQL']
+        runIndexReleaseState()
+
+        Map doc = criterionDoc('code_coverage_not_decreased', 'both')
+        assert doc.status == 'not_met'
+        assert doc.blocking_components == ['k-NN', 'SQL']
+        assertThat(getCommands('echo', 'recorded as'),
+                hasItem("Check 'code_coverage_not_decreased [both]' for version 3.9.0 recorded as 'not_met'."))
+    }
+
+    @Test
+    void testUnknownWhenChoreThrows() {
+        choreThrows = ['checkReleaseNotes'] as Set
+        runIndexReleaseState()
+
+        assert criterionDoc('release_notes_ready', 'both').status == 'unknown'
+        assertThat(getCommands('echo', 'failed to run'),
+                hasItem("Check 'release_notes_ready [both]' failed to run: boom. Recording status as unknown."))
+    }
+
+    @Test
+    void testVulnerabilitiesRenderBlockingComponentsAndDetails() {
+        choreOutcomes.checkUnpatchedVulnerabilities = ['SQL': ['CVE-1', 'CVE-2'], 'Alerting': ['CVE-3']]
+        runIndexReleaseState()
+
+        // no_unpatched_vulnerabilities is indexed once per product; the stub returns the same map for both.
+        Map doc = criterionDoc('no_unpatched_vulnerabilities', 'opensearch')
+        assert doc.status == 'not_met'
+        assert doc.blocking_components.sort() == ['Alerting', 'SQL']
+        assert doc.details.contains('SQL: CVE-1, CVE-2')
+        assert doc.details.contains('Alerting: CVE-3')
+    }
+
+    @Test
+    void testIntegResultsRenderFailingComponents() {
+        choreOutcomes.checkIntegTestResultsOverview = [
+            'opensearch'           : ['linux_x64': ['sql'], 'linux_arm64': []],
+            'opensearch-dashboards': ['linux_x64': []]
+        ]
+        runIndexReleaseState()
+
+        Map os = criterionDoc('all_integration_tests_passing', 'opensearch')
+        assert os.status == 'not_met'
+        assert os.blocking_components == ['sql']
+
+        Map osd = criterionDoc('all_integration_tests_passing', 'opensearch-dashboards')
+        assert osd.status == 'met'
+    }
+
+    @Test
+    void testNoActiveReleasesShortCircuits() {
+        helper.registerAllowedMethod('sh', [Map], { Map callArgs ->
+            String script = callArgs.script ?: ''
+            if (script.contains('_search')) {
+                return '{"hits": {"hits": []}}'
+            }
+            return '201'
+        })
+        runIndexReleaseState()
+
+        assert indexedDocs.isEmpty()
+        assertThat(getCommands('echo', 'No active releases'),
+                hasItem('No active releases to index state for.'))
+    }
+
+    @Test
+    void testManualCriteriaSkippedWhenNoReleaseIssue() {
+        helper.registerAllowedMethod('sh', [Map], { Map callArgs ->
+            String script = callArgs.script ?: ''
+            if (script.contains('_search')) {
+                return '{"hits": {"hits": [{"_source": {"version": "3.9.0", "release_date": "2026-09-15"}}]}}'
+            }
+            return '201'
+        })
+        runIndexReleaseState()
+
+        // Chore docs still indexed; no manual (issue_table) docs.
+        assert indexedDocs.findAll { it.source == 'chore_check' }.size() == 10
+        assert indexedDocs.findAll { it.source == 'issue_table' }.isEmpty()
+        assertThat(getCommands('echo', 'skipping manual criteria'),
+                hasItem('No release issue for version 3.9.0; skipping manual criteria.'))
+    }
+}

--- a/tests/jenkins/TestIndexReleaseState.groovy
+++ b/tests/jenkins/TestIndexReleaseState.groovy
@@ -299,6 +299,24 @@ class TestIndexReleaseState extends BuildPipelineTest {
     }
 
     @Test
+    void testManualCriteriaSkippedWhenReleaseIssueUrlInvalid() {
+        helper.registerAllowedMethod('sh', [Map], { Map callArgs ->
+            String script = callArgs.script ?: ''
+            if (script.contains('_search')) {
+                return '{"hits": {"hits": [{"_source": {"version": "3.9.0", "release_date": "2026-09-15", "release_issue": "not-a-url"}}]}}'
+            }
+            return '201'
+        })
+        runIndexReleaseState()
+
+        // An invalid issue URL never reaches gh; manual criteria are skipped.
+        assert getCommands('sh', 'gh issue view').isEmpty()
+        assert indexedDocs.findAll { it.source == 'issue_table' }.isEmpty()
+        assertThat(getCommands('echo', 'not a valid issue URL'),
+                hasItem("Release issue 'not-a-url' for version 3.9.0 is not a valid issue URL; skipping manual criteria."))
+    }
+
+    @Test
     void testCriteriaFilterIndexesOnlyRequestedChoreCriterion() {
         runIndexReleaseState('code_coverage_not_decreased')
 

--- a/tests/jenkins/TestIndexReleaseState.groovy
+++ b/tests/jenkins/TestIndexReleaseState.groovy
@@ -147,7 +147,9 @@ class TestIndexReleaseState extends BuildPipelineTest {
      * so a test can set the outcome before calling this), or throws when the name is present in
      * choreThrows to exercise the runCheck -> 'unknown' path.
      */
-    private void runIndexReleaseState() {
+    private void runIndexReleaseState(criteria = null) {
+        // The job wrapper reads CRITERIA from the binding and passes it as args.criteria (null = all).
+        binding.setVariable('CRITERIA', criteria)
         def script = loadScript('tests/jenkins/jobs/IndexReleaseState_Jenkinsfile')
         ['checkRequestAssignReleaseOwners', 'checkDocumentationIssues', 'checkCodeCoverage',
          'checkReleaseNotes', 'checkReleaseIssues', 'checkDocumentationPullRequests',
@@ -294,5 +296,78 @@ class TestIndexReleaseState extends BuildPipelineTest {
         assert indexedDocs.findAll { it.source == 'issue_table' }.isEmpty()
         assertThat(getCommands('echo', 'skipping manual criteria'),
                 hasItem('No release issue for version 3.9.0; skipping manual criteria.'))
+    }
+
+    @Test
+    void testCriteriaFilterIndexesOnlyRequestedChoreCriterion() {
+        runIndexReleaseState('code_coverage_not_decreased')
+
+        // Only the requested chore criterion is indexed; nothing else runs.
+        assert indexedDocs.size() == 1
+        assert indexedDocs[0].criterion_name == 'code_coverage_not_decreased'
+        assert indexedDocs[0].source == 'chore_check'
+        assertThat(getCommands('echo', 'Restricting to criteria'),
+                hasItem('Restricting to criteria: code_coverage_not_decreased.'))
+        // A skipped check never logs a "Running check" line.
+        assert getCommands('echo', "Running check 'release_owners_assigned").isEmpty()
+    }
+
+    @Test
+    void testCriteriaFilterAsListRunsBothProductsOfAName() {
+        // Requesting a per-product criterion by name re-runs both products for it.
+        runIndexReleaseState(['all_integration_tests_passing'])
+
+        def docs = criterionDocs('all_integration_tests_passing')
+        assert docs.size() == 2
+        assert docs.collect { it.product }.sort() == ['opensearch', 'opensearch-dashboards']
+        // No other criteria and no manual docs.
+        assert indexedDocs.size() == 2
+    }
+
+    @Test
+    void testCriteriaFilterSelectsManualCriterionAndSkipsChores() {
+        runIndexReleaseState('security_reviews_complete')
+
+        // Only the one manual criterion is indexed; no chore docs.
+        assert indexedDocs.findAll { it.source == 'chore_check' }.isEmpty()
+        def docs = indexedDocs.findAll { it.source == 'issue_table' }
+        assert docs.size() == 1
+        assert docs[0].criterion_name == 'security_reviews_complete'
+        assert docs[0].status == 'met'
+    }
+
+    @Test
+    void testCriteriaFilterOfOnlyChoreNamesSkipsIssueFetch() {
+        runIndexReleaseState('code_coverage_not_decreased')
+
+        // A filter that names no manual criteria skips the GitHub issue fetch entirely.
+        assert getCommands('sh', 'gh issue view').isEmpty()
+        assertThat(getCommands('echo', 'No manual criteria requested'),
+                hasItem('No manual criteria requested for version 3.9.0; skipping manual criteria.'))
+    }
+
+    @Test
+    void testCommaSeparatedCriteriaStringMixesChoreAndManual() {
+        runIndexReleaseState('code_coverage_not_decreased, security_reviews_complete')
+
+        assert criterionDoc('code_coverage_not_decreased', 'both').source == 'chore_check'
+        assert criterionDoc('security_reviews_complete', 'both').source == 'issue_table'
+        assert indexedDocs.size() == 2
+    }
+
+    @Test
+    void testUnknownCriterionNameAbortsBeforeIndexing() {
+        String message = null
+        helper.registerAllowedMethod('error', [String], { String m ->
+            message = m
+            throw new RuntimeException(m)
+        })
+        try {
+            runIndexReleaseState('not_a_real_criterion')
+        } catch (ignored) {
+            // error() aborts the pipeline; the wrapping exception is expected.
+        }
+        assert message?.contains('Unknown criterion name(s): not_a_real_criterion')
+        assert indexedDocs.isEmpty()
     }
 }

--- a/tests/jenkins/TestIndexReleaseState.groovy
+++ b/tests/jenkins/TestIndexReleaseState.groovy
@@ -244,24 +244,39 @@ class TestIndexReleaseState extends BuildPipelineTest {
         Map doc = criterionDoc('no_unpatched_vulnerabilities', 'opensearch')
         assert doc.status == 'not_met'
         assert doc.blocking_components.sort() == ['Alerting', 'SQL']
-        assert doc.details.contains('SQL: CVE-1, CVE-2')
-        assert doc.details.contains('Alerting: CVE-3')
+        // Each key's items are bracketed so the per-key list is visually distinct.
+        assert doc.details.contains('SQL: [CVE-1, CVE-2]')
+        assert doc.details.contains('Alerting: [CVE-3]')
     }
 
     @Test
     void testIntegResultsRenderFailingComponents() {
         choreOutcomes.checkIntegTestResultsOverview = [
-            'opensearch'           : ['linux_x64': ['sql'], 'linux_arm64': []],
+            'opensearch'           : ['linux_x64': ['sql', 'k-NN'], 'linux_arm64': ['sql']],
             'opensearch-dashboards': ['linux_x64': []]
         ]
         runIndexReleaseState()
 
         Map os = criterionDoc('all_integration_tests_passing', 'opensearch')
         assert os.status == 'not_met'
-        assert os.blocking_components == ['sql']
+        // blocking_components is the deduped union across dist/arch.
+        assert os.blocking_components.sort() == ['k-NN', 'sql']
+        // details keeps each dist/arch's own bracketed list (x64 and arm64 can differ).
+        assert os.details.contains('linux_x64: [sql, k-NN]')
+        assert os.details.contains('linux_arm64: [sql]')
 
         Map osd = criterionDoc('all_integration_tests_passing', 'opensearch-dashboards')
         assert osd.status == 'met'
+    }
+
+    @Test
+    void testDaysToReleaseComputedFromReleaseDate() {
+        // release_date is 2026-09-15 (see ACTIVE_RELEASES_RESPONSE); days_to_release is computed on
+        // the fly at check time, so assert it is a populated integer rather than the old null.
+        runIndexReleaseState()
+        Map doc = criterionDoc('code_coverage_not_decreased', 'both')
+        assert doc.days_to_release != null
+        assert doc.days_to_release instanceof Integer
     }
 
     @Test

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -69,12 +69,29 @@ class TestSecurityAdvisoryData {
     }
 
     @Test
+    void testResolveManifestRefTagMapsRefsToBranchTags() {
+        // The three ref formats seen in real manifests.
+        assertEquals('origin/main', SecurityAdvisoryData.resolveManifestRefTag('main'))
+        assertEquals('origin/3.8', SecurityAdvisoryData.resolveManifestRefTag('tags/3.8.0'))
+        assertEquals('origin/3.8', SecurityAdvisoryData.resolveManifestRefTag('3.8'))
+        assertEquals('origin/3.8', SecurityAdvisoryData.resolveManifestRefTag('3.8.1'))
+        assertEquals('origin/main', SecurityAdvisoryData.resolveManifestRefTag('latest'))
+        // An already-resolved tag is passed through unchanged.
+        assertEquals('origin/2.19', SecurityAdvisoryData.resolveManifestRefTag('origin/2.19'))
+        // A non-version ref is prefixed rather than mangled.
+        assertEquals('origin/some-branch', SecurityAdvisoryData.resolveManifestRefTag('some-branch'))
+        // Blank/absent ref returns null so the caller can fall back to the version.
+        assertEquals(null, SecurityAdvisoryData.resolveManifestRefTag(null))
+        assertEquals(null, SecurityAdvisoryData.resolveManifestRefTag('   '))
+    }
+
+    @Test
     void testGetLatestScansIndexReturnsHighestNumberedIndex() {
-        // The cluster-wide search sorts _index desc, so the first hit is the newest scans index.
+        // The scans-* search sorts _index desc, so the first hit is the newest scans index.
         responses = ['{"hits":{"hits":[{"_index":"scans-000335"}]}}']
         assertEquals('scans-000335', advisoryData.getLatestScansIndex())
-        // Resolved via a cluster-wide search (no index prefix in the URL).
-        assertEquals('', searchedIndices[0])
+        // Resolved via a search scoped to the scans-* index pattern.
+        assertEquals(SecurityAdvisoryData.SCANS_INDEX_PATTERN, searchedIndices[0])
     }
 
     @Test

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -38,6 +38,7 @@ class TestSecurityAdvisoryData {
         ignoredAdvisoriesResponse = '{"hits":{"hits":[]}}'
         script = new Expando()
         script.println = { msg -> }
+        script.error = { String message -> throw new RuntimeException(message) }
         script.sh = { Map args ->
             String s = args.script
             def matcher = (s =~ /${advisoriesUrl}\/([^\/]*)\/?_search/)

--- a/tests/jenkins/TestSecurityAdvisoryData.groovy
+++ b/tests/jenkins/TestSecurityAdvisoryData.groovy
@@ -87,11 +87,12 @@ class TestSecurityAdvisoryData {
 
     @Test
     void testGetLatestScansIndexReturnsHighestNumberedIndex() {
-        // The scans-* search sorts _index desc, so the first hit is the newest scans index.
+        // The unscoped search sorts _index desc, so the first hit is the newest scans index.
         responses = ['{"hits":{"hits":[{"_index":"scans-000335"}]}}']
         assertEquals('scans-000335', advisoryData.getLatestScansIndex())
-        // Resolved via a search scoped to the scans-* index pattern.
-        assertEquals(SecurityAdvisoryData.SCANS_INDEX_PATTERN, searchedIndices[0])
+        // Resolved via an unscoped search (no index prefix in the URL) so a SigV4-encoded wildcard
+        // can never be read as a literal index name.
+        assertEquals('', searchedIndices[0])
     }
 
     @Test

--- a/tests/jenkins/jobs/IndexReleaseState_Jenkinsfile
+++ b/tests/jenkins/jobs/IndexReleaseState_Jenkinsfile
@@ -1,0 +1,20 @@
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('indexReleaseState') {
+            steps {
+                script {
+                    indexReleaseState()
+                }
+            }
+        }
+    }
+}

--- a/tests/jenkins/jobs/IndexReleaseState_Jenkinsfile
+++ b/tests/jenkins/jobs/IndexReleaseState_Jenkinsfile
@@ -12,7 +12,9 @@ pipeline {
         stage('indexReleaseState') {
             steps {
                 script {
-                    indexReleaseState()
+                    // CRITERIA is set by the test binding to exercise the criteria filter; unset it
+                    // defaults to null, which the var treats as "index every criterion".
+                    indexReleaseState(criteria: binding.hasVariable('CRITERIA') ? CRITERIA : null)
                 }
             }
         }

--- a/tests/utils/TestOpenSearchMetricsQuery.groovy
+++ b/tests/utils/TestOpenSearchMetricsQuery.groovy
@@ -57,6 +57,8 @@ class TestOpenSearchMetricsQuery {
             // Mock implementation for println
             println(message)
         }
+
+        script.error = { String message -> throw new RuntimeException(message) }
     }
 
     @Test

--- a/tests/utils/TestSecurityAdvisoriesQuery.groovy
+++ b/tests/utils/TestSecurityAdvisoriesQuery.groovy
@@ -31,6 +31,7 @@ class TestSecurityAdvisoriesQuery {
             return response
         }
         script.println = { message -> }
+        script.error = { String message -> throw new RuntimeException(message) }
     }
 
     @Test

--- a/vars/checkIntegTestResultsOverview.groovy
+++ b/vars/checkIntegTestResultsOverview.groovy
@@ -64,9 +64,17 @@ Map<String, Map> call(Map args = [:]) {
             def opensearchRcNumber = releaseCandidateStatus.getLatestRcNumber('OpenSearch')
             def opensearchDashboardsRcNumber = releaseCandidateStatus.getLatestRcNumber('OpenSearch-Dashboards')
 
-            if (opensearchRcNumber == null || opensearchDashboardsRcNumber == null || opensearchRcNumber == 0 || opensearchDashboardsRcNumber == 0) {
-                    error("Unable to fetch latest RC number from metrics. Received null or 0 value.")
+            // getLatestRcNumber returns null only on a query failure, and 0 when no successful RC
+            // build exists yet (the normal pre-RC state, before the RC date). A null is a real error;
+            // a 0 is not — before the first RC, fall back to the current non-RC integration results
+            // (rc_number 0) so the criterion reflects live test status instead of reading as unknown
+            // for the whole pre-RC window.
+            if (opensearchRcNumber == null || opensearchDashboardsRcNumber == null) {
+                    error("Unable to fetch latest RC number from metrics. Received null value.")
             } else {
+                if (opensearchRcNumber == 0 || opensearchDashboardsRcNumber == 0) {
+                    echo("No successful RC build yet; reporting current (non-RC) integration test results.")
+                }
                 archDistMap.each {arch, distributions ->
                     distributions.each { dist ->
                         failingComponents['opensearch']["${dist}_${arch}"] = componentIntegTestStatus.getAllFailedComponents(opensearchRcNumber, dist, arch, openSearchComponents)

--- a/vars/checkUnpatchedVulnerabilities.groovy
+++ b/vars/checkUnpatchedVulnerabilities.groovy
@@ -24,13 +24,21 @@ import java.time.format.DateTimeFormatter
  * only if it will have been public for more than 60 days by the time the release ships. When no
  * release date is supplied, it falls back to now() - 60 days.
  *
- * The version is resolved to a branch tag (origin/3.8, origin/main) — never the exact 3.8.0 tag,
- * which only exists after release.
+ * The scan branch tag is resolved from the core component's manifest ref (the source of truth for
+ * the branch a release currently builds from): before the release branch is cut the ref is still
+ * 'main', so scans are keyed on origin/main rather than the not-yet-existing origin/{major}.{minor}.
+ * The product's manifest path is derived from the version and product
+ * (manifests/{version}/{product}-{version}.yml); when it cannot be read or lacks the core ref, it
+ * falls back to deriving the tag from the version. Never the exact 3.8.0 tag, which only exists
+ * after release.
  *
  * @param Map args = [:] args A map of the following parameters
- * @param args.version <required> - Release version, e.g. "3.8.0" or "3.8" (resolved to origin/3.8).
+ * @param args.version <required> - Release version, e.g. "3.8.0"; locates the product manifest and is
+ *                                   the branch-tag fallback when the manifest ref is unavailable.
  * @param args.product <required> - Release product to scope to: 'opensearch' or
- *                                   'opensearch-dashboards'; selects the bundled components checked.
+ *                                   'opensearch-dashboards'; selects the bundled components checked,
+ *                                   the product manifest, and the core component whose ref sets the
+ *                                   branch tag.
  * @param args.releaseDate <optional> - Release date as yyyy-MM-dd; the age window is measured back
  *                                       from this date. Falls back to today when omitted.
  * @return Map of project name -> list of its blocking CVE ids (empty map when the criterion is met).
@@ -51,8 +59,8 @@ Map<String, List<String>> call(Map args = [:]) {
         [envVar: 'ADVISORIES_HOST_URL', secretRef: 'op://opensearch-release-secrets/security-advisories-cluster/security-advisories-cluster-endpoint']
     ]
 
-    String branchTag = SecurityAdvisoryData.resolveVersionTag(args.version)
     String product = args.product
+    String branchTag = resolveBranchTag(args.version, product) ?: SecurityAdvisoryData.resolveVersionTag(args.version)
     String cutoffIso = ageCutoffIso(args.releaseDate)
     echo("Checking unpatched medium-or-higher vulnerabilities for ${branchTag} (published on or before ${cutoffIso}).")
 
@@ -90,6 +98,32 @@ Map<String, List<String>> call(Map args = [:]) {
         echo('No unpatched medium-or-higher vulnerabilities older than the 60-day window.')
     }
     return blockingByProject
+}
+
+/**
+ * Resolves the scan branch tag from the core component's manifest ref, or null when the product
+ * manifest cannot be read or its core ref is absent (the caller then falls back to the version). The
+ * manifest path is derived from the version and product; the core component is the product's own
+ * entry (OpenSearch / OpenSearch-Dashboards), whose ref reflects the branch the release currently
+ * builds from, so this is 'main' before the release branch is cut.
+ */
+private String resolveBranchTag(String version, String product) {
+    String coreComponent = SecurityAdvisoryData.CORE_COMPONENT_BY_PRODUCT[product]
+    if (!coreComponent) {
+        return null
+    }
+    String manifestFile = "manifests/${version}/${product}-${version}.yml"
+    if (!fileExists(manifestFile)) {
+        echo("Manifest ${manifestFile} not found; falling back to the version for the branch tag.")
+        return null
+    }
+    def manifest = readYaml(file: manifestFile)
+    def core = manifest.components?.find { it.name == coreComponent }
+    if (!core?.ref) {
+        echo("No '${coreComponent}' ref in ${manifestFile}; falling back to the version for the branch tag.")
+        return null
+    }
+    return SecurityAdvisoryData.resolveManifestRefTag(core.ref)
 }
 
 /**

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -7,6 +7,10 @@
  * compatible open source license.
  */
 
+import com.cloudbees.groovy.cps.NonCPS
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
 import jenkins.ReleaseStateData
 import jenkins.ReleaseCriterion
 import jenkins.ReleaseCriterionCatalog
@@ -313,6 +317,7 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
         releaseStateData.indexCriterion(new ReleaseCriterion([
             version      : release.version,
             releaseDate  : release.releaseDate,
+            daysToRelease: daysToRelease(release.releaseDate),
             product      : criterion.product,
             criterionType: criterion.type,
             criterionName: criterion.name,
@@ -325,11 +330,31 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
 }
 
 /**
+ * Days from today (UTC) until the release date, computed on the fly so each indexed criterion records
+ * how far out the release is at check time. Returns null when the release date is absent or unparseable
+ * (yyyy-MM-dd). Marked @NonCPS: LocalDate/ChronoUnit are not serializable, so the computation must not
+ * leave any of those objects as a live local across a pipeline step.
+ */
+@NonCPS
+private Integer daysToRelease(String releaseDate) {
+    if (!releaseDate?.trim()) {
+        return null
+    }
+    try {
+        return ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.parse(releaseDate.trim())) as Integer
+    } catch (DateTimeParseException ignored) {
+        return null
+    }
+}
+
+/**
  * Renders a keyed problem map into a readable one-line summary for the criterion's details field,
- * e.g. [SQL: [CVE-1, CVE-2], Alerting: [CVE-3]] -> "SQL: CVE-1, CVE-2; Alerting: CVE-3".
+ * e.g. [SQL: [CVE-1, CVE-2], Alerting: [CVE-3]] -> "SQL: [CVE-1, CVE-2]; Alerting: [CVE-3]". Each
+ * key's items are bracketed so a per-key list is visually distinct (e.g. integration-test failures
+ * per dist/arch, where tar_x64 and tar_arm64 can differ).
  */
 private String renderDetails(Map<String, List<String>> problemsByKey) {
-    return problemsByKey.collect { key, items -> "${key}: ${items.join(', ')}" }.join('; ')
+    return problemsByKey.collect { key, items -> "${key}: [${items.join(', ')}]" }.join('; ')
 }
 
 /**
@@ -402,6 +427,7 @@ private void indexCriterion(ReleaseStateData releaseStateData, Map release, Map 
     releaseStateData.indexCriterion(new ReleaseCriterion([
         version            : release.version,
         releaseDate        : release.releaseDate,
+        daysToRelease      : daysToRelease(release.releaseDate),
         product            : check.product,
         criterionType      : check.type,
         criterionName      : check.name,

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -273,11 +273,14 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
         return
     }
 
-    // The release issue is read from the schedule index as a full GitHub issue URL; resolve it to a
-    // bare issue number so a crafted value can never inject into the gh shell command.
-    def issueNumber = (release.releaseIssue =~ /\/issues\/(\d+)/)
-    if (!issueNumber.find()) {
-        echo("Release issue '${release.releaseIssue}' for version ${release.version} is not a valid issue URL; skipping manual criteria.")
+    // gh issue view accepts the full issue URL directly, so the URL from the schedule index is passed
+    // through as-is. It is validated against the expected opensearch-build issue URL shape first so a
+    // crafted value can never inject into the gh shell command. String.matches returns a boolean (not
+    // a java.util.regex.Matcher), so no non-serializable object is held across the pipeline steps
+    // below — holding a Matcher across a step crashes the CPS VM when it persists program state.
+    String issueUrl = release.releaseIssue
+    if (!issueUrl.matches('https://github\\.com/opensearch-project/opensearch-build/issues/\\d+')) {
+        echo("Release issue '${issueUrl}' for version ${release.version} is not a valid issue URL; skipping manual criteria.")
         return
     }
 
@@ -286,11 +289,11 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
         [envVar: 'GITHUB_TOKEN', secretRef: 'op://opensearch-release-secrets/github-bot/ci-bot-token']
     ]
 
-    echo("Reading manual criteria for version ${release.version} from release issue #${issueNumber.group(1)}.")
+    echo("Reading manual criteria for version ${release.version} from release issue ${issueUrl}.")
     String issueBody
     withSecrets(secrets: secret_github_bot) {
         issueBody = sh(
-            script: "gh issue view ${issueNumber.group(1)} --repo opensearch-project/opensearch-build --json body --jq '.body'",
+            script: "gh issue view ${issueUrl} --json body --jq '.body'",
             returnStdout: true
         )
     }

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -34,6 +34,15 @@ void call(Map args = [:]) {
         [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
     ]
 
+    // The outer withAWS assumes OpenSearchJenkinsAccessRole ONLY to capture the metrics-cluster
+    // credentials; it must not enclose the chore loop below. ReleaseStateData signs its reads and
+    // writes with these captured credential strings directly (see OpenSearchMetricsQuery.curlAuthArgs),
+    // so it does not need the ambient AWS session once constructed. Each chore check runs its own
+    // withAWS(role: 'OpenSearchJenkinsAccessRole', ...) internally; if the loop ran inside this outer
+    // assumed-role session, that nested re-assume would fail with sts:AssumeRole AccessDenied (an
+    // assumed-role session cannot re-assume the same role), and every criterion would record 'unknown'.
+    def releaseStateData
+    def releases
     withSecrets(secrets: secret_metrics_cluster) {
         withAWS(role: 'OpenSearchJenkinsAccessRole', roleAccount: "${METRICS_HOST_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-session') {
             def metricsUrl = env.METRICS_HOST_URL
@@ -41,23 +50,26 @@ void call(Map args = [:]) {
             def awsSecretKey = env.AWS_SECRET_ACCESS_KEY
             def awsSessionToken = env.AWS_SESSION_TOKEN
 
-            def releaseStateData = new ReleaseStateData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, this)
-
-            def releases = releaseStateData.getActiveReleases()
-            if (args.version) {
-                releases = releases.findAll { it.version == args.version }
-            }
-            if (releases.isEmpty()) {
-                echo('No active releases to index state for.')
-                return
-            }
-
-            releases.each { release ->
-                echo("Indexing release state for version ${release.version}.")
-                indexCriteriaForRelease(releaseStateData, release)
-                indexManualCriteriaForRelease(releaseStateData, release)
-            }
+            releaseStateData = new ReleaseStateData(metricsUrl, awsAccessKey, awsSecretKey, awsSessionToken, this)
+            releases = releaseStateData.getActiveReleases()
         }
+    }
+    echo("Found ${releases.size()} active release(s) in the schedule index.")
+
+    if (args.version) {
+        releases = releases.findAll { it.version == args.version }
+        echo("Restricting to version ${args.version}: ${releases.size()} match(es).")
+    }
+    if (releases.isEmpty()) {
+        echo('No active releases to index state for.')
+        return
+    }
+    echo("Indexing release state for ${releases.size()} version(s): ${releases.collect { it.version }.join(', ')}.")
+
+    releases.each { release ->
+        echo("Indexing release state for version ${release.version}.")
+        indexCriteriaForRelease(releaseStateData, release)
+        indexManualCriteriaForRelease(releaseStateData, release)
     }
 }
 
@@ -165,10 +177,26 @@ private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map rele
     // ReleaseCriterion's fields mid-compile, re-entering a non-reentrant GroovyClassLoader recompile
     // lock and deadlocking. The loop compiles inline, so that re-entrant path never happens.
     for (check in checks) {
-        def raw = runCheck(check.name, check.run)
+        // Product disambiguates the two per-product criteria (integration tests, vulnerabilities),
+        // which share a criterion name but run once per product.
+        String label = "${check.name} [${check.product}]"
+        echo("Running check '${label}' for version ${version}.")
+        def raw = runCheck(label, check.run)
         def result = normalizeResult(check, raw)
         indexCriterion(releaseStateData, release, check, result)
+        echo("Check '${label}' for version ${version} recorded as '${statusOf(result)}'.")
     }
+}
+
+/**
+ * Reports the status indexCriterion will record for a normalized result, so the check loop can log
+ * the outcome without duplicating the null -> unknown / empty -> met / else -> not_met mapping.
+ */
+private String statusOf(Map result) {
+    if (result == null) {
+        return 'unknown'
+    }
+    return result.blockingComponents.isEmpty() ? 'met' : 'not_met'
 }
 
 /**
@@ -195,6 +223,7 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
         [envVar: 'GITHUB_TOKEN', secretRef: 'op://opensearch-release-secrets/github-bot/ci-bot-token']
     ]
 
+    echo("Reading manual criteria for version ${release.version} from release issue #${issueNumber.group(1)}.")
     String issueBody
     withSecrets(secrets: secret_github_bot) {
         issueBody = sh(
@@ -203,11 +232,15 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
         )
     }
 
+    def manualCriteria = releaseStateData.parseManualCriteria(issueBody)
+    echo("Parsed ${manualCriteria.size()} manual criteria for version ${release.version}.")
+
     // A plain for-loop, not .each { }: constructing a ReleaseCriterion and passing it to a typed method
     // inside a closure body makes the Groovy pipeline-unit compiler resolve ReleaseCriterion's fields
     // mid-compile, re-entering a non-reentrant GroovyClassLoader recompile lock and deadlocking. The
     // loop compiles inline, so that re-entrant path never happens.
-    for (criterion in releaseStateData.parseManualCriteria(issueBody)) {
+    for (criterion in manualCriteria) {
+        echo("Recording manual criterion '${criterion.name} [${criterion.product}]' as '${criterion.status}' for version ${release.version}.")
         releaseStateData.indexCriterion(new ReleaseCriterion([
             version      : release.version,
             releaseDate  : release.releaseDate,
@@ -289,15 +322,10 @@ private def normalizeResult(Map check, def raw) {
  * null -> unknown, empty blockingComponents -> met, otherwise not_met with the components and details.
  */
 private void indexCriterion(ReleaseStateData releaseStateData, Map release, Map check, Map result) {
-    String status
+    String status = statusOf(result)
     List<String> blockingComponents = []
     String details = null
-    if (result == null) {
-        status = 'unknown'
-    } else if (result.blockingComponents.isEmpty()) {
-        status = 'met'
-    } else {
-        status = 'not_met'
+    if (status == 'not_met') {
         blockingComponents = result.blockingComponents
         details = result.details
     }

--- a/vars/indexReleaseState.groovy
+++ b/vars/indexReleaseState.groovy
@@ -9,6 +9,7 @@
 
 import jenkins.ReleaseStateData
 import jenkins.ReleaseCriterion
+import jenkins.ReleaseCriterionCatalog
 
 /**
  * Computes and indexes per-criterion release readiness state for active releases.
@@ -27,8 +28,19 @@ import jenkins.ReleaseCriterion
  * @param Map args = [:] args A map of the following parameters
  * @param args.version <optional> - Restrict to a single release version. When omitted, all active
  *                                   releases from the schedule index are processed.
+ * @param args.criteria <optional> - Restrict to these criterion names (a comma-separated String or a
+ *                                    List of names, e.g. 'code_coverage_not_decreased' or
+ *                                    ['all_integration_tests_passing', 'security_reviews_complete']).
+ *                                    When omitted or empty, every criterion is indexed (the scheduled
+ *                                    cron default). Lets a re-run re-index only the criteria that need
+ *                                    it — e.g. after fixing the cause of a transient failure — instead
+ *                                    of re-running the whole set. Applies to both the automated chore
+ *                                    criteria and the manual (issue-table) criteria. Unknown names are
+ *                                    rejected up front so a typo aborts loudly rather than silently
+ *                                    indexing nothing.
  */
 void call(Map args = [:]) {
+    List<String> criteriaFilter = normalizeCriteriaFilter(args.criteria)
     def secret_metrics_cluster = [
         [envVar: 'METRICS_HOST_ACCOUNT', secretRef: 'op://opensearch-release-secrets/aws-accounts/jenkins-health-metrics-account-number'],
         [envVar: 'METRICS_HOST_URL', secretRef: 'op://opensearch-release-secrets/metrics-cluster/jenkins-health-metrics-cluster-endpoint']
@@ -65,18 +77,49 @@ void call(Map args = [:]) {
         return
     }
     echo("Indexing release state for ${releases.size()} version(s): ${releases.collect { it.version }.join(', ')}.")
+    if (criteriaFilter) {
+        echo("Restricting to criteria: ${criteriaFilter.join(', ')}.")
+    }
 
     releases.each { release ->
         echo("Indexing release state for version ${release.version}.")
-        indexCriteriaForRelease(releaseStateData, release)
-        indexManualCriteriaForRelease(releaseStateData, release)
+        indexCriteriaForRelease(releaseStateData, release, criteriaFilter)
+        indexManualCriteriaForRelease(releaseStateData, release, criteriaFilter)
     }
 }
 
 /**
- * Runs every automated criterion check for a release and indexes a criterion document for each.
+ * Normalizes the optional criteria filter into a list of criterion names and validates each against
+ * the catalog. Accepts a comma-separated String or a List (each element may itself be comma-separated
+ * or carry surrounding whitespace, e.g. from a Jenkins parameter). Returns an empty list when nothing
+ * is requested, which the callers treat as "all criteria". Throws on any name not in the catalog so a
+ * typo aborts the run rather than silently indexing nothing.
  */
-private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map release) {
+private List<String> normalizeCriteriaFilter(rawCriteria) {
+    if (!rawCriteria) {
+        return []
+    }
+    List<String> requested = (rawCriteria instanceof List ? rawCriteria : [rawCriteria])
+        .collectMany { it.toString().split(',').collect { name -> name.trim() } }
+        .findAll { it }
+        .unique()
+    if (!requested) {
+        return []
+    }
+    Set<String> valid = ReleaseCriterionCatalog.values().collect { it.criterionName } as Set
+    List<String> unknown = requested.findAll { !valid.contains(it) }
+    if (unknown) {
+        error("Unknown criterion name(s): ${unknown.join(', ')}. Valid names: ${valid.sort().join(', ')}.")
+    }
+    return requested
+}
+
+/**
+ * Runs the automated criterion checks for a release and indexes a criterion document for each.
+ * When criteriaFilter is non-empty, only checks whose criterion name is in the filter are run and
+ * indexed; an empty filter runs them all.
+ */
+private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map release, List<String> criteriaFilter) {
     String version = release.version
     List<String> inputManifest = [
         "manifests/${version}/opensearch-${version}.yml",
@@ -177,6 +220,12 @@ private void indexCriteriaForRelease(ReleaseStateData releaseStateData, Map rele
     // ReleaseCriterion's fields mid-compile, re-entering a non-reentrant GroovyClassLoader recompile
     // lock and deadlocking. The loop compiles inline, so that re-entrant path never happens.
     for (check in checks) {
+        // Skip checks not in the requested filter (an empty filter runs them all). A per-product
+        // criterion (integration tests, vulnerabilities) is matched by name, so requesting the name
+        // re-runs both products for it.
+        if (criteriaFilter && !criteriaFilter.contains(check.name)) {
+            continue
+        }
         // Product disambiguates the two per-product criteria (integration tests, vulnerabilities),
         // which share a criterion name but run once per product.
         String label = "${check.name} [${check.product}]"
@@ -203,8 +252,22 @@ private String statusOf(Map result) {
  * Reads the manual criteria (no chore verifies them) from the release issue's criteria tables and
  * indexes one criterion document for each. The issue body is fetched with the github-bot token and
  * parsed by ReleaseStateData; each row's status circle is recorded as-is (source 'issue_table').
+ * When criteriaFilter is non-empty, only manual criteria whose name is in the filter are indexed;
+ * if the filter names no manual criteria at all, the GitHub fetch is skipped entirely.
  */
-private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Map release) {
+private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Map release, List<String> criteriaFilter) {
+    // When a filter is set but names only chore criteria, there is nothing manual to do — skip the
+    // issue fetch (and its github-bot secret + gh call) rather than reading the issue for nothing.
+    if (criteriaFilter) {
+        Set<String> manualNames = ReleaseCriterionCatalog.values()
+            .findAll { it.source == ReleaseCriterionCatalog.SOURCE_ISSUE_TABLE }
+            .collect { it.criterionName } as Set
+        if (!criteriaFilter.any { manualNames.contains(it) }) {
+            echo("No manual criteria requested for version ${release.version}; skipping manual criteria.")
+            return
+        }
+    }
+
     if (!release.releaseIssue) {
         echo("No release issue for version ${release.version}; skipping manual criteria.")
         return
@@ -233,6 +296,9 @@ private void indexManualCriteriaForRelease(ReleaseStateData releaseStateData, Ma
     }
 
     def manualCriteria = releaseStateData.parseManualCriteria(issueBody)
+    if (criteriaFilter) {
+        manualCriteria = manualCriteria.findAll { criteriaFilter.contains(it.name) }
+    }
     echo("Parsed ${manualCriteria.size()} manual criteria for version ${release.version}.")
 
     // A plain for-loop, not .each { }: constructing a ReleaseCriterion and passing it to a typed method


### PR DESCRIPTION
### Description

**indexReleaseState.groovy**
- Fix withAWS nesting that made every criterion record as unknown (nested re-assume of the same role → AccessDenied).
- Add optional criteria filter to re-index only selected criteria (empty = all); validated against the catalog.
- Compute days_to_release on the fly (was always null).
- Fetch the release issue by full URL (removes a non-serializable Matcher held across a step that crashed the CPS VM).
- Bracket details lists (key: [a, b, c]) and add per-check progress logging.

**checkIntegTestResultsOverview.groovy**
- Before an RC exists, fall back to current non-RC integration results instead of erroring to unknown.

**checkUnpatchedVulnerabilities.groovy**
- Resolve the scan branch tag from the manifest ref (so pre-branch-cut it's origin/main, not the non-existent origin/3.9).

**Security advisories / metrics classes**
- Replace throw new RuntimeException with the error step (no script-approval prompts under the sandbox); clearer scan-index-resolution log.

**Tests**
- New TestIndexReleaseState + job file; extended integ/vuln/advisory tests; version bump.

### Issues Resolved
https://github.com/opensearch-project/oscar-ai-bot/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
